### PR TITLE
don't get restore XML for each session

### DIFF
--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -36,10 +36,8 @@ public class CaseAPIs {
     public static UserSqlSandbox restoreIfNotExists(RestoreFactory restoreFactory) throws Exception{
         File db = new File(restoreFactory.getDbFile());
         if(db.exists()){
-            System.out.println("db exists for path " + db);
             return restoreFactory.getSqlSandbox();
         } else{
-            System.out.println("NOT db exists for path " + db);
             db.getParentFile().mkdirs();
             String xml = restoreFactory.getRestoreXml();
             return restoreUser(restoreFactory.getWrappedUsername(), restoreFactory.getDbPath(), xml);

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -29,15 +29,17 @@ import java.io.IOException;
 public class CaseAPIs {
 
     public static UserSqlSandbox forceRestore(RestoreFactory restoreFactory) throws Exception {
-        new File(restoreFactory.getDbFile()).delete();
+        SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
         return restoreIfNotExists(restoreFactory);
     }
 
     public static UserSqlSandbox restoreIfNotExists(RestoreFactory restoreFactory) throws Exception{
         File db = new File(restoreFactory.getDbFile());
         if(db.exists()){
+            System.out.println("db exists for path " + db);
             return restoreFactory.getSqlSandbox();
         } else{
+            System.out.println("NOT db exists for path " + db);
             db.getParentFile().mkdirs();
             String xml = restoreFactory.getRestoreXml();
             return restoreUser(restoreFactory.getWrappedUsername(), restoreFactory.getDbPath(), xml);
@@ -51,13 +53,8 @@ public class CaseAPIs {
         restoreFactory.setDomain(domain);
         restoreFactory.setUsername(username);
         restoreFactory.setAsUsername(asUsername);
-        File db = new File(restoreFactory.getDbFile());
-        if(db.exists()){
-            return restoreFactory.getSqlSandbox();
-        } else{
-            db.getParentFile().mkdirs();
-            return restoreUser(restoreFactory.getWrappedUsername(), restoreFactory.getDbPath(),  xml);
-        }
+        restoreFactory.setCachedRestore(xml);
+        return restoreIfNotExists(restoreFactory);
     }
 
     public static String filterCases(RestoreFactory restoreFactory, String filterExpression) {

--- a/src/main/java/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresFormSessionRepo.java
@@ -10,7 +10,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import repo.FormSessionRepo;
-import services.RestoreFactory;
 import util.Constants;
 
 import javax.persistence.LockModeType;
@@ -32,9 +31,6 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
     @Autowired
     @Qualifier("formplayerTemplate")
     private JdbcTemplate jdbcTemplate;
-
-    @Autowired
-    private RestoreFactory restoreFactory;
 
     @Override
     public List<SerializableFormSession> findUserSessions(String username) {
@@ -194,10 +190,6 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
             session.setOneQuestionPerScreen(rs.getBoolean("oneQuestionPerScreen"));
             session.setCurrentIndex(rs.getString("currentIndex"));
             session.setAsUser(rs.getString("asUser"));
-
-            if(session.getRestoreXml() == null) {
-                session.setRestoreXml(restoreFactory.getRestoreXml());
-            }
 
             byte[] st = (byte[]) rs.getObject("sessionData");
             if (st != null) {

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -209,4 +209,8 @@ public class RestoreFactory {
     public void setAsUsername(String asUsername) {
         this.asUsername = asUsername;
     }
+
+    public void setCachedRestore(String cachedRestore) {
+        this.cachedRestore = cachedRestore;
+    }
 }


### PR DESCRIPTION
We were looking up the restoreXml each time we looked up a session, even if this user already had extant databases. fix that. 