### PR TITLE
configure storage factory before end of form nav

### DIFF
--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -52,6 +52,9 @@ public class MenuController extends AbstractBaseController{
     @UserLock
     public BaseResponseBean installRequest(@RequestBody InstallRequestBean installRequestBean,
                                            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+        DjangoAuth auth = new DjangoAuth(authToken);
+        restoreFactory.configure(installRequestBean, auth);
+        storageFactory.configure(installRequestBean);
         BaseResponseBean response = getNextMenu(performInstall(installRequestBean, authToken));
         return response;
     }
@@ -61,6 +64,9 @@ public class MenuController extends AbstractBaseController{
     @UserLock
     public BaseResponseBean updateRequest(@RequestBody UpdateRequestBean updateRequestBean,
                                            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+        DjangoAuth auth = new DjangoAuth(authToken);
+        restoreFactory.configure(updateRequestBean, auth);
+        storageFactory.configure(updateRequestBean);
         MenuSession updatedSession = performUpdate(updateRequestBean, authToken);
         if (updateRequestBean.getSessionId() != null) {
             // Try restoring the old session, fail gracefully.
@@ -93,6 +99,7 @@ public class MenuController extends AbstractBaseController{
         MenuSession menuSession;
         DjangoAuth auth = new DjangoAuth(authToken);
         restoreFactory.configure(sessionNavigationBean, auth);
+        storageFactory.configure(sessionNavigationBean);
         String menuSessionId = sessionNavigationBean.getMenuSessionId();
         if (menuSessionId != null && !"".equals(menuSessionId)) {
             try {
@@ -254,7 +261,6 @@ public class MenuController extends AbstractBaseController{
 
     private MenuSession performInstall(InstallRequestBean bean, String authToken) throws Exception {
         restoreFactory.configure(bean, new DjangoAuth(authToken));
-        storageFactory.configure(bean);
         if ((bean.getAppId() == null || "".equals(bean.getAppId())) &&
                 bean.getInstallReference() == null || "".equals(bean.getInstallReference())) {
             throw new RuntimeException("Either app_id or installReference must be non-null.");

--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -23,9 +23,15 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory{
     private String trimmedUsername;
 
     public void configure(InstallRequestBean authenticatedRequestBean) {
-        this.username = authenticatedRequestBean.getUsername();
-        this.appId = authenticatedRequestBean.getAppId();
-        this.domain = authenticatedRequestBean.getDomain();
+        configure(authenticatedRequestBean.getUsername(),
+                authenticatedRequestBean.getDomain(),
+                authenticatedRequestBean.getAppId());
+    }
+
+    public void configure(String username, String domain, String appId) {
+        this.username = username;
+        this.domain = domain;
+        this.appId = appId;
         this.trimmedUsername = StringUtils.substringBefore(username, "@");
         this.databasePath = ApplicationUtils.getApplicationDBPath(domain, username, appId);
     }

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -47,9 +47,16 @@ public class RestoreFactory {
     private String cachedRestore = null;
 
     public void configure(AuthenticatedRequestBean authenticatedRequestBean, HqAuth auth) {
-        this.setDomain(authenticatedRequestBean.getDomain());
-        this.setAsUsername(authenticatedRequestBean.getRestoreAs());
-        this.setUsername(authenticatedRequestBean.getUsername());
+        configure(authenticatedRequestBean.getUsername(),
+                authenticatedRequestBean.getDomain(),
+                authenticatedRequestBean.getRestoreAs(),
+                auth);
+    }
+
+    public void configure(String username, String domain, String asUsername, HqAuth auth) {
+        this.setUsername(username);
+        this.setDomain(domain);
+        this.setAsUsername(asUsername);
         this.setHqAuth(auth);
         cachedRestore = null;
     }

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -10,11 +10,8 @@ import beans.debugger.XPathQueryItem;
 import beans.menus.CommandListResponseBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import installers.FormplayerInstallerFactory;
-import objects.SerializableFormSession;
 import org.junit.Before;
 import org.mockito.*;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -37,12 +34,9 @@ import utils.FileUtils;
 import utils.TestContext;
 
 import javax.servlet.http.Cookie;
-import java.io.File;
-import java.net.URL;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;


### PR DESCRIPTION
@benrudolph we weren't configuring the storage factory after end of form navigation, I suspect this caused this squirrelly error: :shipit: 

java.lang.ArrayIndexOutOfBoundsException: 0 >= 0
   at java.util.Vector.elementAt(Vector.java:470)
   at org.commcare.session.CommCareSession.getEvaluationContext(CommCareSession.java:563)
   at org.commcare.session.CommCareSession.getEvaluationContext(CommCareSession.java:549)
   at org.commcare.modern.session.SessionWrapper.getEvaluationContext(SessionWrapper.java:37)
   at session.MenuSession.getNextScreen(MenuSession.java:174)
   at session.MenuSession.(MenuSession.java:98)
   at application.FormController.doEndOfFormNav(FormController.java:161)
   at application.FormController.submitForm(FormController.java:144)