### PR TITLE
Update plugin versions, update deprecated classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core'
-    compile group: 'org.json', name:'json'
+    compile 'org.json:json:20140107'
     compile group: 'org.apache.httpcomponents', name: 'httpclient'
     compile group: 'org.postgresql', name: 'postgresql'
     compile group: 'org.flywaydb', name: 'flyway-core'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.4.3.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.3.RELEASE")
     }
 }
 
@@ -28,59 +28,62 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile group: 'org.springframework.boot', name: 'spring-boot', version: '1.4.3.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.4.3.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '1.4.3.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '1.4.3.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc', version: '1.4.3.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '1.4.3.RELEASE'
-    compile group: 'org.springframework.data', name: 'spring-data-jpa', version: '1.10.6.RELEASE'
-    compile("org.springframework:spring-web")
-    compile group: 'org.springframework.data', name: 'spring-data-redis', version: '1.7.6.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '1.4.3.RELEASE'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.6'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.6'
+    // Versionless dependencies that the spring-boot plugin will manage for us
+    compile group: 'org.springframework.boot', name: 'spring-boot'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
+    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
+    compile group: 'org.springframework.data', name: 'spring-data-jpa'
+    compile group: 'org.springframework', name: 'spring-web'
+    compile group: 'org.springframework.data', name: 'spring-data-redis'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core'
+    compile group: 'org.json', name:'json'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient'
+    compile group: 'org.postgresql', name: 'postgresql'
+    compile group: 'org.flywaydb', name: 'flyway-core'
+    compile group: 'org.springframework', name: 'spring-orm'
+    compile group: 'org.springframework', name: 'spring-jdbc'
+    compile group: 'org.hibernate', name: 'hibernate-entitymanager'
+    compile group: 'org.hibernate', name: 'hibernate-core'
+    compile group: 'org.springframework.data', name: 'spring-data-commons'
+    compile group: 'org.springframework', name: 'spring-test'
+    compile group: 'org.springframework.integration', name: 'spring-integration-redis'
+    compile group: 'org.xerial', name: 'sqlite-jdbc'
+    compile group: 'javax.servlet', name: 'jstl'
+
+    testCompile("org.springframework.boot:spring-boot-starter-test")
+    testCompile group: 'com.jayway.jsonpath', name: 'json-path'
+    testCompile group: 'com.jayway.jsonpath', name: 'json-path-assert'
+
+
     compile 'com.carrotsearch:hppc:0.7.2'
     compile 'com.getsentry.raven:raven:8.0.2'
 
-    compile("org.apache.directory.studio:org.apache.commons.io:2.0.1")
+    compile 'org.apache.directory.studio:org.apache.commons.io:2.0.1'
     compile 'net.sf.kxml:kxml2:2.3.0'
     compile 'xpp3:xpp3:1.1.4c'
-    compile 'org.json:json:20131018'
     compile 'redis.clients:jedis:2.8.0'
     compile 'org.apache.commons:commons-pool2:2.4.2'
     compile 'commons-codec:commons-codec:1.5'
-    compile("javax.servlet:jstl:1.2")
-    compile('org.lightcouch:lightcouch:0.1.6')
-    compile("io.springfox:springfox-swagger2:2.4.0")
-    compile("io.springfox:springfox-swagger-ui:2.4.0")
+    compile 'org.lightcouch:lightcouch:0.1.6'
+    compile 'io.springfox:springfox-swagger2:2.4.0'
+    compile 'io.springfox:springfox-swagger-ui:2.4.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'org.apache.commons', name: 'commons-email', version: '1.2'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
-    compile group: 'org.springframework', name: 'spring-jdbc', version: '3.1.0.RELEASE'
-    compile group: 'org.postgresql', name: 'postgresql', version: '9.3-1100-jdbc4'
-    compile group: 'org.flywaydb', name: 'flyway-core', version: '4.0.3'
-    compile group: 'org.springframework', name: 'spring-orm', version: '3.1.1.RELEASE'
-    compile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.1.0.Final'
-    compile group: 'org.hibernate', name: 'hibernate-core', version: '5.1.0.Final'
-    compile group: 'org.springframework.data', name: 'spring-data-commons', version: '1.12.2.RELEASE'
     compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
     compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
-    compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '4.3.9.RELEASE'
-    compile 'org.xerial:sqlite-jdbc:3.16.1'
     compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
     compile group: 'regexp', name: 'regexp', version: '1.3'
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
     compile project(path: ':commcare', configuration: 'translate')
     testCompile project(path: ':commcare', configuration: 'api')
-    testCompile("org.springframework.boot:spring-boot-starter-test:1.4.3.RELEASE")
-    testCompile('org.springframework:spring-test:4.2.4.RELEASE')
-    testCompile("org.springframework:spring-mock:2.0.8")
-    testCompile("com.jayway.jsonpath:json-path:0.8.1")
-    testCompile("com.jayway.jsonpath:json-path-assert:0.8.1")
     testCompile 'com.carrotsearch:hppc:0.7.2'
-    testRuntime("org.skyscreamer:jsonassert:1.4.0")
+    testRuntime 'org.skyscreamer:jsonassert:1.4.0'
 }
 
 test {

--- a/src/main/java/application/Application.java
+++ b/src/main/java/application/Application.java
@@ -6,7 +6,7 @@ import org.flywaydb.core.Flyway;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.orm.jpa.EntityScan;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -38,6 +38,7 @@ import utils.TestContext;
 import javax.servlet.http.Cookie;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Hashtable;
 import java.util.Map;
 
@@ -473,6 +474,18 @@ public class BaseTestClass {
                 CommandListResponseBean.class);
     }
 
+    ResultActions doValidate(String formXML) throws Exception {
+        MediaType contentType = new MediaType(MediaType.APPLICATION_XML.getType(),
+                MediaType.APPLICATION_XML.getSubtype(),
+                Charset.forName("utf8"));
+        return generateMockQuery(ControllerType.UTIL,
+                RequestType.POST,
+                Constants.URL_VALIDATE_FORM,
+                formXML,
+                ResultActions.class,
+                contentType);
+    }
+
     public enum RequestType {
         POST, GET
     }
@@ -486,6 +499,22 @@ public class BaseTestClass {
                                     String urlPath,
                                     Object bean,
                                     Class<T> clazz) throws Exception {
+        return generateMockQuery(controllerType,
+                requestType,
+                urlPath,
+                bean,
+                clazz,
+                MediaType.APPLICATION_JSON
+
+        );
+    }
+
+    private <T> T generateMockQuery(ControllerType controllerType,
+                                    RequestType requestType,
+                                    String urlPath,
+                                    Object bean,
+                                    Class<T> clazz,
+                                    MediaType contentType) throws Exception {
         MockMvc controller = null;
         ResultActions evaluateXpathResult = null;
 
@@ -518,7 +547,7 @@ public class BaseTestClass {
             case POST:
                 evaluateXpathResult = controller.perform(
                         post(urlPrepend(urlPath))
-                                .contentType(MediaType.APPLICATION_JSON)
+                                .contentType(contentType)
                                 .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
                                 .content((String) bean));
                 break;
@@ -526,11 +555,16 @@ public class BaseTestClass {
             case GET:
                 evaluateXpathResult = controller.perform(
                         get(urlPrepend(urlPath))
-                                .contentType(MediaType.APPLICATION_JSON)
+                                .contentType(contentType)
                                 .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
                                 .content((String) bean));
                 break;
         }
+
+        if (clazz == ResultActions.class) {
+            return (T) evaluateXpathResult;
+        }
+
         return mapper.readValue(
                 evaluateXpathResult.andReturn().getResponse().getContentAsString(),
                 clazz

--- a/src/test/java/tests/FormValidatorTests.java
+++ b/src/test/java/tests/FormValidatorTests.java
@@ -1,74 +1,31 @@
 package tests;
 
-import application.Application;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.mock.http.MockHttpOutputMessage;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.web.context.WebApplicationContext;
 import util.Constants;
 import utils.FileUtils;
+import utils.TestContext;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
-
 import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = Application.class)
-@WebAppConfiguration
-public class FormValidatorTests {
-
-    private MediaType contentType = new MediaType(MediaType.APPLICATION_XML.getType(),
-            MediaType.APPLICATION_XML.getSubtype(),
-            Charset.forName("utf8"));
-
-    private MockMvc mockMvc;
-
-    private HttpMessageConverter string2HttpMessageConverter;
-
-    @Autowired
-    private WebApplicationContext webApplicationContext;
-
-    @Autowired
-    void setConverters(HttpMessageConverter<?>[] converters) {
-        Optional<HttpMessageConverter<?>> converterOptional = Iterables.tryFind(Arrays.asList(converters), new Predicate<HttpMessageConverter<?>>() {
-            @Override
-            public boolean apply(HttpMessageConverter<?> hmc) {
-                return hmc instanceof StringHttpMessageConverter;
-            }
-        });
-
-        assertTrue("the XML message converter must not be null", converterOptional.isPresent());
-        this.string2HttpMessageConverter = converterOptional.get();
-    }
-
-
-    @Before
-    public void setup() throws Exception {
-        this.mockMvc = webAppContextSetup(webApplicationContext).build();
-    }
+@ContextConfiguration(classes = TestContext.class)
+public class FormValidatorTests extends BaseTestClass {
 
     @Test
     public void testValidateForm() throws Exception {
@@ -110,22 +67,10 @@ public class FormValidatorTests {
     }
 
     public void testValidateForm(String formXML, List<ResultMatcher> matchers) throws Exception {
-        ResultActions actions = mockMvc.perform(post(String.format("/%s", Constants.URL_VALIDATE_FORM))
-                .content(this.xml(formXML))
-                .contentType(contentType))
-                .andExpect(status().isOk())
-                .andDo(log());
+        ResultActions actions = doValidate(formXML);
 
         for (ResultMatcher matcher : matchers   ) {
             actions = actions.andExpect(matcher);
         }
     }
-
-    protected String xml(Object o) throws IOException {
-        MockHttpOutputMessage mockHttpOutputMessage = new MockHttpOutputMessage();
-        this.string2HttpMessageConverter.write(
-                o, MediaType.APPLICATION_XML, mockHttpOutputMessage);
-        return mockHttpOutputMessage.getBodyAsString();
-    }
-
 }

--- a/src/test/java/tests/FormValidatorTests.java
+++ b/src/test/java/tests/FormValidatorTests.java
@@ -8,11 +8,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.mock.http.MockHttpOutputMessage;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = Application.class)
+@ContextConfiguration(classes = Application.class)
 @WebAppConfiguration
 public class FormValidatorTests {
 


### PR DESCRIPTION
This brings us to the latest `spring-boot` version and updates deprecated classes accordingly. Also switched from setting dependency versions manually to using the Spring Boot Gradle plugin's [dependency manager](https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html) which is the more canonical way to do this.