### PR TITLE
Stream Response

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -248,7 +248,7 @@ public abstract class AbstractBaseController {
     }
 
     private NewFormResponse generateFormEntryScreen(MenuSession menuSession) throws Exception {
-        FormSession formEntrySession = menuSession.getFormEntrySession();
+        FormSession formEntrySession = menuSession.getFormEntrySession(restoreFactory);
         menuSessionRepo.save(new SerializableMenuSession(menuSession));
         NewFormResponse response = new NewFormResponse(formEntrySession);
         formSessionRepo.save(formEntrySession.serialize());

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -21,6 +21,7 @@ import services.RestoreFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Created by willpride on 1/7/16.
@@ -41,12 +42,12 @@ public class CaseAPIs {
             return restoreFactory.getSqlSandbox();
         } else{
             db.getParentFile().mkdirs();
-            String xml = restoreFactory.getRestoreXml(overwriteCache);
-            return restoreUser(restoreFactory.getWrappedUsername(), restoreFactory.getDbPath(), xml);
+            InputStream restoreStream = restoreFactory.getRestoreXml(overwriteCache);
+            return restoreUser(restoreFactory.getWrappedUsername(), restoreFactory.getDbPath(), restoreStream);
         }
     }
 
-    public static UserSqlSandbox restoreIfNotExists(String username, String asUsername, String domain, String xml) throws Exception {
+    public static UserSqlSandbox restoreIfNotExists(String username, String asUsername, String domain, InputStream xml) throws Exception {
         // This is a shitty hack to allow serialized sessions to use the RestoreFactory path methods.
         // We need a refactor of the entire infrastructure
         RestoreFactory restoreFactory = new RestoreFactory();
@@ -62,7 +63,7 @@ public class CaseAPIs {
         return new CaseBean(cCase);
     }
 
-    private static UserSqlSandbox restoreUser(String username, String path, String restorePayload) throws
+    private static UserSqlSandbox restoreUser(String username, String path, InputStream restorePayload) throws
             UnfullfilledRequirementsException, InvalidStructureException, IOException, XmlPullParserException {
         UserSqlSandbox mSandbox = new UserSqlSandbox(username, path);
         PrototypeFactory.setStaticHasher(new ClassNameHasher());

--- a/src/main/java/objects/SerializableFormSession.java
+++ b/src/main/java/objects/SerializableFormSession.java
@@ -2,6 +2,7 @@ package objects;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.util.Map;
 
@@ -14,7 +15,7 @@ public class SerializableFormSession implements Serializable{
     private String id;
     private String instanceXml;
     private String formXml;
-    private String restoreXml;
+    private InputStream restoreXml;
     private String username;
     private String initLang;
     private int sequenceId;
@@ -77,11 +78,11 @@ public class SerializableFormSession implements Serializable{
         this.username = username;
     }
 
-    public String getRestoreXml() {
+    public InputStream getRestoreXml() {
         return restoreXml;
     }
 
-    public void setRestoreXml(String restoreXml){
+    public void setRestoreXml(InputStream restoreXml){
         this.restoreXml = restoreXml;
     }
 

--- a/src/main/java/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresFormSessionRepo.java
@@ -2,6 +2,7 @@ package repo.impl;
 
 import exceptions.FormNotFoundException;
 import objects.SerializableFormSession;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -76,8 +77,8 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
         public void setValues(PreparedStatement ps) throws SQLException {
             byte[] sessionDataBytes = writeToBytes(mSession.getSessionData());
 
-            ps.setString(1, mSession.getInstanceXml());
-            ps.setString(2, mSession.getId());
+            ps.setString(1, mSession.getId());
+            ps.setString(2, mSession.getInstanceXml());
             ps.setString(3, mSession.getFormXml());
             try {
                 ps.setCharacterStream(4, new InputStreamReader(mSession.getRestoreXml(), "UTF-8"), mSession.getRestoreXml().available());
@@ -113,19 +114,19 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
         public void setValues(PreparedStatement ps) throws SQLException {
             byte[] sessionDataBytes = writeToBytes(mSession.getSessionData());
 
-            ps.setString(0, mSession.getInstanceXml());
-            ps.setBytes(1, sessionDataBytes);
-            ps.setString(2, String.valueOf(mSession.getSequenceId()));
-            ps.setString(3, mSession.getCurrentIndex());
-            ps.setString(4, mSession.getPostUrl());
+            ps.setString(1, mSession.getInstanceXml());
+            ps.setBytes(2, sessionDataBytes);
+            ps.setString(3, String.valueOf(mSession.getSequenceId()));
+            ps.setString(4, mSession.getCurrentIndex());
+            ps.setString(5, mSession.getPostUrl());
             try {
-                ps.setCharacterStream(5, new InputStreamReader(mSession.getRestoreXml(), "UTF-8"), mSession.getRestoreXml().available());
+                ps.setCharacterStream(6, new InputStreamReader(mSession.getRestoreXml(), "UTF-8"), mSession.getRestoreXml().available());
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            ps.setString(6, mSession.getId());
+            ps.setString(7, mSession.getId());
         }
     }
 

--- a/src/main/java/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresFormSessionRepo.java
@@ -236,8 +236,8 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
             session.setId(rs.getString("id"));
             session.setInstanceXml(rs.getString("instanceXml"));
             session.setFormXml(rs.getString("formXml"));
-            Blob blobXml = rs.getBlob("restoreXml");
-            InputStream restoreStream = blobXml.getBinaryStream();
+            Reader restoreReader = rs.getCharacterStream("restoreXml");
+            InputStream restoreStream = new ReaderInputStream(restoreReader, "UTF-8");
             session.setRestoreXml(restoreStream);
             session.setUsername(rs.getString("username"));
             session.setInitLang(rs.getString("initLang"));

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -41,7 +41,7 @@ public class NewFormResponseFactory {
         UserSqlSandbox sandbox = CaseAPIs.forceRestore(restoreFactory);
 
         FormSession formSession = new FormSession(
-                sandbox,
+                restoreFactory,
                 parseFormDef(formXml),
                 bean.getUsername(),
                 bean.getDomain(),

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -34,6 +34,7 @@ import org.javarosa.xform.schema.FormInstanceLoader;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.stereotype.Component;
+import services.RestoreFactory;
 import util.ApplicationUtils;
 
 import java.io.*;
@@ -113,7 +114,7 @@ public class FormSession {
     }
 
     // New FormSession constructor
-    public FormSession(UserSandbox sandbox,
+    public FormSession(RestoreFactory restoreFactory,
                        FormDef formDef,
                        String username,
                        String domain,
@@ -128,7 +129,7 @@ public class FormSession {
                        Map<String, FunctionHandler[]> functionContext) throws Exception {
         this.username = TableBuilder.scrubName(username);
         this.formDef = formDef;
-        this.sandbox = sandbox;
+        this.sandbox = CaseAPIs.restoreIfNotExists(restoreFactory, false);
         this.sessionData = sessionData;
         this.domain = domain;
         this.postUrl = postUrl;
@@ -141,6 +142,7 @@ public class FormSession {
         this.asUser = asUser;
         this.appId = appId;
         this.currentIndex = "0";
+        this.restoreXml = restoreFactory.getRestoreXml();
         setupJavaRosaObjects();
         setupFunctionContext(this.formDef, functionContext);
         if(instanceContent != null){

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -61,7 +61,7 @@ public class FormSession {
     private FormEntryModel formEntryModel;
     private FormEntryController formEntryController;
     private FormController formController;
-    private String restoreXml;
+    private InputStream restoreXml;
     private UserSandbox sandbox;
     private int sequenceId;
     private String dateOpened;
@@ -263,7 +263,7 @@ public class FormSession {
         return metaData.toString();
     }
 
-    private String getRestoreXml() {
+    private InputStream getRestoreXml() {
         return restoreXml;
     }
 

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -235,15 +235,26 @@ public class MenuSession {
         return ret;
     }
 
-    public FormSession getFormEntrySession() throws Exception {
+    public FormSession getFormEntrySession(RestoreFactory restoreFactory) throws Exception {
         String formXmlns = sessionWrapper.getForm();
         FormDef formDef = engine.loadFormByXmlns(formXmlns);
         HashMap<String, String> sessionData = getSessionData();
         String postUrl = PropertyManager.instance().getSingularProperty("PostURL");
-        return new FormSession(sandbox, formDef, username, domain,
-                sessionData, postUrl, locale, uuid,
-                null, oneQuestionPerScreen,
-                asUser, appId, null);
+        return new FormSession(
+                restoreFactory,
+                formDef,
+                username,
+                domain,
+                sessionData,
+                postUrl,
+                locale,
+                uuid,
+                null,
+                oneQuestionPerScreen,
+                asUser,
+                appId,
+                null
+        );
     }
 
     public void reloadSession(FormSession formSession) throws Exception {


### PR DESCRIPTION
@wpride @snopoke this is some work towards only dealing with restores via streams. not completely finished but wanted to get opinions on the approach. so far this correctly saves all the restore xml into postgres and you can open a form. i think there's an error occurring when answering a question where it tries to read the full stream twice. i don't think loading the entire restore into memory is tenable for enikshay if we plan on having 100s of concurrent users