### PR TITLE
Reuse DBs

### DIFF
--- a/src/main/java/application/Application.java
+++ b/src/main/java/application/Application.java
@@ -40,8 +40,6 @@ public class Application {
     public static void main(String[] args) {
         ConfigurableApplicationContext context = SpringApplication.run(Application.class, args);
         migrate();
-        // wipe out all user data for now. We need this until we can fix up some static mapping objects.
-        SqlSandboxUtils.deleteDatabaseFolder(SQLiteProperties.getDataDir());
         PrototypeUtils.setupPrototypes();
     }
 

--- a/src/main/java/installers/FormplayerOfflineUserRestoreInstaller.java
+++ b/src/main/java/installers/FormplayerOfflineUserRestoreInstaller.java
@@ -36,17 +36,19 @@ public class FormplayerOfflineUserRestoreInstaller extends OfflineUserRestoreIns
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
-        String databasePath = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String trimmedUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(databasePath, trimmedUsername);
+        storageFactory.configure(username, domain, appId);
 
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDatabasePath()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getTrimmedUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
     }
 }

--- a/src/main/java/installers/FormplayerProfileInstaller.java
+++ b/src/main/java/installers/FormplayerProfileInstaller.java
@@ -37,17 +37,19 @@ public class FormplayerProfileInstaller extends ProfileInstaller {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
-        String databasePath = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String trimmedUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(databasePath, trimmedUsername);
+        storageFactory.configure(username, domain, appId);
 
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDatabasePath()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getTrimmedUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
     }
 }

--- a/src/main/java/installers/FormplayerSuiteInstaller.java
+++ b/src/main/java/installers/FormplayerSuiteInstaller.java
@@ -36,17 +36,19 @@ public class FormplayerSuiteInstaller extends SuiteInstaller {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
-        String databasePath = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String trimmedUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(databasePath, trimmedUsername);
+        storageFactory.configure(username, domain, appId);
 
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDatabasePath()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getTrimmedUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
     }
 }

--- a/src/main/java/installers/FormplayerXFormInstaller.java
+++ b/src/main/java/installers/FormplayerXFormInstaller.java
@@ -36,17 +36,18 @@ public class FormplayerXFormInstaller extends XFormInstaller {
     @Override
     public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
         super.readExternal(in, pf);
-        String databasePath = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String trimmedUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
+        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
         storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(databasePath, trimmedUsername);
-
+        storageFactory.configure(username, domain, appId);
     }
 
     @Override
     public void writeExternal(DataOutputStream out) throws IOException {
         super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDatabasePath()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getTrimmedUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
+        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
     }
 }

--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -36,11 +36,6 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory{
         this.databasePath = ApplicationUtils.getApplicationDBPath(domain, username, appId);
     }
 
-    public void configure(String databasePath, String trimmedUsername) {
-        this.trimmedUsername = trimmedUsername;
-        this.databasePath = databasePath;
-    }
-
     @Override
     public IStorageUtilityIndexed newStorage(String name, Class type) {
         return new SqliteIndexedStorageUtility(type, trimmedUsername, name, databasePath);

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -1,15 +1,14 @@
 package tests;
 
-import application.DebuggerController;
-import application.FormController;
-import application.MenuController;
-import application.UtilController;
+import application.*;
 import auth.HqAuth;
 import beans.*;
 import beans.debugger.XPathQueryItem;
 import beans.menus.CommandListResponseBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import installers.FormplayerInstallerFactory;
+import org.commcare.api.persistence.SqlSandboxUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,6 +128,12 @@ public class BaseTestClass {
                 .when(submitServiceMock).submitForm(anyString(), anyString(), any(HqAuth.class));
         mapper = new ObjectMapper();
         PrototypeUtils.setupPrototypes();
+        new SQLiteProperties().setDataDir("testdbs/");
+    }
+
+    @After
+    public void tearDown() {
+        SqlSandboxUtils.deleteDatabaseFolder(SQLiteProperties.getDataDir());
     }
 
     private String urlPrepend(String string) {

--- a/src/test/java/tests/DoubleManagementTest.java
+++ b/src/test/java/tests/DoubleManagementTest.java
@@ -1,10 +1,11 @@
 package tests;
 
-import auth.HqAuth;
 import beans.NewFormResponse;
 import beans.SubmitResponseBean;
-import beans.menus.*;
-import org.json.JSONObject;
+import beans.menus.CommandListResponseBean;
+import beans.menus.DisplayElement;
+import beans.menus.EntityDetailResponse;
+import beans.menus.EntityListResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
@@ -12,10 +13,6 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import utils.FileUtils;
 import utils.TestContext;
 
-import java.io.IOException;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**
@@ -121,7 +118,7 @@ public class DoubleManagementTest  extends BaseTestClass{
         EntityListResponse entityListResponse =
                 sessionNavigate(new String[] {"2"}, "doublemgmt", EntityListResponse.class);
         assert entityListResponse.getTitle().equals("Parent (2)");
-        assert entityListResponse.getEntities().length == 3;
+        assert entityListResponse.getEntities().length == 2;
         assert entityListResponse.getAction() != null;
         DisplayElement action = entityListResponse.getAction();
         assert action.getText().equals("New Parent");

--- a/src/test/java/tests/FilterTests.java
+++ b/src/test/java/tests/FilterTests.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import util.Constants;
 import utils.FileUtils;
@@ -62,13 +63,11 @@ public class FilterTests extends BaseTestClass {
         SyncDbResponseBean syncDbResponseBean = syncDb();
 
         assert(syncDbResponseBean.getStatus().equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE));
-        assert(SqlSandboxUtils.databaseFolderExists(UserSqlSandbox.DEFAULT_DATBASE_PATH));
+        assert(SqlSandboxUtils.databaseFolderExists(SQLiteProperties.getDataDir()));
 
         UserSqlSandbox sandbox = SqlSandboxUtils.getStaticStorage("synctestuser", SQLiteProperties.getDataDir() + "synctestdomain");
 
         SqliteIndexedStorageUtility<Case> caseStorage =  sandbox.getCaseStorage();
-
-        System.out.println("Case Storage records: " + caseStorage.getNumRecords());
 
         assert(15 == caseStorage.getNumRecords());
 

--- a/src/test/java/tests/PreviewTests.java
+++ b/src/test/java/tests/PreviewTests.java
@@ -1,20 +1,15 @@
 package tests;
 
-import auth.HqAuth;
 import beans.NewFormResponse;
 import beans.menus.EntityListResponse;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import utils.FileUtils;
 import utils.TestContext;
 
-import java.io.IOException;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**

--- a/src/test/resources/restores/parent_child.xml
+++ b/src/test/resources/restores/parent_child.xml
@@ -1,2 +1,65 @@
-
-<OpenRosaResponse xmlns="http://openrosa.org/http/response"><message nature="ota_restore_success">Successfully restored account test!</message><Sync xmlns="http://commcarehq.org/sync"><restore_id>c44e895f6a926cd28c89fba5dba3db5e</restore_id></Sync><Registration xmlns="http://openrosa.org/user/registration"><username>test</username><password>sha1$avrRdkqgjooF$c548dff77e30ad1d5f71360ca9cdac7706abd65f</password><uuid>9355120324b8c4955970a4cb962919f1</uuid><date>2016-02-04</date><user_data><data key="commcare_first_name" /><data key="commcare_last_name">123</data><data key="commcare_phone_number" /></user_data></Registration><fixture id="user-groups" user_id="9355120324b8c4955970a4cb962919f1"><groups /></fixture><case case_id="4d1831ab-abfe-4086-bce7-16d325d9ca3a" date_modified="2016-04-04T13:06:30.512000Z" user_id="9355120324b8c4955970a4cb962919f1" xmlns="http://commcarehq.org/case/transaction/v2"><create><case_type>parent</case_type><case_name>will</case_name><owner_id>9355120324b8c4955970a4cb962919f1</owner_id></create><update><age>25</age></update></case><case case_id="6a4c61ec-7357-435f-90b0-6f7baf92f8e5" date_modified="2016-04-01T10:12:36.831000Z" user_id="9355120324b8c4955970a4cb962919f1" xmlns="http://commcarehq.org/case/transaction/v2"><create><case_type>individual_order</case_type><case_name>will</case_name><owner_id>9355120324b8c4955970a4cb962919f1</owner_id></create><update><does_will_rule>choice3</does_will_rule><food_you_want>dun dun noodles, suan la chow</food_you_want></update><index><parent case_type="team_order">7ad6624c-5f67-4d29-ab55-c88cc0fb64c6</parent></index></case><case case_id="7ad6624c-5f67-4d29-ab55-c88cc0fb64c6" date_modified="2016-04-01T10:12:36.831000Z" user_id="9355120324b8c4955970a4cb962919f1" xmlns="http://commcarehq.org/case/transaction/v2"><create><case_type>team_order</case_type><case_name>Mary Chungs</case_name><owner_id>9355120324b8c4955970a4cb962919f1</owner_id></create><update><order_date>2016-04-01</order_date></update></case><case case_id="a9fde9ae-24ee-4d70-9cb4-20f266a62ef8" date_modified="2016-03-30T14:38:33.265000Z" user_id="9355120324b8c4955970a4cb962919f1" xmlns="http://commcarehq.org/case/transaction/v2"><create><case_type>parent</case_type><case_name>Anne</case_name><owner_id>9355120324b8c4955970a4cb962919f1</owner_id></create><update><age>55</age></update></case></OpenRosaResponse>
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account test!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>c44e895f6a926cd28c89fba5dba3db5e</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>test</username>
+        <password>sha1$avrRdkqgjooF$c548dff77e30ad1d5f71360ca9cdac7706abd65f</password>
+        <uuid>9355120324b8c4955970a4cb962919f1</uuid>
+        <date>2016-02-04</date>
+        <user_data>
+            <data key="commcare_first_name" />
+            <data key="commcare_last_name">123</data>
+            <data key="commcare_phone_number" />
+        </user_data>
+    </Registration>
+    <fixture id="user-groups" user_id="9355120324b8c4955970a4cb962919f1">
+        <groups />
+    </fixture>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="4d1831ab-abfe-4086-bce7-16d325d9ca3a" date_modified="2016-04-04T13:06:30.512000Z" user_id="9355120324b8c4955970a4cb962919f1">
+        <create>
+            <case_type>parent</case_type>
+            <case_name>will</case_name>
+            <owner_id>9355120324b8c4955970a4cb962919f1</owner_id>
+        </create>
+        <update>
+            <age>25</age>
+        </update>
+    </case>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="6a4c61ec-7357-435f-90b0-6f7baf92f8e5" date_modified="2016-04-01T10:12:36.831000Z" user_id="9355120324b8c4955970a4cb962919f1">
+        <create>
+            <case_type>individual_order</case_type>
+            <case_name>will</case_name>
+            <owner_id>9355120324b8c4955970a4cb962919f1</owner_id>
+        </create>
+        <update>
+            <does_will_rule>choice3</does_will_rule>
+            <food_you_want>dun dun noodles, suan la chow</food_you_want>
+        </update>
+        <index>
+            <parent case_type="team_order">7ad6624c-5f67-4d29-ab55-c88cc0fb64c6</parent>
+        </index>
+    </case>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="7ad6624c-5f67-4d29-ab55-c88cc0fb64c6" date_modified="2016-04-01T10:12:36.831000Z" user_id="9355120324b8c4955970a4cb962919f1">
+        <create>
+            <case_type>team_order</case_type>
+            <case_name>Mary Chungs</case_name>
+            <owner_id>9355120324b8c4955970a4cb962919f1</owner_id>
+        </create>
+        <update>
+            <order_date>2016-04-01</order_date>
+        </update>
+    </case>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="a9fde9ae-24ee-4d70-9cb4-20f266a62ef8" date_modified="2016-03-30T14:38:33.265000Z" user_id="9355120324b8c4955970a4cb962919f1">
+        <create>
+            <case_type>parent</case_type>
+            <case_name>Anne</case_name>
+            <owner_id>9355120324b8c4955970a4cb962919f1</owner_id>
+        </create>
+        <update>
+            <age>55</age>
+        </update>
+    </case>
+</OpenRosaResponse>


### PR DESCRIPTION
@benrudolph changes needed to not all user data when Formplayer is booted up. 
Moved test DBs into the testdbs/ folder so that we can clear those

At the moment re-using application DBs between runtimes will fail because the ReferenceManager() contains static mappings for URI's to the user archives. Currently this will fail elegantly and just clear the old DBs/reinstall. Fixing this will require refactoring the ReferenceManager() class or backing its mappings up to somewhere persistent. I'm eying that class as a source of the concurrency issues we're seeing too.

User DBs can be reused just fine