### PR TITLE
Fail fast when encountering parse error

### DIFF
--- a/src/main/java/beans/menus/EntityListResponse.java
+++ b/src/main/java/beans/menus/EntityListResponse.java
@@ -47,8 +47,7 @@ public class EntityListResponse extends MenuBean {
     private int maxWidth;
     private int maxHeight;
 
-    public EntityListResponse() {
-    }
+    public EntityListResponse() {}
 
     public EntityListResponse(EntityScreen nextScreen, int offset, String searchText, String id) {
         SessionWrapper session = nextScreen.getSession();
@@ -218,7 +217,7 @@ public class EntityListResponse extends MenuBean {
         int i = 0;
         for (DetailField field : fields) {
             Object o;
-                o = field.getTemplate().evaluate(context);
+            o = field.getTemplate().evaluate(context);
             data[i] = o;
             i++;
         }

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -92,7 +92,7 @@ public class CaseAPIs {
             UnfullfilledRequirementsException, InvalidStructureException, IOException, XmlPullParserException {
         UserSqlSandbox mSandbox = SqlSandboxUtils.getStaticStorage(username, path);
         PrototypeFactory.setStaticHasher(new ClassNameHasher());
-        ParseUtilsHelper.parseXMLIntoSandbox(restorePayload, mSandbox);
+        ParseUtilsHelper.parseXMLIntoSandbox(restorePayload, mSandbox, true);
         // initialize our sandbox's logged in user
         for (IStorageIterator<User> iterator = mSandbox.getUserStorage().iterate(); iterator.hasMore(); ) {
             User u = iterator.nextRecord();

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -1,5 +1,7 @@
 package util;
 
+import org.commcare.modern.util.Pair;
+
 /**
  * Created by willpride on 2/4/16.
  */


### PR DESCRIPTION
This was really dumb. The restore for this user has a bunch of invalid XML. Rather than failing quickly, our code was using the default path to continue parsing and present the errors at the end. This resulted in the restore taking forever as we accumulated errors and traversed the XML. Now we'll just fail quickly when the first invalid line is encountered.