### PR TITLE
Eval xpath and instance XML

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -239,7 +239,7 @@ public class FormController extends AbstractBaseController{
     }
 
     @ApiOperation(value = "Evaluate the given XPath under the current context")
-    @RequestMapping(value = Constants.URL_EVALUATE_XPATH, method = RequestMethod.GET)
+    @RequestMapping(value = Constants.URL_EVALUATE_XPATH, method = RequestMethod.POST)
     @ResponseBody
     public EvaluateXPathResponseBean evaluateXpath(@RequestBody EvaluateXPathRequestBean evaluateXPathRequestBean) throws Exception {
         log.info("Evaluate XPath Request: " + evaluateXPathRequestBean);

--- a/src/main/java/beans/GetInstanceResponseBean.java
+++ b/src/main/java/beans/GetInstanceResponseBean.java
@@ -2,7 +2,12 @@ package beans;
 
 import session.FormSession;
 
+import javax.xml.transform.*;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * Created by willpride on 1/20/16.
@@ -15,8 +20,36 @@ public class GetInstanceResponseBean {
     public GetInstanceResponseBean(){}
 
     public GetInstanceResponseBean(FormSession session) throws IOException {
-        output = session.getInstanceXml();
+        output = indentXml(session.getInstanceXml());
         xmlns = session.getXmlns();
+    }
+
+    /**
+     * Given a String representation of a valid XML document, this returns an
+     * indented version of it.
+     * @param xml - A string XML document
+     * @return A string XML document that is indented
+     */
+    private String indentXml(String xml) {
+        Transformer transformer;
+        try {
+            transformer = TransformerFactory.newInstance().newTransformer();
+        } catch (TransformerConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+
+        Source xmlInput = new StreamSource(new StringReader(xml));
+        StreamResult result = new StreamResult(new StringWriter());
+
+        try {
+            transformer.transform(xmlInput, result);
+        } catch (TransformerException e) {
+            throw new RuntimeException(e);
+        }
+        return result.getWriter().toString();
     }
 
     public String getXmlns() {

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -451,7 +451,7 @@ public class BaseTestClass {
         evaluateXPathRequestBean.setSessionId(sessionId);
         evaluateXPathRequestBean.setXpath(xPath);
         String evaluateXpathResultString = generateMockQuery(ControllerType.FORM,
-                RequestType.GET,
+                RequestType.POST,
                 Constants.URL_EVALUATE_XPATH,
                 evaluateXPathRequestBean);
         return mapper.readValue(evaluateXpathResultString,


### PR DESCRIPTION
@wpride fixes up the xpath route and indents the instance xml. the readable form questions to come later. it's a bit more tricky since a lot of the logic to represent the form data questions is in HQ and i don't think it makes sense to replicate that logic in java. we can either 1, make a request to HQ from inside formplayer, or 2, have the formplayer frontend make a request to HQ directly instead of formplayer. right now i'm leaning towards option 1

cc: @dannyroberts 