### PR TITLE
Don't rely on member variable

### DIFF
--- a/src/main/java/beans/menus/EntityListResponse.java
+++ b/src/main/java/beans/menus/EntityListResponse.java
@@ -161,7 +161,7 @@ public class EntityListResponse extends MenuBean {
         List<Entity<TreeReference>> matched = filterEntities(searchText, nodeEntityFactory, full);
         sort(matched, shortDetail);
 
-        if (matched.size() > CASE_LENGTH_LIMIT && !(numEntitiesPerRow > 1)) {
+        if (matched.size() > CASE_LENGTH_LIMIT && !(shortDetail.getNumEntitiesToDisplayPerRow() > 1)) {
             // we're doing pagination
             setCurrentPage(offset / CASE_LENGTH_LIMIT);
             setPageCount((int) Math.ceil((double) matched.size() / CASE_LENGTH_LIMIT));


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?251978

This happened because the pagination code relied (indirectly) on the case tile processing code being called first, at some point the calls must've gotten out of order. Removed this silly dependency. 