### PR TITLE
Add session id back in

### DIFF
--- a/src/main/java/beans/SessionListItem.java
+++ b/src/main/java/beans/SessionListItem.java
@@ -9,10 +9,12 @@ public class SessionListItem {
 
     private String title;
     private String dateOpened;
+    private String sessionId;
 
     public SessionListItem(SerializableFormSession session){
         this.title = session.getTitle();
         this.dateOpened = session.getDateOpened();
+        this.sessionId = session.getId();
     }
 
     public String getTitle() {
@@ -29,5 +31,13 @@ public class SessionListItem {
 
     public void setDateOpened(String dateOpened) {
         this.dateOpened = dateOpened;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
     }
 }


### PR DESCRIPTION
@wpride this fixes opening saved sessions. we weren't passing the session id to the browser so opening an incomplete form would result in an error cause we'd try to look up the id "undefined." going to add a test for this.

cc: @dannyroberts 