### PR TITLE
Better logging and error handling around menu nav

### DIFF
--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -2,8 +2,6 @@ package services;
 
 import beans.InstallRequestBean;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.commcare.api.persistence.SqliteIndexedStorageUtility;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -24,9 +22,6 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory{
     private String databasePath;
     private String trimmedUsername;
 
-    private final Log log = LogFactory.getLog(FormplayerStorageFactory.class);
-
-
     public void configure(InstallRequestBean authenticatedRequestBean) {
         configure(authenticatedRequestBean.getUsername(),
                 authenticatedRequestBean.getDomain(),
@@ -34,8 +29,10 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory{
     }
 
     public void configure(String username, String domain, String appId) {
-        log.info(String.format("Configuring StorageFactory with username %s, domain %s, appId %s",
-                username, domain, appId));
+        if(username == null || domain == null || appId == null) {
+            throw new RuntimeException(String.format("Cannot configure FormplayerStorageFactory with null arguments. " +
+                    "username = %s, domain = %s, appId = %s", username, domain, appId));
+        }
         this.username = username;
         this.domain = domain;
         this.appId = appId;

--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -2,6 +2,8 @@ package services;
 
 import beans.InstallRequestBean;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.commcare.api.persistence.SqliteIndexedStorageUtility;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -22,6 +24,9 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory{
     private String databasePath;
     private String trimmedUsername;
 
+    private final Log log = LogFactory.getLog(FormplayerStorageFactory.class);
+
+
     public void configure(InstallRequestBean authenticatedRequestBean) {
         configure(authenticatedRequestBean.getUsername(),
                 authenticatedRequestBean.getDomain(),
@@ -29,6 +34,8 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory{
     }
 
     public void configure(String username, String domain, String appId) {
+        log.info(String.format("Configuring StorageFactory with username %s, domain %s, appId %s",
+                username, domain, appId));
         this.username = username;
         this.domain = domain;
         this.appId = appId;

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -161,10 +161,16 @@ public class MenuSession {
         if(screen == null) {
             return false;
         }
-        boolean ret = screen.handleInputAndUpdateSession(sessionWrapper, input);
-        screen = getNextScreen();
-        log.info("Screen " + screen + " set to " + ret);
-        return true;
+        try {
+            boolean ret = screen.handleInputAndUpdateSession(sessionWrapper, input);
+            screen = getNextScreen();
+            log.info("Screen " + screen + " set to " + ret);
+            return true;
+        } catch(ArrayIndexOutOfBoundsException e) {
+            throw new RuntimeException("Screen " + screen + "  handling input " + input +
+                    " threw exception " + e.getMessage() + ". Please try reloading this application" +
+                    " and if the problem persists please report a bug.", e);
+        }
     }
 
     public Screen getNextScreen() throws CommCareSessionException {

--- a/src/test/java/mocks/MockFormSessionRepo.java
+++ b/src/test/java/mocks/MockFormSessionRepo.java
@@ -23,6 +23,7 @@ public abstract class MockFormSessionRepo implements FormSessionRepo {
         serializableFormSession.setSessionData(toBeSaved.getSessionData());
         serializableFormSession.setDomain(toBeSaved.getDomain());
         serializableFormSession.setMenuSessionId(toBeSaved.getMenuSessionId());
+        serializableFormSession.setAppId(toBeSaved.getAppId());
         return serializableFormSession;
     }
 

--- a/src/test/resources/requests/install/case_media.json
+++ b/src/test/resources/requests/install/case_media.json
@@ -2,5 +2,6 @@
   "username": "casemediauser",
   "password": "casemediapass",
   "domain": "casemediadomain",
+  "app_id": "caseappid",
   "installReference": "archives/casemedia.ccz"
 }

--- a/src/test/resources/requests/navigators/navigator_0.json
+++ b/src/test/resources/requests/navigators/navigator_0.json
@@ -1,7 +1,8 @@
 {
   "username": "navigatoruser",
-  "password": "testpass",
+  "password": "navigatorpass",
   "domain": "navigatordomain",
+  "app_id": "navigatorappid",
   "installReference": "archives/doublemgmt.ccz",
   "selections": [2, "4d1831ab-abfe-4086-bce7-16d325d9ca3a", 0]
 }

--- a/src/test/resources/requests/preview/preview.json
+++ b/src/test/resources/requests/preview/preview.json
@@ -2,6 +2,7 @@
   "username": "previewuser",
   "password": "previewpass",
   "domain": "previewdomain",
+  "app_id": "previewappid",
   "installReference": "archives/case.ccz",
   "previewCommand": "m2-f2"
 }

--- a/src/test/resources/requests/preview/preview_step.json
+++ b/src/test/resources/requests/preview/preview_step.json
@@ -2,6 +2,7 @@
   "username": "previewuser",
   "password": "previewpass",
   "domain": "previewdomain",
+  "app_id": "previewappid",
   "installReference": "archives/case.ccz",
   "previewCommand": "m2-f2",
   "selections": ["01650834-7c30-4ace-a3cd-f675d9611113"]


### PR DESCRIPTION
This adds some logging and better error messaging around the exception Jessica reported:

java.lang.ArrayIndexOutOfBoundsException: 2
   at org.commcare.util.screen.MenuScreen.handleInputAndUpdateSession(MenuScreen.java:158)
   at session.MenuSession.handleInput(MenuSession.java:167)

the logs around this are very strange:

Request to navigate_menu with bean SessionNavigationBean [id= 3d45b792-cf0e-4d61-9ca5-60e5e74e7deb, selections=[2, 41df827f-bf39-41a5-804d-d0e17836b455, 74a8153d-2bde-4069-b3a9-48ab6a5243b8] parent=InstallRequestBean: [installReference=null, username=asi-test@asi-selever.commcarehq.org, domain=asi-selever, appId=cb33358bb543442b0fc14990358f7118, oneQuestionPerScreen: false]]
2016-12-13 11:01:59.936  INFO 30929 --- [nio-8181-exec-7] services.impl.InstallServiceImpl         : Configuring application with reference https://www.commcarehq.org/a/asi-selever/apps/api/download_ccz/?app_id=cb33358bb543442b0fc14990358f7118&latest=save and dbPath: /opt/data/formplayer/asi-selever/asi_test@asi_selever_commcarehq_org/null.

In the database path the appId is null (presumably what's causing this issue) but in the request the appId is present. Further, in the database path the username and domain are set fine so this doesn't look like a concurrency issue. Stranger things