### PR TITLE
Wsp/edit form fix

### DIFF
--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -98,6 +98,9 @@ public class FormSession {
 
         if(instanceContent != null){
             loadInstanceXml(formDef, instanceContent);
+            initialize(false, sessionData);
+        } else {
+            initialize(true, sessionData);
         }
 
         formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_NON_LINEAR);
@@ -108,7 +111,6 @@ public class FormSession {
         setLocale(locale, langs);
         uuid = UUID.randomUUID().toString();
         this.sequenceId = 1;
-        initialize(false, sessionData);
         getFormTree();
     }
 

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -108,7 +108,7 @@ public class FormSession {
         setLocale(locale, langs);
         uuid = UUID.randomUUID().toString();
         this.sequenceId = 1;
-        initialize(true, sessionData);
+        initialize(false, sessionData);
         getFormTree();
     }
 


### PR DESCRIPTION
Fix for bug mentioned here https://github.com/dimagi/commcare-hq/pull/12341. We were re-firing the initialization code even when we had an instance to load. This was causing us to load the form with a new instanceID which HQ accepted as a new form submission rather than an edit. 

@benrudolph 