### PR TITLE
Fix appId in menu session

### DIFF
--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -97,7 +97,7 @@ public class MenuSession {
         SessionUtils.setLocale(this.locale);
         sessionWrapper.syncState();
         this.screen = getNextScreen();
-        this.appId = this.engine.getPlatform().getCurrentProfile().getUniqueId();
+        this.appId = session.getAppId();
     }
 
     public MenuSession(String username, String domain, String appId, String installReference, String locale,
@@ -106,6 +106,7 @@ public class MenuSession {
         this.username = TableBuilder.scrubName(username);
         this.domain = domain;
         this.auth = auth;
+        this.appId = appId;
         this.asUser = asUser;
         resolveInstallReference(installReference, appId, host);
         this.engine = installService.configureApplication(this.installReference);
@@ -115,7 +116,6 @@ public class MenuSession {
         SessionUtils.setLocale(this.locale);
         this.screen = getNextScreen();
         this.uuid = UUID.randomUUID().toString();
-        this.appId = this.engine.getPlatform().getCurrentProfile().getUniqueId();
         this.oneQuestionPerScreen = oneQuestionPerScreen;
     }
     


### PR DESCRIPTION
Use appId from the request instead of from the profile. This was not correct and was resulting in re-installations happening on some submissions (also explaining why submit times were so long for some requests). 