### PR TITLE
Properly handle HTTP client error exceptions

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -32,6 +32,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
 import repo.SerializableMenuSession;
@@ -231,6 +232,15 @@ public abstract class AbstractBaseController {
         log.error("Request: " + req.getRequestURL() + " raised " + exception);
 
         return new ExceptionResponseBean(exception.getMessage(), req.getRequestURL().toString());
+    }
+
+    /**
+     * Handles exceptions thrown when making external requests, usually to CommCareHQ.
+     */
+    @ExceptionHandler({HttpClientErrorException.class})
+    @ResponseBody
+    public ExceptionResponseBean handleHttpRequestError(FormplayerHttpRequest req, HttpClientErrorException exception) {
+        return new ExceptionResponseBean(exception.getResponseBodyAsString(), req.getRequestURL().toString());
     }
 
     @ExceptionHandler({AsyncRetryException.class})


### PR DESCRIPTION
@wpride this'll catch HTTP error properly (useful so we don't email on permission denied errors and also provides more useful error messages in the response)