### PR TITLE
Remove sys.exit

### DIFF
--- a/src/main/java/install/FormplayerConfigEngine.java
+++ b/src/main/java/install/FormplayerConfigEngine.java
@@ -201,8 +201,7 @@ public class FormplayerConfigEngine {
 
             Localization.setLocale(newLocale);
         } catch (ResourceInitializationException e) {
-            log.error("Error while initializing one of the resolved resources");
-            System.exit(-1);
+            log.error("Error while initializing one of the resolved resources", e);
         }
     }
 


### PR DESCRIPTION
@wpride i see a bunch of these in the commcare lib, but a couple in formplayer. isn't it really dangerous to have sys.exit? doesn't that mean it just stops the web server for everyone. not sure how to handle the ones in the commcare lib yet