### PR TITLE
Handle 500 error for app builds

### DIFF
--- a/src/main/java/install/FormplayerConfigEngine.java
+++ b/src/main/java/install/FormplayerConfigEngine.java
@@ -133,6 +133,10 @@ public class FormplayerConfigEngine {
             HttpURLConnection.setFollowRedirects(true);
             if (conn.getResponseCode() == 400) {
                 handleInstallError(conn.getErrorStream());
+            } else if (conn.getResponseCode() == 500) {
+                throw new ApplicationConfigException(
+                    "Encountered an error while processing the application. Please submit an ticket if you continue to see this."
+                );
             }
             InputStream result = conn.getInputStream();
 

--- a/src/main/java/install/FormplayerConfigEngine.java
+++ b/src/main/java/install/FormplayerConfigEngine.java
@@ -135,7 +135,7 @@ public class FormplayerConfigEngine {
                 handleInstallError(conn.getErrorStream());
             } else if (conn.getResponseCode() == 500) {
                 throw new ApplicationConfigException(
-                    "Encountered an error while processing the application. Please submit an ticket if you continue to see this."
+                    "Encountered an error while processing the application. Please submit a ticket if you continue to see this."
                 );
             }
             InputStream result = conn.getInputStream();


### PR DESCRIPTION
@wpride couldn't get case tiles to work, but did realize we don't properly handle 500 errors from app manager
<img width="300" alt="screen shot 2016-11-03 at 10 47 23 am" src="https://cloud.githubusercontent.com/assets/918514/19970786/715bd1f6-a1b3-11e6-8942-7b96ae025491.png">
I think it's fine not to email, since that 500 email will be sent from HQ's side
