### PR TITLE
Require raven param

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -94,6 +94,9 @@ public abstract class AbstractBaseController {
     protected StatsDClient datadogStatsDClient;
 
     @Autowired
+    protected Raven raven;
+
+    @Autowired
     PostgresUserRepo postgresUserRepo;
 
     @Value("${commcarehq.host}")
@@ -283,7 +286,7 @@ public abstract class AbstractBaseController {
                 .withMessage("Application Configuration Error")
                 .withLevel(Event.Level.INFO)
                 .withSentryInterface(new ExceptionInterface(exception));
-        SentryUtils.sendRavenEvent(eventBuilder);
+        SentryUtils.sendRavenEvent(raven, eventBuilder);
         return getPrettyExceptionResponse(exception, request);
     }
 
@@ -337,7 +340,7 @@ public abstract class AbstractBaseController {
         log.error("Request: " + req.getRequestURL() + " raised " + exception);
         incrementDatadogCounter(Constants.DATADOG_ERRORS_CRASH, req);
         exception.printStackTrace();
-        SentryUtils.sendRavenException(exception);
+        SentryUtils.sendRavenException(raven, exception);
         try {
             sendExceptionEmail(req, exception);
         } catch (Exception e) {

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -39,6 +39,7 @@ import repo.impl.*;
 import services.*;
 import services.impl.*;
 import util.Constants;
+import util.SentryUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -311,7 +312,9 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
         data.put("environment", environment);
         BreadcrumbBuilder builder = new BreadcrumbBuilder();
         builder.setData(data);
-        return RavenFactory.ravenInstance(ravenDsn);
+        Raven raven = RavenFactory.ravenInstance(ravenDsn);
+        SentryUtils.recordBreadcrumb(raven, builder.build());
+        return raven;
     }
 
     @Bean

--- a/src/main/java/aspects/AppInstallAspect.java
+++ b/src/main/java/aspects/AppInstallAspect.java
@@ -1,6 +1,7 @@
 package aspects;
 
 import beans.InstallRequestBean;
+import com.getsentry.raven.Raven;
 import com.getsentry.raven.event.BreadcrumbBuilder;
 import com.getsentry.raven.event.Breadcrumbs;
 import org.apache.commons.logging.Log;
@@ -26,6 +27,9 @@ public class AppInstallAspect {
     @Autowired
     protected FormplayerStorageFactory storageFactory;
 
+    @Autowired
+    private Raven raven;
+
     @Before(value = "@annotation(annotations.AppInstall)")
     public void configureStorageFactory(JoinPoint joinPoint) throws Throwable {
         Object[] args = joinPoint.getArgs();
@@ -43,6 +47,6 @@ public class AppInstallAspect {
         BreadcrumbBuilder builder = new BreadcrumbBuilder();
         builder.setData(data);
         builder.setCategory("application_install");
-        SentryUtils.recordBreadcrumb(builder.build());
+        SentryUtils.recordBreadcrumb(raven, builder.build());
     }
 }

--- a/src/main/java/aspects/LoggingAspect.java
+++ b/src/main/java/aspects/LoggingAspect.java
@@ -28,8 +28,7 @@ public class LoggingAspect {
     private final Log log = LogFactory.getLog(LoggingAspect.class);
 
     @Autowired
-    protected Raven raven;
-
+    private Raven raven;
 
     @Around(value = "@annotation(org.springframework.web.bind.annotation.RequestMapping) " +
             "&& !@annotation(annotations.NoLogging)")
@@ -46,6 +45,7 @@ public class LoggingAspect {
             log.info("Request to " + requestPath + " with no request body.");
         }
 
+        Object result = joinPoint.proceed();
         if (requestBean != null && requestBean instanceof AuthenticatedRequestBean) {
             AuthenticatedRequestBean authenticatedRequestBean = (AuthenticatedRequestBean) requestBean;
             Map<String, String> data = new HashMap<String, String>();
@@ -56,9 +56,8 @@ public class LoggingAspect {
 
             BreadcrumbBuilder builder = new BreadcrumbBuilder();
             builder.setData(data);
-            SentryUtils.recordBreadcrumb(builder.build());
+            SentryUtils.recordBreadcrumb(raven, builder.build());
         }
-        Object result = joinPoint.proceed();
         log.info("Request to " + requestPath + " returned result " + result);
         return result;
     }

--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -1,5 +1,6 @@
 package engine;
 
+import com.getsentry.raven.Raven;
 import com.getsentry.raven.event.BreadcrumbBuilder;
 import com.getsentry.raven.event.Breadcrumbs;
 import exceptions.ApplicationConfigException;
@@ -29,6 +30,7 @@ import org.javarosa.core.services.properties.Property;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
 import org.javarosa.core.services.storage.StorageManager;
 import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
 import util.SentryUtils;
 
 import java.io.*;
@@ -43,6 +45,9 @@ import java.util.Map;
 public class FormplayerConfigEngine extends CommCareConfigEngine {
 
     private final Log log = LogFactory.getLog(FormplayerConfigEngine.class);
+
+    @Autowired
+    private Raven raven;
 
     public FormplayerConfigEngine(IStorageIndexedFactory storageFactory,
                                   FormplayerInstallerFactory formplayerInstallerFactory,
@@ -61,7 +66,7 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         builder.setData(data);
         builder.setCategory("application-install");
         builder.setMessage("Downloading application from URL " + downloadUrl);
-        SentryUtils.recordBreadcrumb(builder.build());
+        SentryUtils.recordBreadcrumb(raven, builder.build());
     }
 
     @Override

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -3,6 +3,7 @@ package services;
 import application.SQLiteProperties;
 import auth.HqAuth;
 import beans.AuthenticatedRequestBean;
+import com.getsentry.raven.Raven;
 import com.getsentry.raven.event.BreadcrumbBuilder;
 import exceptions.AsyncRetryException;
 import org.apache.commons.io.IOUtils;
@@ -68,6 +69,9 @@ public class RestoreFactory implements ConnectionHandler{
 
     public static final Long ONE_DAY_IN_MILLISECONDS = 86400000l;
     public static final Long ONE_WEEK_IN_MILLISECONDS = ONE_DAY_IN_MILLISECONDS * 7;
+
+    @Autowired
+    private Raven raven;
 
     @Autowired
     private RedisTemplate redisTemplateLong;
@@ -223,7 +227,7 @@ public class RestoreFactory implements ConnectionHandler{
         builder.setData(data);
         builder.setCategory("restore");
         builder.setMessage("Restoring from URL " + restoreUrl);
-        SentryUtils.recordBreadcrumb(builder.build());
+        SentryUtils.recordBreadcrumb(raven, builder.build());
     }
 
     private void setLastSyncTime() {

--- a/src/main/java/util/SentryUtils.java
+++ b/src/main/java/util/SentryUtils.java
@@ -6,6 +6,7 @@ import com.getsentry.raven.event.Breadcrumbs;
 import com.getsentry.raven.event.EventBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Created by benrudolph on 4/27/17.
@@ -14,7 +15,10 @@ public class SentryUtils {
 
     private static final Log log = LogFactory.getLog(SentryUtils.class);
 
-    public static void recordBreadcrumb(Breadcrumb breadcrumb) {
+    public static void recordBreadcrumb(Raven raven, Breadcrumb breadcrumb) {
+        if (raven == null) {
+            return;
+        }
         try {
             Breadcrumbs.record(breadcrumb);
         } catch (Exception e) {
@@ -22,7 +26,10 @@ public class SentryUtils {
         }
     }
 
-    public static void sendRavenException(Exception exception) {
+    public static void sendRavenException(Raven raven, Exception exception) {
+        if (raven == null) {
+            return;
+        }
         try {
             Raven.getStoredInstance().sendException(exception);
         } catch (Exception e) {
@@ -30,7 +37,10 @@ public class SentryUtils {
         }
     }
 
-    public static void sendRavenEvent(EventBuilder event) {
+    public static void sendRavenEvent(Raven raven, EventBuilder event) {
+        if (raven == null) {
+            return;
+        }
         try {
             Raven.getStoredInstance().sendEvent(event);
         } catch (Exception e) {

--- a/src/main/java/util/SentryUtils.java
+++ b/src/main/java/util/SentryUtils.java
@@ -12,6 +12,13 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Created by benrudolph on 4/27/17.
  */
 public class SentryUtils {
+    /**
+     * We require a Raven instance in these Utils to ensure that the caller has instantiated
+     * the Raven instance. Raven keeps track of the raven instance internally with
+     * Raven.getStoredInstance(). If this call returns null, the Sentry call will fail.
+     * In order to ensure the bean gets created, we need to ensure that the instance is
+     * Autowired, which is why it is a required parameter.
+     */
 
     private static final Log log = LogFactory.getLog(SentryUtils.class);
 

--- a/src/main/java/util/SentryUtils.java
+++ b/src/main/java/util/SentryUtils.java
@@ -16,8 +16,6 @@ public class SentryUtils {
      * We require a Raven instance in these Utils to ensure that the caller has instantiated
      * the Raven instance. Raven keeps track of the raven instance internally with
      * Raven.getStoredInstance(). If this call returns null, the Sentry call will fail.
-     * In order to ensure the bean gets created, we need to ensure that the instance is
-     * Autowired, which is why it is a required parameter.
      */
 
     private static final Log log = LogFactory.getLog(SentryUtils.class);

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -7,6 +7,7 @@ import beans.*;
 import beans.debugger.XPathQueryItem;
 import beans.menus.CommandListResponseBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.getsentry.raven.Raven;
 import installers.FormplayerInstallerFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -88,6 +89,9 @@ public class BaseTestClass {
     private NewFormResponseFactory newFormResponseFactoryMock;
 
     @Autowired
+    protected Raven ravenMock;
+
+    @Autowired
     protected LockRegistry userLockRegistry;
 
     @Autowired
@@ -133,6 +137,7 @@ public class BaseTestClass {
         Mockito.reset(formplayerInstallerFactory);
         Mockito.reset(queryRequester);
         Mockito.reset(syncRequester);
+        Mockito.reset(ravenMock);
         MockitoAnnotations.initMocks(this);
         mockFormController = MockMvcBuilders.standaloneSetup(formController).build();
         mockUtilController = MockMvcBuilders.standaloneSetup(utilController).build();

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -1,5 +1,6 @@
 package utils;
 
+import com.getsentry.raven.Raven;
 import installers.FormplayerInstallerFactory;
 import mocks.MockFormSessionRepo;
 import mocks.MockLockRegistry;
@@ -90,6 +91,11 @@ public class TestContext {
     @Bean
     public SubmitService submitService() {
         return Mockito.mock(SubmitServiceImpl.class);
+    }
+
+    @Bean
+    public Raven raven() {
+        return Mockito.mock(Raven.class);
     }
 
     @Bean


### PR DESCRIPTION
@wpride this should fix up sentry for the most part. there is still one race condition when the logging of one of the breadcrumbs fails on the initial request. Wasn't able to quickly get to the bottom of it, but it works on subsequent requests oddly. For now going to leave as is because I don't think it's terribly high priority