### PR TITLE
Handle app config errors

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -15,6 +15,7 @@ import org.commcare.util.cli.EntityScreen;
 import org.commcare.util.cli.MenuScreen;
 import org.commcare.util.cli.QueryScreen;
 import org.commcare.util.cli.Screen;
+import org.javarosa.xpath.XPathMissingInstanceException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -145,7 +146,7 @@ public abstract class AbstractBaseController {
         return new NewFormSessionResponse(formEntrySession);
     }
 
-    @ExceptionHandler(ApplicationConfigException.class)
+    @ExceptionHandler({ApplicationConfigException.class, XPathMissingInstanceException.class})
     @ResponseBody
     public ExceptionResponseBean handleApplicationError(HttpServletRequest req, Exception exception) {
         log.error("Request: " + req.getRequestURL() + " raised " + exception);

--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -1,7 +1,9 @@
 package application;
 
+import beans.ExceptionResponseBean;
 import beans.NewFormSessionResponse;
 import beans.menus.*;
+import exceptions.ApplicationConfigException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
@@ -18,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
 import repo.SerializableMenuSession;
@@ -142,8 +145,17 @@ public abstract class AbstractBaseController {
         return new NewFormSessionResponse(formEntrySession);
     }
 
+    @ExceptionHandler(ApplicationConfigException.class)
+    @ResponseBody
+    public ExceptionResponseBean handleApplicationError(HttpServletRequest req, Exception exception) {
+        log.error("Request: " + req.getRequestURL() + " raised " + exception);
+
+        return new ExceptionResponseBean(exception.getMessage(), req.getRequestURL().toString());
+    }
+
     @ExceptionHandler(Exception.class)
-    public String handleError(HttpServletRequest req, Exception exception) {
+    @ResponseBody
+    public ExceptionResponseBean handleError(HttpServletRequest req, Exception exception) {
         log.error("Request: " + req.getRequestURL() + " raised " + exception);
         exception.printStackTrace();
         try {
@@ -152,11 +164,7 @@ public abstract class AbstractBaseController {
             e.printStackTrace();
             log.error("Unable to send email");
         }
-        JSONObject errorReturn = new JSONObject();
-        errorReturn.put("exception", exception);
-        errorReturn.put("url", req.getRequestURL());
-        errorReturn.put("status", "error");
-        return errorReturn.toString();
+        return new ExceptionResponseBean(exception.getMessage(), req.getRequestURL().toString());
     }
 
     private void sendExceptionEmail(HttpServletRequest req, Exception exception) {

--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -15,6 +15,7 @@ import org.commcare.util.cli.EntityScreen;
 import org.commcare.util.cli.MenuScreen;
 import org.commcare.util.cli.QueryScreen;
 import org.commcare.util.cli.Screen;
+import org.javarosa.xpath.XPathException;
 import org.javarosa.xpath.XPathMissingInstanceException;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -146,7 +147,7 @@ public abstract class AbstractBaseController {
         return new NewFormSessionResponse(formEntrySession);
     }
 
-    @ExceptionHandler({ApplicationConfigException.class, XPathMissingInstanceException.class})
+    @ExceptionHandler({ApplicationConfigException.class, XPathException.class})
     @ResponseBody
     public ExceptionResponseBean handleApplicationError(HttpServletRequest req, Exception exception) {
         log.error("Request: " + req.getRequestURL() + " raised " + exception);

--- a/src/main/java/beans/ExceptionResponseBean.java
+++ b/src/main/java/beans/ExceptionResponseBean.java
@@ -1,0 +1,48 @@
+package beans;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+
+/**
+ * Created by benrudolph on 8/29/16.
+ */
+public class ExceptionResponseBean {
+    private String exception;
+    private String status;
+    private String url;
+
+    public ExceptionResponseBean() {
+    }
+
+    public ExceptionResponseBean(String exception, String url) {
+        this.exception = exception;
+        this.url = url;
+        this.status = "error";
+    }
+
+    @JsonGetter(value = "exception")
+    public String getException() {
+        return exception;
+    }
+
+    public void setException(String exception) {
+        this.exception = exception;
+    }
+
+    @JsonGetter(value = "status")
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @JsonGetter(value = "url")
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/beans/ExceptionResponseBean.java
+++ b/src/main/java/beans/ExceptionResponseBean.java
@@ -3,7 +3,7 @@ package beans;
 import com.fasterxml.jackson.annotation.JsonGetter;
 
 /**
- * Created by benrudolph on 8/29/16.
+ * This class is a generic response for an exception raised in Formplayer
  */
 public class ExceptionResponseBean {
     private String exception;

--- a/src/main/java/exceptions/ApplicationConfigException.java
+++ b/src/main/java/exceptions/ApplicationConfigException.java
@@ -1,0 +1,10 @@
+package exceptions;
+
+/**
+ * Created by benrudolph on 8/29/16.
+ */
+public class ApplicationConfigException extends RuntimeException {
+    public ApplicationConfigException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/exceptions/ApplicationConfigException.java
+++ b/src/main/java/exceptions/ApplicationConfigException.java
@@ -1,7 +1,9 @@
 package exceptions;
 
 /**
- * Created by benrudolph on 8/29/16.
+ * ApplicationConfigException should be raised when an app config
+ * error occurs such as a bad xpath query. When an ApplicationConfigException
+ * is thrown, no error emails are sent.
  */
 public class ApplicationConfigException extends RuntimeException {
     public ApplicationConfigException(String message) {

--- a/src/main/java/install/FormplayerConfigEngine.java
+++ b/src/main/java/install/FormplayerConfigEngine.java
@@ -159,7 +159,7 @@ public class FormplayerConfigEngine {
         try {
             IOUtils.copy(errorStream, writer, "utf-8");
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("Unable to read error stream", e);
         }
         String errorMessage = writer.toString();
         JSONObject errorJson = new JSONObject(errorMessage);

--- a/src/main/java/install/FormplayerConfigEngine.java
+++ b/src/main/java/install/FormplayerConfigEngine.java
@@ -3,8 +3,12 @@
  */
 package install;
 
+import exceptions.ApplicationConfigException;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.commcare.api.persistence.SqliteIndexedStorageUtility;
 import org.commcare.modern.reference.ArchiveFileRoot;
 import org.commcare.modern.reference.JavaFileRoot;
@@ -27,11 +31,10 @@ import org.javarosa.core.services.storage.IStorageUtility;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.StorageManager;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.json.JSONObject;
 import util.PrototypeUtils;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.zip.ZipFile;
@@ -129,16 +132,19 @@ public class FormplayerConfigEngine {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setInstanceFollowRedirects(true);  //you still need to handle redirect manully.
             HttpURLConnection.setFollowRedirects(true);
+            if (conn.getResponseCode() == 400) {
+                handleInstallError(conn.getErrorStream());
+            }
+            InputStream result = conn.getInputStream();
 
             File file = File.createTempFile("commcare_", ".ccz");
 
             FileOutputStream fos = new FileOutputStream(file);
-            StreamsUtil.writeFromInputToOutput(new BufferedInputStream(conn.getInputStream()), fos);
+            StreamsUtil.writeFromInputToOutput(new BufferedInputStream(result), fos);
             return file.getAbsolutePath();
         } catch (IOException e) {
             log.error("Issue downloading or create stream for " + resource);
             e.printStackTrace();
-            System.exit(-1);
             return null;
         }
     }
@@ -146,6 +152,18 @@ public class FormplayerConfigEngine {
     public void initFromLocalFileResource(String resource) throws InstallCancelledException, UnresolvedResourceException, UnfullfilledRequirementsException {
         String reference = setFileSystemRootFromResourceAndReturnRelativeRef(resource);
         init(reference);
+    }
+
+    private void handleInstallError(InputStream errorStream) {
+        StringWriter writer = new StringWriter();
+        try {
+            IOUtils.copy(errorStream, writer, "utf-8");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        String errorMessage = writer.toString();
+        JSONObject errorJson = new JSONObject(errorMessage);
+        throw new ApplicationConfigException(errorJson.getJSONArray("errors").join(" "));
     }
 
     private String setFileSystemRootFromResourceAndReturnRelativeRef(String resource) {


### PR DESCRIPTION
@wpride @snopoke this'll handle handle app config errors and display the message. i don't think this'll yet handle xpath errors, but all we need to do is catch those and re wrap as an ApplicationConfigError and that'll stop the emails

<img width="318" alt="screen shot 2016-08-29 at 10 00 53 pm" src="https://cloud.githubusercontent.com/assets/918514/18073445/1787ac0c-6e34-11e6-800e-20132a59ca91.png">

I know it's ugly at the moment, going to work on fixing later

cross: https://github.com/dimagi/commcare-hq/pull/13038