### PR TITLE
Case list optimization

### DIFF
--- a/src/main/java/beans/menus/EntityListResponse.java
+++ b/src/main/java/beans/menus/EntityListResponse.java
@@ -47,8 +47,7 @@ public class EntityListResponse extends MenuBean {
     private int maxWidth;
     private int maxHeight;
 
-    public EntityListResponse() {
-    }
+    public EntityListResponse() {}
 
     public EntityListResponse(EntityScreen nextScreen, int offset, String searchText, String id) {
         SessionWrapper session = nextScreen.getSession();
@@ -218,7 +217,7 @@ public class EntityListResponse extends MenuBean {
         int i = 0;
         for (DetailField field : fields) {
             Object o;
-                o = field.getTemplate().evaluate(context);
+            o = field.getTemplate().evaluate(context);
             data[i] = o;
             i++;
         }

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -1,5 +1,7 @@
 package util;
 
+import org.commcare.modern.util.Pair;
+
 /**
  * Created by willpride on 2/4/16.
  */

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -1,7 +1,5 @@
 package util;
 
-import org.commcare.modern.util.Pair;
-
 /**
  * Created by willpride on 2/4/16.
  */


### PR DESCRIPTION
Previously we were evaluating every case list field for every case in user's DB before showing the case list even when this list might be filtered and would certainly be paginated. This changes that pushing the row loading back in the EntityListScreen class until they're needed and by making the filter and paginate operations work on the list of pre-rendered Entity<TreeReference> objects instead of the fully actualized rows. Required moving some code down from -android into -core.

This should be a massive performance win for enikshay

@benrudolph cc @czue 