### PR TITLE
Increase lock expiration time, don't crash when it timesout

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -225,7 +225,7 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     @Bean
     public RedisLockRegistry userLockRegistry() {
         JedisConnectionFactory jedisConnectionFactory = jedisConnFactory();
-        return new RedisLockRegistry(jedisConnectionFactory, "formplayer-user");
+        return new RedisLockRegistry(jedisConnectionFactory, "formplayer-user", 5 * 60 * 1000);
     }
 
     @Bean

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -1,8 +1,6 @@
 package aspects;
 
 import beans.AuthenticatedRequestBean;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -19,8 +17,6 @@ import java.util.concurrent.locks.Lock;
  */
 @Aspect
 public class LockAspect {
-
-    private final Log log = LogFactory.getLog(LockAspect.class);
 
     @Autowired
     protected LockRegistry userLockRegistry;
@@ -43,7 +39,9 @@ public class LockAspect {
         try {
             return joinPoint.proceed();
         } finally {
-            lock.unlock();
+            if (lock != null) {
+                lock.unlock();
+            }
         }
     }
 

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -43,14 +43,7 @@ public class LockAspect {
         try {
             return joinPoint.proceed();
         } finally {
-            if (lock != null) {
-                try {
-                    lock.unlock();
-                } catch (IllegalStateException e) {
-                    // Don't crash here, still return result
-                    log.error("Request " + bean + " lost the lock. This could have had negative consequences.");
-                }
-            }
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
Partial fix for http://manage.dimagi.com/default.asp?244524#

Before we were expiring the lock after 60 seconds of ownership (the default) so if the request took longer than this the request would fail (even though the result was returned correctly). This bumps that expiry time to five minutes. 

I've also made it so that we won't crash and discard the result if we've lost the lock. I'm not sure if this is the right thing to do since there are potential concurrency issues (IE another thread could have gotten the lock and changed the DBs). However, this seems exceedingly unlikely to me since 1) the expiry period is now five minutes and 2) now that app and user DBs are used data churn seems much less likely.

In fact I was considering whether we can disregard the user locking entirely now that we're reusing DBs and handling concurrency more cleanly, but that's a separate discussion.

CC @czue @benrudolph 