### PR TITLE
Set logged in user after restore

### DIFF
--- a/src/main/java/hq/RestoreUtils.java
+++ b/src/main/java/hq/RestoreUtils.java
@@ -28,6 +28,7 @@ public class RestoreUtils {
         UserSqlSandbox mSandbox = SqlSandboxUtils.getStaticStorage(username, path);
         PrototypeFactory.setStaticHasher(new ClassNameHasher());
         ParseUtilsHelper.parseXMLIntoSandbox(restorePayload, mSandbox);
+        mSandbox.setLoggedInUser(mSandbox.getUserStorage().read(0));
         return mSandbox;
     }
 

--- a/src/main/java/hq/RestoreUtils.java
+++ b/src/main/java/hq/RestoreUtils.java
@@ -5,9 +5,11 @@ import org.commcare.api.persistence.UserSqlSandbox;
 import org.commcare.modern.parse.ParseUtilsHelper;
 import org.javarosa.core.api.ClassNameHasher;
 import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.User;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.services.storage.IStorageIterator;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.xform.parse.XFormParser;
@@ -28,7 +30,13 @@ public class RestoreUtils {
         UserSqlSandbox mSandbox = SqlSandboxUtils.getStaticStorage(username, path);
         PrototypeFactory.setStaticHasher(new ClassNameHasher());
         ParseUtilsHelper.parseXMLIntoSandbox(restorePayload, mSandbox);
-        mSandbox.setLoggedInUser(mSandbox.getUserStorage().read(0));
+        // initialize our sandbox's logged in user
+        for (IStorageIterator<User> iterator = mSandbox.getUserStorage().iterate(); iterator.hasMore(); ) {
+            User u = iterator.nextRecord();
+            if (username.equalsIgnoreCase(u.getUsername())) {
+                mSandbox.setLoggedInUser(u);
+            }
+        }
         return mSandbox;
     }
 

--- a/src/main/java/session/FormplayerInstanceInitializer.java
+++ b/src/main/java/session/FormplayerInstanceInitializer.java
@@ -1,8 +1,11 @@
 package session;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.session.SessionInstanceBuilder;
+import org.commcare.suite.model.FormEntry;
 import org.commcare.util.CommCarePlatform;
 import org.javarosa.core.model.User;
 import org.javarosa.core.model.instance.AbstractTreeElement;
@@ -17,6 +20,7 @@ import java.util.Map;
 class FormplayerInstanceInitializer extends CommCareInstanceInitializer {
 
     private final Map<String, String> injectedSessionData;
+    private final Log log = LogFactory.getLog(FormplayerInstanceInitializer.class);
 
     public FormplayerInstanceInitializer(FormplayerSessionWrapper formplayerSessionWrapper,
                                          UserSandbox mSandbox, CommCarePlatform mPlatform,
@@ -31,6 +35,9 @@ class FormplayerInstanceInitializer extends CommCareInstanceInitializer {
             throw new RuntimeException("Cannot generate session instance with undeclared platform!");
         }
         User u = mSandbox.getLoggedInUser();
+        if(u == null){
+            log.error("Got null logged in user for username, this is bad.");
+        }
         if(injectedSessionData != null) {
             for (String key : injectedSessionData.keySet()) {
                 session.setDatum(key, injectedSessionData.get(key));


### PR DESCRIPTION
So the NPE Priya was seeing was due to getLoggedInUser of the SQLSandbox returning null. When I examined the table there were no rows for the User which was really weird. Hopefully this will obviate the need to read that table and will also fail early if we do a restore and don't get a user entry. 