### PR TITLE
Fix form linking

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -76,6 +76,8 @@ public abstract class AbstractBaseController {
 
     public BaseResponseBean getNextMenu(MenuSession menuSession) throws Exception {
         Screen nextScreen = menuSession.getNextScreen();
+        // If the nextScreen is null, that means we are heading into 
+        // form entry and there isn't a screen title
         if (nextScreen == null) {
             return getNextMenu(menuSession, 0, "", null);
         }

--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -75,7 +75,11 @@ public abstract class AbstractBaseController {
     }
 
     public BaseResponseBean getNextMenu(MenuSession menuSession) throws Exception {
-        return getNextMenu(menuSession, 0, "", new String[] {menuSession.getNextScreen().getScreenTitle()});
+        Screen nextScreen = menuSession.getNextScreen();
+        if (nextScreen == null) {
+            return getNextMenu(menuSession, 0, "", null);
+        }
+        return getNextMenu(menuSession, 0, "", new String[] {nextScreen.getScreenTitle()});
     }
 
     protected BaseResponseBean getNextMenu(MenuSession menuSession,


### PR DESCRIPTION
@wpride fixes form linking. previously it would try to get the title of the screen even though the next screen was null causing an error. Also wouldn't this function be more aptly named `getNextScreen` rather than `getNextMenu`? maybe we can pair on a way to test this. couldn't think of any way that wasn't super heavy like creating and installing an app that has form linking

cc: @dannyroberts 