### PR TITLE
Don't use sync token anymore

### DIFF
--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -357,10 +357,12 @@ public class RestoreFactory implements ConnectionHandler{
         if (overwriteCache) {
             builder.append("&overwrite_cache=true");
         }
+        /*
         String syncToken = getSyncToken(getWrappedUsername());
         if (syncToken != null) {
             builder.append("&since=").append(syncToken);
         }
+        */
         if( asUsername != null) {
             builder.append("&as=" + asUsername + "@" + domain + ".commcarehq.org");
         }


### PR DESCRIPTION
Temporarily remove `since` param from restore requests 

@benrudolph 