### PR TITLE
Change StorageManager static to StorageManager thread safe singleton

### DIFF
--- a/src/test/java/tests/InstallTests.java
+++ b/src/test/java/tests/InstallTests.java
@@ -68,7 +68,7 @@ public class InstallTests extends BaseTestClass {
         assert formSessionResponse.getTree().length == 7;
 
         SqlSandboxUtils.deleteDatabaseFolder("dbs");
-        StorageManager.forceClear();
+        StorageManager.instance().forceClear();
     }
 
 }


### PR DESCRIPTION
Don't know how I missed this one on my previous static object pass. Should fix the GLOBAL_RESOURCES_TABLE exception that we've been seeing. Hopefully the last of these. 