### PR TITLE
Check if form index is first in the form

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -264,9 +264,8 @@ public class FormController extends AbstractBaseController{
         restoreFactory.configure(requestBean, new DjangoAuth(authToken));
         FormSession formSession = new FormSession(serializableFormSession, restoreFactory);
         formSession.stepToNextIndex();
-        JSONObject resp = formSession.getNextJson();
+        FormEntryNavigationResponseBean responseBean = formSession.getFormNavigation();
         updateSession(formSession, serializableFormSession);
-        FormEntryNavigationResponseBean responseBean = mapper.readValue(resp.toString(), FormEntryNavigationResponseBean.class);
         return responseBean;
     }
 
@@ -280,12 +279,8 @@ public class FormController extends AbstractBaseController{
         restoreFactory.configure(requestBean, new DjangoAuth(authToken));
         FormSession formSession = new FormSession(serializableFormSession, restoreFactory);
         formSession.stepToPreviousIndex();
-        JSONObject resp = JsonActionUtils.getCurrentJson(formSession.getFormEntryController(),
-                formSession.getFormEntryModel(),
-                formSession.getCurrentIndex());
+        FormEntryNavigationResponseBean responseBean = formSession.getFormNavigation();
         updateSession(formSession, serializableFormSession);
-        FormEntryNavigationResponseBean responseBean = mapper.readValue(resp.toString(), FormEntryNavigationResponseBean.class);
-        responseBean.setCurrentIndex(formSession.getCurrentIndex());
         return responseBean;
     }
 

--- a/src/main/java/beans/FormEntryNavigationResponseBean.java
+++ b/src/main/java/beans/FormEntryNavigationResponseBean.java
@@ -8,8 +8,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * Use this to respond to requests related to in form navigation (next / previous / etc)
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FormEntryNavigationResponseBean extends FormEntryResponseBean{
+public class FormEntryNavigationResponseBean extends FormEntryResponseBean {
   private boolean isAtLastIndex = false;
+  private boolean isAtFirstIndex = false;
   private String currentIndex;
 
   public boolean getIsAtLastIndex() { return isAtLastIndex; }
@@ -24,4 +25,11 @@ public class FormEntryNavigationResponseBean extends FormEntryResponseBean{
     this.currentIndex = currentIndex;
   }
 
+  public boolean getIsAtFirstIndex() {
+    return isAtFirstIndex;
+  }
+
+  public void setIsAtFirstIndex(boolean atFirstIndex) {
+    isAtFirstIndex = atFirstIndex;
+  }
 }


### PR DESCRIPTION
We were running into a situation where anytime the FormIndex for the first displayed question wasn't `0` - for example when the first question is in a group it will have index `0,0` - then we would not grey out the getPrevious arrow if we returned to the question. This rectifies that by checking on Formplayer whether there is truly another question before the current one. 

cross-request: https://github.com/dimagi/commcare-hq/pull/15738