### PR TITLE
Actually order by date

### DIFF
--- a/src/main/java/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresFormSessionRepo.java
@@ -35,7 +35,10 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
     @Override
     public List<SerializableFormSession> findUserSessions(String username) {
         List<SerializableFormSession> sessions = this.jdbcTemplate.query(
-                replaceTableName("SELECT * FROM %s WHERE username = ? ORDER BY dateOpened ASC"),
+                replaceTableName(
+                        "SELECT *, dateopened::timestamptz as dateopened_timestamp " +
+                        "FROM %s WHERE username = ? ORDER BY dateopened_timestamp DESC"
+                ),
                 new Object[] {username},
                 new SessionMapper());
         return sessions;


### PR DESCRIPTION
@wpride realized we weren't actually ordering by date. since dateOpened is stored as text as a string like `"Fri Jan 06 15:58:03 SAST 2017`. thus when we order by dateopened it orders by the day of the week. i think at some point we should move dateOpened to actual date time column stored as an epoch or in UTC format. tried writing a test for this, but had trouble mocking the time, but verified it works locally.