### PR TITLE
Sentry tweaks

### DIFF
--- a/src/main/java/util/SentryUtils.java
+++ b/src/main/java/util/SentryUtils.java
@@ -25,7 +25,7 @@ public class SentryUtils {
             return;
         }
         try {
-            Breadcrumbs.record(breadcrumb);
+            raven.getContext().recordBreadcrumb(breadcrumb);
         } catch (Exception e) {
             log.info("Error recording breadcrumb. Ensure that raven is configured. " + e.toString());
         }

--- a/src/main/java/util/SentryUtils.java
+++ b/src/main/java/util/SentryUtils.java
@@ -27,7 +27,7 @@ public class SentryUtils {
         try {
             raven.getContext().recordBreadcrumb(breadcrumb);
         } catch (Exception e) {
-            log.info("Error recording breadcrumb. Ensure that raven is configured. " + e.toString());
+            log.info("Error recording breadcrumb. Ensure that raven is configured. ", e);
         }
     }
 

--- a/src/main/java/util/SentryUtils.java
+++ b/src/main/java/util/SentryUtils.java
@@ -36,9 +36,9 @@ public class SentryUtils {
             return;
         }
         try {
-            Raven.getStoredInstance().sendException(exception);
+            raven.sendException(exception);
         } catch (Exception e) {
-            log.info("Error sending to Sentry. Ensure that raven is configured. " + e.toString());
+            log.info("Error sending exception to Sentry. Ensure that raven is configured. ", e);
         }
     }
 
@@ -47,9 +47,9 @@ public class SentryUtils {
             return;
         }
         try {
-            Raven.getStoredInstance().sendEvent(event);
+            raven.sendEvent(event);
         } catch (Exception e) {
-            log.info("Error sending to Sentry. Ensure that raven is configured. " + e.toString());
+            log.info("Error sending event to Sentry. Ensure that raven is configured. ", e);
         }
     }
 }

--- a/src/test/java/tests/ApplicationUtilsTests.java
+++ b/src/test/java/tests/ApplicationUtilsTests.java
@@ -16,7 +16,7 @@ import java.io.File;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestContext.class)
-public class ApplicationUtilsTests extends BaseTestClass {
+public class ApplicationUtilsTests {
 
     @Test
     public void testDeleteApplicationDbs() throws Exception {


### PR DESCRIPTION
Confused as to why this works locally and not on prod. My guess is that the way raven does it's static reference to the raven instance doesn't work as I expect it to. This changes the calls to utilize the raven object passed in, not the one stored statically. Also adds stack trace to log call so i can see where the null pointer is coming from if this doesn't fix it