### PR TITLE
New form auth

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -1,5 +1,8 @@
 package application;
 
+import auth.BasicAuth;
+import auth.DjangoAuth;
+import auth.HqAuth;
 import beans.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hq.CaseAPIs;
@@ -48,9 +51,10 @@ public class FormController {
 
     @ApiOperation(value = "Start a new form entry session")
     @RequestMapping(value = Constants.URL_NEW_SESSION , method = RequestMethod.POST)
-    public NewFormSessionResponse newFormResponse(@RequestBody NewSessionRequestBean newSessionBean) throws Exception {
-        log.info("New form requests with bean: " + newSessionBean);
-        NewFormRequest newFormRequest = new NewFormRequest(newSessionBean, sessionRepo, xFormService, restoreService);
+    public NewFormSessionResponse newFormResponse(@RequestBody NewSessionRequestBean newSessionBean,
+                                                  @CookieValue("sessionid") String authToken) throws Exception {
+        log.info("New form requests with bean: " + newSessionBean + " sessionId :" + authToken);
+        NewFormRequest newFormRequest = new NewFormRequest(newSessionBean, sessionRepo, xFormService, restoreService, authToken);
         NewFormSessionResponse newSessionResponse = newFormRequest.getResponse();
         log.info("Return new session response: " + newSessionResponse);
         return newSessionResponse;

--- a/src/main/java/requests/NewFormRequest.java
+++ b/src/main/java/requests/NewFormRequest.java
@@ -28,15 +28,12 @@ public class NewFormRequest {
 
     private NewFormRequest(String formUrl, Map<String, String> authDict, String username, String domain, String lang,
                            Map<String, String> sessionData, SessionRepo sessionRepo,
-                           XFormService xFormService, RestoreService restoreService) throws Exception {
-        SessionRepo sessionRepo1 = sessionRepo;
+                           XFormService xFormService, RestoreService restoreService, String authToken) throws Exception {
         this.xFormService = xFormService;
         this.restoreService = restoreService;
         this.formUrl = formUrl;
-        this.auth = getAuth((authDict));
-        String username1 = username;
+        this.auth = getAuth(authDict, authToken);
         this.domain = domain;
-        String lang1 = lang;
         try {
             formEntrySession = new FormSession(getFormXml(), getRestoreXml(), lang, username, domain, sessionData);
             sessionRepo.save(formEntrySession.serialize());
@@ -45,20 +42,24 @@ public class NewFormRequest {
         }
     }
 
-    private HqAuth getAuth(Map<String, String> authMap){
-        if(authMap.containsKey("type")){
+    //TODO WSP combine this with logic in MenuController
+    private HqAuth getAuth(Map<String, String> authMap, String authToken){
+        HqAuth auth = null;
+        if(authToken != null && !authToken.trim().equals("")){
+            auth = new DjangoAuth(authToken);
+        } else if(authMap.containsKey("type")){
             if(authMap.get("type").equals("django-session")){
-                return new DjangoAuth(authMap.get("key"));
+                auth = new DjangoAuth(authMap.get("key"));
             }
         }
-        return null;
+        return auth;
     }
 
     public NewFormRequest(NewSessionRequestBean bean, SessionRepo sessionRepo,
-                          XFormService xFormService, RestoreService restoreService) throws Exception {
+                          XFormService xFormService, RestoreService restoreService, String authToken) throws Exception {
         this(bean.getFormUrl(), bean.getHqAuth(),
                 bean.getSessionData().getUsername(), bean.getSessionData().getDomain(),
-                bean.getLang(), bean.getSessionData().getData(), sessionRepo, xFormService, restoreService);
+                bean.getLang(), bean.getSessionData().getData(), sessionRepo, xFormService, restoreService, authToken);
     }
 
     public NewFormSessionResponse getResponse() throws IOException {

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -130,7 +130,7 @@ public class FormSession {
     private void initialize(boolean newInstance, Map<String, String> sessionData) {
         CommCarePlatform platform = new CommCarePlatform(2, 27);
         FormplayerSessionWrapper sessionWrapper = new FormplayerSessionWrapper(platform, this.sandbox, sessionData);
-        FormplayerConfigEngine.setupStorageManager(username, "dbs");
+        FormplayerConfigEngine.setupStorageManager("test", "dbs/" + domain + "/" + username);
         formDef.initialize(newInstance, sessionWrapper.getIIF());
     }
 

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -24,6 +24,7 @@ import services.XFormService;
 import util.Constants;
 import utils.FileUtils;
 
+import javax.servlet.http.Cookie;
 import java.io.IOException;
 
 import static org.mockito.Matchers.any;
@@ -126,6 +127,7 @@ public class BaseTestClass {
         MvcResult result = this.mockMvc.perform(
                 post(urlPrepend(Constants.URL_NEW_SESSION))
                         .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie("sessionid", "derp"))
                         .content(new ObjectMapper().writeValueAsString(newSessionRequestBean))).andReturn();
         String responseBody = result.getResponse().getContentAsString();
         return mapper.readValue(responseBody, NewFormSessionResponse.class);


### PR DESCRIPTION
Pull auth token from new-form request and use for authentication
Also fix for using emails as usernames (for Web user restores)

cross: https://github.com/dimagi/touchforms/pull/231
cross: https://github.com/dimagi/commcare-hq/pull/12186