### PR TITLE
Fix for recursive filter calls

### DIFF
--- a/src/main/java/application/CORSFilter.java
+++ b/src/main/java/application/CORSFilter.java
@@ -2,8 +2,10 @@ package application;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
@@ -13,27 +15,21 @@ import java.io.IOException;
  * See http://stackoverflow.com/questions/13457772/cors-ajax-session-cookies-access-control-allow-credentials-withcredentials
  */
 @Component
-public class CORSFilter implements Filter {
+public class CORSFilter extends OncePerRequestFilter {
 
     @Value("${commcarehq.host}")
     private String hqHost;
 
     @Override
-    public void doFilter(ServletRequest req, ServletResponse res,
-                         FilterChain chain) throws IOException, ServletException {
-        HttpServletResponse response = (HttpServletResponse) res;
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         response.setHeader("Access-Control-Allow-Origin", hqHost);
         response.setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, OPTIONS, DELETE");
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
         response.setHeader("Access-Control-Allow-Credentials", "true");
-        chain.doFilter(req, res);
+        filterChain.doFilter(request, response);
     }
 
     @Override
     public void destroy() {}
-
-    @Override
-    public void init(FilterConfig arg0) throws ServletException {}
-
 }

--- a/src/main/java/application/FormplayerAuthFilter.java
+++ b/src/main/java/application/FormplayerAuthFilter.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 import repo.TokenRepo;
 import repo.impl.CouchUserRepo;
 import repo.impl.PostgresUserRepo;
@@ -32,7 +33,7 @@ import java.util.regex.Pattern;
  * @author wspride
  */
 @Component
-public class FormplayerAuthFilter implements Filter {
+public class FormplayerAuthFilter extends OncePerRequestFilter {
 
     @Autowired
     TokenRepo tokenRepo;
@@ -47,18 +48,12 @@ public class FormplayerAuthFilter implements Filter {
     RedisLockRegistry userLockRegistry;
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-
-    }
-
-    @Override
-    public void doFilter(ServletRequest req, ServletResponse res,
-                         FilterChain chain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         FormplayerHttpRequest request = new FormplayerHttpRequest((HttpServletRequest) req);
         if (isAuthorizationRequired(request)) {
             // These are order dependent
             if (getSessionId(request) == null) {
-                setResponseUnauthorized((HttpServletResponse) res);
+                setResponseUnauthorized(response);
                 return;
             }
             setToken(request);
@@ -66,12 +61,10 @@ public class FormplayerAuthFilter implements Filter {
             setDomain(request);
             JSONObject data = RequestUtils.getPostData(request);
             if (!authorizeRequest(request, data.getString("domain"), getUsername(data))) {
-                setResponseUnauthorized((HttpServletResponse) res);
+                setResponseUnauthorized(response);
                 return;
             }
         }
-
-        chain.doFilter(request, res);
     }
 
     private String getUsername(JSONObject data) {

--- a/src/main/java/application/FormplayerAuthFilter.java
+++ b/src/main/java/application/FormplayerAuthFilter.java
@@ -65,6 +65,7 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
                 return;
             }
         }
+        filterChain.doFilter(request, response);
     }
 
     private String getUsername(JSONObject data) {


### PR DESCRIPTION
Have our filters extend a class that guarantees to only fire once, hopefully will resolve these recursive filtering overflows we saw. Also makes the code tidier. 