### PR TITLE
Fix OQPS sub-group indexing issue

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -202,7 +202,8 @@ public class FormController extends AbstractBaseController{
                             formEntryModel,
                             answer,
                             key,
-                            false);
+                            false,
+                            null);
             if(!answerResult.get(ApiConstants.RESPONSE_STATUS_KEY).equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)) {
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 ErrorBean error = new ErrorBean();

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -408,6 +408,7 @@ public class FormSession {
     }
 
     public JSONObject answerQuestionToJSON(Object answer, String formIndex) {
+        System.out.println("Form index " + formIndex + " answer " + answer + " oqps " + oneQuestionPerScreen);
         JSONObject resp = JsonActionUtils.questionAnswerToJson(formEntryController,
                 formEntryModel,
                 answer != null ? answer.toString() : null,

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -407,12 +407,13 @@ public class FormSession {
         setCurrentIndex(newIndex.toString());
     }
 
-    public JSONObject answerQuestionToJSON(Object answer, String formIndex) {
+    public JSONObject answerQuestionToJSON(Object answer, String answerIndex) {
         return JsonActionUtils.questionAnswerToJson(formEntryController,
                 formEntryModel,
                 answer != null ? answer.toString() : null,
-                formIndex,
-                oneQuestionPerScreen);
+                answerIndex,
+                oneQuestionPerScreen,
+                currentIndex);
     }
 
     public JSONObject getNextJson() {

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -408,13 +408,11 @@ public class FormSession {
     }
 
     public JSONObject answerQuestionToJSON(Object answer, String formIndex) {
-        System.out.println("Form index " + formIndex + " answer " + answer + " oqps " + oneQuestionPerScreen);
-        JSONObject resp = JsonActionUtils.questionAnswerToJson(formEntryController,
+        return JsonActionUtils.questionAnswerToJson(formEntryController,
                 formEntryModel,
                 answer != null ? answer.toString() : null,
                 formIndex,
                 oneQuestionPerScreen);
-        return resp;
     }
 
     public JSONObject getNextJson() {

--- a/src/test/java/mocks/MockFormSessionRepo.java
+++ b/src/test/java/mocks/MockFormSessionRepo.java
@@ -24,6 +24,7 @@ public abstract class MockFormSessionRepo implements FormSessionRepo {
         serializableFormSession.setDomain(toBeSaved.getDomain());
         serializableFormSession.setMenuSessionId(toBeSaved.getMenuSessionId());
         serializableFormSession.setAppId(toBeSaved.getAppId());
+        serializableFormSession.setOneQuestionPerScreen(toBeSaved.getOneQuestionPerScreen());
         return serializableFormSession;
     }
 

--- a/src/test/java/mocks/MockFormSessionRepo.java
+++ b/src/test/java/mocks/MockFormSessionRepo.java
@@ -25,6 +25,7 @@ public abstract class MockFormSessionRepo implements FormSessionRepo {
         serializableFormSession.setMenuSessionId(toBeSaved.getMenuSessionId());
         serializableFormSession.setAppId(toBeSaved.getAppId());
         serializableFormSession.setOneQuestionPerScreen(toBeSaved.getOneQuestionPerScreen());
+        serializableFormSession.setCurrentIndex(toBeSaved.getCurrentIndex());
         return serializableFormSession;
     }
 

--- a/src/test/java/tests/OQPSDateRegression.java
+++ b/src/test/java/tests/OQPSDateRegression.java
@@ -1,0 +1,38 @@
+package tests;
+
+import beans.FormEntryResponseBean;
+import beans.NewFormResponse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import utils.TestContext;
+
+/**
+ * Regression tests for fixed behaviors
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestContext.class)
+public class OQPSDateRegression extends BaseTestClass{
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        configureRestoreFactory("oqpsdatedomain", "oqpsusername");
+    }
+
+    // test that we can override today() successfully
+    @Test
+    public void testFunctionHandlers() throws Throwable {
+        NewFormResponse newFormResponse = startNewForm("requests/new_form/new_form_oqps.json", "xforms/oqps_date.xml");
+        String sessionId = newFormResponse.getSessionId();
+        FormEntryResponseBean response = nextScreen(sessionId);
+        assert response.getTree().length == 3;
+        assert response.getTree()[0].getBinding().equals("/data/question4/question2");
+        assert response.getTree()[2].getBinding().equals("/data/question4/question6");
+        response = answerQuestionGetResult("1,0", "1", sessionId);
+        assert response.getTree().length == 3;
+        assert response.getTree()[0].getBinding().equals("/data/question4/question2");
+        assert response.getTree()[2].getBinding().equals("/data/question4/question6");
+    }
+}

--- a/src/test/java/tests/OQPSDateRegression.java
+++ b/src/test/java/tests/OQPSDateRegression.java
@@ -23,7 +23,7 @@ public class OQPSDateRegression extends BaseTestClass{
 
     // test that we can override today() successfully
     @Test
-    public void testFunctionHandlers() throws Throwable {
+    public void testOQPSSubGroup() throws Throwable {
         NewFormResponse newFormResponse = startNewForm("requests/new_form/new_form_oqps.json", "xforms/oqps_date.xml");
         String sessionId = newFormResponse.getSessionId();
         FormEntryResponseBean response = nextScreen(sessionId);

--- a/src/test/resources/xforms/oqps_date.xml
+++ b/src/test/resources/xforms/oqps_date.xml
@@ -1,0 +1,67 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Date Picker Field List OQPS</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/11FAC65A-F2CD-427F-A870-CF126336AAB5" uiVersion="1" version="15" name="Date Picker Field List OQPS">
+                    <question1/>
+                    <question4>
+                        <question2/>
+                        <question5/>
+                        <question6/>
+                    </question4>
+                    <question7/>
+                    <orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+            </instance><instance id="commcaresession" src="jr://instance/session"/>
+            <bind nodeset="/data/question1"/>
+            <bind nodeset="/data/question4"/>
+            <bind nodeset="/data/question4/question2" type="xsd:string"/>
+            <bind nodeset="/data/question4/question5" type="xsd:date" required="true()"/>
+            <bind nodeset="/data/question4/question6" type="xsd:string" required="true()"/>
+            <bind nodeset="/data/question7"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="question1-label">
+                        <value>This is a placeholder, go to the next question and try to use a date, weird things will happen
+                        </value>
+                    </text>
+                    <text id="question4-label">
+                        <value>Field List</value>
+                    </text>
+                    <text id="question4/question2-label">
+                        <value>Text  goes here</value>
+                    </text>
+                    <text id="question4/question5-label">
+                        <value>Date Picker (using this will break things)</value>
+                    </text>
+                    <text id="question4/question6-label">
+                        <value>You need to put text here to proceed</value>
+                    </text>
+                    <text id="question7-label">
+                        <value>If you chose a date and got here, things are golden!</value>
+                    </text>
+                </translation>
+            </itext>
+            <setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
+    </h:head>
+    <h:body>
+        <trigger ref="/data/question1" appearance="minimal">
+            <label ref="jr:itext('question1-label')"/>
+        </trigger>
+        <group ref="/data/question4" appearance="field-list">
+            <label ref="jr:itext('question4-label')"/>
+            <input ref="/data/question4/question2">
+                <label ref="jr:itext('question4/question2-label')"/>
+            </input>
+            <input ref="/data/question4/question5">
+                <label ref="jr:itext('question4/question5-label')"/>
+            </input>
+            <input ref="/data/question4/question6">
+                <label ref="jr:itext('question4/question6-label')"/>
+            </input>
+        </group>
+        <trigger ref="/data/question7" appearance="minimal">
+            <label ref="jr:itext('question7-label')"/>
+        </trigger>
+    </h:body>
+</h:html>


### PR DESCRIPTION
fixes https://manage.dimagi.com/default.asp?247996

In OQPS when you answered a question in a sub-group, the currentIndex would focus on that specific answer (as if it had not been in a sub-group at all) so the other group members would not be displayed.

~This PR addresses that by using the top-level (shallowest) index (rather than the deepest one) to generate the current set of relevant questions.~

Actually, re-wrote to use currentIndex from the FormSession rather than hacky string chopping