### PR TITLE
Skip EntityScreen when necessary

### DIFF
--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -187,6 +187,9 @@ public class MenuSession {
         } else if (next.equals(SessionFrame.STATE_DATUM_VAL)) {
             EntityScreen entityScreen = new EntityScreen();
             entityScreen.init(sessionWrapper);
+            if (entityScreen.shouldBeSkipped()) {
+                return getNextScreen();
+            }
             return entityScreen;
         } else if (next.equalsIgnoreCase(SessionFrame.STATE_DATUM_COMPUTED)) {
             computeDatum();


### PR DESCRIPTION
Should fix these exceptions:

Screen org.commcare.util.screen.EntityScreen@5bc3341e handling input 7bd4c465-facc-47d9-91c8-16ab3140361e threw exception null. Please try reloading this application and if the problem persists please report a bug.

@ctsims 