### PR TITLE
PropertyManager singleton fix

### DIFF
--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -238,7 +238,7 @@ public class MenuSession {
         String formXmlns = sessionWrapper.getForm();
         FormDef formDef = engine.loadFormByXmlns(formXmlns);
         HashMap<String, String> sessionData = getSessionData();
-        String postUrl = new PropertyManager().getSingularProperty("PostURL");
+        String postUrl = PropertyManager.instance().getSingularProperty("PostURL");
         return new FormSession(sandbox, formDef, username, domain,
                 sessionData, postUrl, locale, uuid,
                 null, oneQuestionPerScreen, asUser, appId);
@@ -247,7 +247,7 @@ public class MenuSession {
     public FormSession reloadSession(FormSession oldSession) throws Exception {
         String formXmlns = oldSession.getXmlns();
         FormDef formDef = engine.loadFormByXmlns(formXmlns);
-        String postUrl = new PropertyManager().getSingularProperty("PostURL");
+        String postUrl = PropertyManager.instance().getSingularProperty("PostURL");
         return new FormSession(sandbox, formDef, username, domain,
                 oldSession.getSessionData(), postUrl, locale, oldSession.getMenuSessionId(),
                 oldSession.getInstanceXml(), oldSession.getOneQuestionPerScreen(), asUser,


### PR DESCRIPTION
Should fix those one:

java.lang.RuntimeException: java.sql.SQLException: [SQLITE_BUSY] The database file is locked (database is locked)
   at org.commcare.api.persistence.SqlHelper.updateToTable(SqlHelper.java:221)
   at org.commcare.api.persistence.SqliteIndexedStorageUtility.update(SqliteIndexedStorageUtility.java:353)
   at org.commcare.api.persistence.SqliteIndexedStorageUtility.write(SqliteIndexedStorageUtility.java:83)
   at org.javarosa.core.services.PropertyManager.writeValue(PropertyManager.java:287)
   at org.javarosa.core.services.PropertyManager.setProperty(PropertyManager.java:137)
   at org.javarosa.core.services.PropertyManager.setProperty(PropertyManager.java:120)
   at org.commcare.suite.model.Profile.initializeProperties(Profile.java:191)
   at org.commcare.resources.model.installers.ProfileInstaller.install(ProfileInstaller.java:12