### PR TITLE
hack fix for model iteration expansion

### DIFF
--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -243,6 +243,7 @@ public class FormSession {
 
     public String submitGetXml() throws IOException {
         formDef.postProcessInstance();
+        getFormTree();
         return getInstanceXml();
     }
 


### PR DESCRIPTION
This fixes http://manage.dimagi.com/default.asp?239335

There's something we're not expanding during the usual getInstanceXml() call that is expanded when generating the form tree (only noticed this because the debugger had the correct XML while the submission didn't)

The right way to fix this is to to unify the android and nimbus submission code, which I'll do next

Can merge this for now as a hack