### PR TITLE
check nullity

### DIFF
--- a/src/main/java/aspects/MetricsAspect.java
+++ b/src/main/java/aspects/MetricsAspect.java
@@ -27,7 +27,7 @@ public class MetricsAspect {
         String user = "<unknown>";
 
         String requestPath = getRequestPath(joinPoint);
-        if (args[0] instanceof AuthenticatedRequestBean) {
+        if (args!= null && args[0] instanceof AuthenticatedRequestBean) {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
             user = bean.getUsernameDetail();


### PR DESCRIPTION
Fixes 500s, I think every request that doesn't have auth is broken:

java.lang.ArrayIndexOutOfBoundsException: 0
   at aspects.MetricsAspect.logRequest(MetricsAspect.java:30)
   at sun.reflect.GeneratedMethodAccessor162.invoke(Unknown Source)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.lang.reflect.Method.invoke(Method.java:606)
   at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethodWithGivenArgs(AbstractAspectJAdvice.java:621)
   at org.springframework.aop.aspectj.AbstractAspectJAdvice.invokeAdviceMethod(AbstractAspectJAdvice.java:610)
   at org.springframework.aop.aspectj.AspectJAroundAdvice.invoke(AspectJAroundAdvice.java:68)
   at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:168)
   at org.springframework.aop.aspectj.MethodInvocationProceedingJoinPoint.proceed(MethodInvocationProceedingJoinPoint.java:85)
   at aspects.LoggingAspect.logRequest(LoggingAspect.java:33)
   at sun.reflect.GeneratedMethodAccessor161.invoke(Unknown Source)
   at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
   at java.lang.reflect.Method.invoke(Method.java:606)