### PR TITLE
Use statsdclient for metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     compile group: 'org.springframework.data', name: 'spring-data-commons', version: '1.12.2.RELEASE'
     // https://mvnrepository.com/artifact/javax.mail/mail
     compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
+    // https://mvnrepository.com/artifact/com.datadoghq/java-dogstatsd-client
+    compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
     compile("org.springframework.integration:spring-integration-redis:4.2.5.RELEASE")
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -2,6 +2,9 @@ package application;
 
 import aspects.LockAspect;
 import aspects.LoggingAspect;
+import aspects.MetricsAspect;
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import installers.FormplayerInstallerFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -169,6 +172,16 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     @Bean
     public static PropertySourcesPlaceholderConfigurer propertiesResolver() {
         return new PropertySourcesPlaceholderConfigurer();
+    }
+
+    @Bean
+    public StatsDClient datadogStatsDClient() {
+        return new NonBlockingStatsDClient(
+                "formplayer.metrics",
+                "localhost",
+                8125,
+                new String[] {"tag:formplayer"}
+        );
     }
 
     @Bean
@@ -343,5 +356,10 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     @Bean
     public LoggingAspect loggingAspect() {
         return new LoggingAspect();
+    }
+
+    @Bean
+    public MetricsAspect metricsAspect() {
+        return new MetricsAspect();
     }
 }

--- a/src/main/java/aspects/MetricsAspect.java
+++ b/src/main/java/aspects/MetricsAspect.java
@@ -1,0 +1,48 @@
+package aspects;
+
+import beans.AuthenticatedRequestBean;
+import com.timgroup.statsd.StatsDClient;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.reflect.Method;
+
+/**
+ * This aspect records various metrics for every request.
+ */
+@Aspect
+public class MetricsAspect {
+
+    @Autowired
+    protected StatsDClient datadogStatsDClient;
+
+    @Around(value = "@annotation(org.springframework.web.bind.annotation.RequestMapping)")
+    public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+        String domain = "<unknown>";
+        String user = "<unknown>";
+
+        String requestPath = getRequestPath(joinPoint);
+        if (args[0] instanceof AuthenticatedRequestBean) {
+            AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
+            domain = bean.getDomain();
+            user = bean.getUsernameDetail();
+        }
+
+        datadogStatsDClient.increment("requests", domain, user, requestPath);
+        long startTime = System.nanoTime();
+        Object result = joinPoint.proceed();
+        datadogStatsDClient.gauge("timings", (System.nanoTime() - startTime) / 1000000, domain, user, requestPath);
+        return result;
+    }
+
+    private String getRequestPath(ProceedingJoinPoint joinPoint) {
+        MethodSignature ms = (MethodSignature) joinPoint.getSignature();
+        Method m = ms.getMethod();
+        return m.getAnnotation(RequestMapping.class).value()[0];
+    }
+}


### PR DESCRIPTION
@wpride @snopoke  gave up trying to get datadog's jmxfetch utility to work with spring actuator and just wrote the metrics myself. there's a write up here: https://github.com/DataDog/jmxfetch/issues/118 of the issue i was facing. think this is better in the end anyways because it will allow us to capture custom metrics if we want. if the statsd client isn't running, it just silently fails which is what we want

cc: @millerdev @gcapalbo 