### PR TITLE
Throw error on missing user restore

### DIFF
--- a/src/main/java/session/FormplayerInstanceInitializer.java
+++ b/src/main/java/session/FormplayerInstanceInitializer.java
@@ -34,8 +34,8 @@ class FormplayerInstanceInitializer extends CommCareInstanceInitializer {
             throw new RuntimeException("Cannot generate session instance with undeclared platform!");
         }
         User u = mSandbox.getLoggedInUser();
-        if(u == null){
-            log.error("Got null logged in user for username, this is bad.");
+        if (u == null) {
+            throw new RuntimeException("There was a problem loading the user data. Please Sync.");
         }
         if(injectedSessionData != null) {
             for (String key : injectedSessionData.keySet()) {


### PR DESCRIPTION
@wpride this would only log the error even though it's critical that `u` not be `null`. this led to many of those null pointers later down the line. think it makes sense to error up front so we know the cause