### PR TITLE
Graceful fail when migrated form session has null lang

### DIFF
--- a/src/main/java/repo/impl/PostgresMigratedFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresMigratedFormSessionRepo.java
@@ -365,7 +365,10 @@ public class PostgresMigratedFormSessionRepo implements FormSessionRepo {
         session.setAsUser(null);
         session.setInstanceXml(sessionObject.getString("instance"));
         session.setFormXml(sessionObject.getString("xform"));
-        session.setInitLang(sessionObject.getString("init_lang"));
+        // default behavior of null locale just results in default
+        if (sessionObject.has("init_lang")) {
+            session.setInitLang(sessionObject.getString("init_lang"));
+        }
         session.setSequenceId(sessionObject.getInt("seq_id"));
         HashMap<String, String> sessionDataMap = new HashMap<>();
         session.setSessionData(sessionDataMap);


### PR DESCRIPTION
Fix for https://manage.dimagi.com/default.asp?249209

If the JSON doesn't have an init_lang, we can just allow this property to be null and we will use the default locale. 