### PR TITLE
Add actuator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '1.3.5.RELEASE'
     compile("org.springframework.boot:spring-boot-starter-web")
+    compile("org.springframework.boot:spring-boot-starter-actuator")
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter
     compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.3.5.RELEASE'
 

--- a/config/application.properties.example
+++ b/config/application.properties.example
@@ -40,3 +40,7 @@ smtp.username=test
 smtp.password=123
 smtp.from.address=mail@formplayer.commcarehq.org
 smtp.to.address=exceptions@commcarehq.org
+
+endpoints.enabled=true
+management.address: 127.0.0.1
+management.port: 8081


### PR DESCRIPTION
@wpride this provides some incredibly useful endpoints on the port specified. this will not be open to the world. read more here: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints. once this is deployed i think it makes sense to replace our servup check with `:8081/health`