### PR TITLE
Make evaluate instance work better

### DIFF
--- a/src/main/java/beans/EvaluateXPathResponseBean.java
+++ b/src/main/java/beans/EvaluateXPathResponseBean.java
@@ -2,7 +2,10 @@ package beans;
 
 import org.commcare.suite.model.Text;
 import org.javarosa.core.model.condition.EvaluationContext;
+import org.javarosa.engine.XFormPlayer;
 import org.javarosa.xpath.XPathException;
+import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 import session.FormSession;
 import util.Constants;
@@ -23,8 +26,9 @@ public class EvaluateXPathResponseBean {
         status = Constants.ANSWER_RESPONSE_STATUS_POSITIVE;
         EvaluationContext evaluationContext = formEntrySession.getFormEntryModel().getForm().getEvaluationContext();
         try {
-            Text mText = Text.XPathText(xpath, new Hashtable<String, Text>());
-            output = mText.evaluate(evaluationContext);
+            XPathExpression  expr = XPathParseTool.parseXPath(xpath);
+            Object val = expr.eval(evaluationContext);
+            output = XFormPlayer.getDisplayString(val);
         } catch (XPathException | XPathSyntaxException e) {
             status = Constants.ANSWER_RESPONSE_STATUS_NEGATIVE;
             output = e.getMessage();

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -5,15 +5,18 @@ import beans.NewFormResponse;
 import beans.NewSessionRequestBean;
 import hq.CaseAPIs;
 import objects.SerializableFormSession;
+import org.apache.commons.io.IOUtils;
 import org.commcare.api.persistence.UserSqlSandbox;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.xform.parse.XFormParser;
+import org.javarosa.xform.util.XFormUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import repo.FormSessionRepo;
 import session.FormSession;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 
 /**
@@ -62,7 +65,7 @@ public class NewFormResponseFactory {
     }
 
     private static FormDef parseFormDef(String formXml) throws IOException {
-        XFormParser mParser = new XFormParser(new StringReader(formXml));
-        return mParser.parse();
+        FormDef formDef = XFormUtils.getFormRaw(new InputStreamReader(IOUtils.toInputStream(formXml, "UTF-8")));
+        return formDef;
     }
 }

--- a/src/test/java/tests/CaseTests.java
+++ b/src/test/java/tests/CaseTests.java
@@ -105,6 +105,17 @@ public class CaseTests extends BaseTestClass {
         assert openCount == 15;
     }
 
+    @Test
+    public void testEvaluateInstance() throws Exception{
+        NewFormResponse newSessionResponse2 = startNewSession("requests/new_form/new_form_4.json", "xforms/cases/update_case.xml");
+
+        // Aside: test EvaluateXPath with instance() and multiple matching nodes works
+        EvaluateXPathResponseBean evaluateXPathResponseBean =
+                evaluateXPath(newSessionResponse2.getSessionId(), "instance('casedb')/casedb/case/@case_id");
+
+        assert evaluateXPathResponseBean.getStatus().equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
+    }
+
     @After
     public void tearDown(){
         SqlSandboxUtils.deleteDatabaseFolder(SQLiteProperties.getDataDir());

--- a/src/test/java/tests/FormEntryTest.java
+++ b/src/test/java/tests/FormEntryTest.java
@@ -78,7 +78,12 @@ public class FormEntryTest extends BaseTestClass{
         assert evaluateXPathResponseBean.getStatus().equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
         assert evaluateXPathResponseBean.getOutput().equals("William Pride");
 
-        evaluateXPathResponseBean = evaluateXPath(sessionId, "/data/broken");
+        // We shouldn't error when a path doesn't exist
+        evaluateXPathResponseBean = evaluateXPath(sessionId, "/data/not_broken");
+        assert evaluateXPathResponseBean.getStatus().equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
+
+        // However, we should error when the path is invalid
+        evaluateXPathResponseBean = evaluateXPath(sessionId, "!data/broken");
         assert evaluateXPathResponseBean.getStatus().equals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
 
         //Test Submission


### PR DESCRIPTION
This aligns our code path with the one used by the CLI, in particular it allows us to return multiple nodes in the case that the expression matches multiple.