### PR TITLE
Move oqps and currentIndex vars into formSession

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -182,7 +182,8 @@ public class FormController extends AbstractBaseController{
                     JsonActionUtils.questionAnswerToJson(formEntryController,
                             formEntryModel,
                             answer,
-                            key);
+                            key,
+                            false);
             if(!answerResult.get(ApiConstants.RESPONSE_STATUS_KEY).equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)) {
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 ErrorBean error = new ErrorBean();

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -22,9 +22,9 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.util.UnregisteredLocaleException;
 import org.javarosa.core.util.externalizable.DeserializationException;
+import org.javarosa.form.api.FormController;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
-import org.javarosa.form.api.FormEntryNavigator;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.util.FormInstanceLoader;
@@ -56,6 +56,7 @@ public class FormSession {
     private FormDef formDef;
     private FormEntryModel formEntryModel;
     private FormEntryController formEntryController;
+    private FormController formController;
     private String restoreXml;
     private UserSandbox sandbox;
     private int sequenceId;
@@ -77,16 +78,10 @@ public class FormSession {
     private void setupJavaRosaObjects() {
         formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_NON_LINEAR);
         formEntryController = new FormEntryController(formEntryModel);
+        formController = new FormController(formEntryController, false);
         title = formDef.getTitle();
         langs = formEntryModel.getLanguages();
         initLocale();
-    }
-
-    private void setupOneQuestionPerScreen() {
-        formEntryController.setOneQuestionPerScreen(oneQuestionPerScreen);
-        if (oneQuestionPerScreen) {
-            formEntryController.setCurrentIndex(JsonActionUtils.indexFromString(currentIndex, formDef));
-        }
     }
 
     public FormSession(SerializableFormSession session) throws Exception{
@@ -109,7 +104,6 @@ public class FormSession {
         this.formDef = FormInstanceLoader.loadInstance(formDef, IOUtils.toInputStream(session.getInstanceXml()));
         setupJavaRosaObjects();
         initialize(false, session.getSessionData());
-        setupOneQuestionPerScreen();
         this.postUrl = session.getPostUrl();
     }
 
@@ -139,7 +133,6 @@ public class FormSession {
         } else {
             initialize(true, sessionData);
         }
-        setupOneQuestionPerScreen();
     }
 
     private void loadInstanceXml(FormDef formDef, String instanceContent) throws IOException {
@@ -322,14 +315,14 @@ public class FormSession {
 
     public void stepToNextIndex() {
         this.formEntryController.jumpToIndex(JsonActionUtils.indexFromString(currentIndex, formDef));
-        FormEntryNavigator formEntryNavigator = new FormEntryNavigator(formEntryController);
-        FormIndex newIndex = formEntryNavigator.getNextFormIndex(formEntryModel.getFormIndex(), true, true);
+        FormController formController = new FormController(formEntryController, false);
+        FormIndex newIndex = formController.getNextFormIndex(formEntryModel.getFormIndex(), true, true);
 
         // check if this index is the beginning of a group that is not a question list.
         IFormElement element = formEntryController.getModel().getForm().getChild(newIndex);
         while (element instanceof GroupDef && !formEntryController.isFieldListHost(newIndex)) {
             log.info("step thru group");
-            newIndex =  formEntryNavigator.getNextFormIndex(newIndex, false, true);
+            newIndex =  formController.getNextFormIndex(newIndex, false, true);
             element = formEntryController.getModel().getForm().getChild(newIndex);
         }
 
@@ -346,13 +339,13 @@ public class FormSession {
 
     public void stepToPreviousIndex() {
         this.formEntryController.jumpToIndex(JsonActionUtils.indexFromString(currentIndex, formDef));
-        FormEntryNavigator formEntryNavigator = new FormEntryNavigator(formEntryController);
-        FormIndex newIndex = formEntryNavigator.getPreviousFormIndex();
+        FormController formController = new FormController(formEntryController, false);
+        FormIndex newIndex = formController.getPreviousFormIndex();
 
         // check if this index is the beginning of a group that is not a question list.
         IFormElement element = formEntryController.getModel().getForm().getChild(newIndex);
         while (element instanceof GroupDef && !formEntryController.isFieldListHost(newIndex)) {
-            newIndex =  formEntryNavigator.getPreviousFormIndex();
+            newIndex =  formController.getPreviousFormIndex();
             element = formEntryController.getModel().getForm().getChild(newIndex);
         }
 
@@ -364,7 +357,8 @@ public class FormSession {
         JSONObject resp = JsonActionUtils.questionAnswerToJson(formEntryController,
                 formEntryModel,
                 answer != null ? answer.toString() : null,
-                formIndex);
+                formIndex,
+                oneQuestionPerScreen);
         return resp;
     }
 


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/459

Since we were already storing these variables in FormSession and they're not useful for Android (where its tracked separately) I refactored this a bit. Would be good to validate this @biyeun @benrudolph 