### PR TITLE
Incremental Sync Episode II

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - curl -X PUT localhost:5984/_config/admins/commcarehq -d '"commcarehq"'
 script:
   - ./gradlew copyTestResources
-  - ./gradlew test --stacktrace --i
+  - ./gradlew test
 services:
   - postgresql
   - redis-server

--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -387,7 +387,7 @@ public class MenuController extends AbstractBaseController {
             return new NotificationMessage("Session error, expected sync block but didn't get one.", true);
         }
         if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            CaseAPIs.forceRestore(restoreFactory);
+            CaseAPIs.performSync(restoreFactory, false);
             return new NotificationMessage("Case claim successful.", false);
         } else {
             return new NotificationMessage(

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -40,8 +40,7 @@ public class UtilController extends AbstractBaseController {
         if (syncRequest.isPreserveCache()) {
             CaseAPIs.getSandbox(restoreFactory, false);
         } else {
-            SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
-            CaseAPIs.performSync(restoreFactory, true);
+            CaseAPIs.forceRestore(restoreFactory);
         }
         return new SyncDbResponseBean();
     }

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -13,6 +13,7 @@ import org.javarosa.xform.schema.JSONReporter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import sandbox.SqlSandboxUtils;
 import util.Constants;
 
 import java.io.StringReader;
@@ -39,6 +40,7 @@ public class UtilController extends AbstractBaseController {
         if (syncRequest.isPreserveCache()) {
             CaseAPIs.getSandbox(restoreFactory, false);
         } else {
+            SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
             CaseAPIs.performSync(restoreFactory, true);
         }
         return new SyncDbResponseBean();

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -39,7 +39,7 @@ public class UtilController extends AbstractBaseController {
         if (syncRequest.isPreserveCache()) {
             CaseAPIs.getSandbox(restoreFactory, false);
         } else {
-            CaseAPIs.forceRestore(restoreFactory);
+            CaseAPIs.performSync(restoreFactory, true);
         }
         return new SyncDbResponseBean();
     }

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -77,8 +77,8 @@ public class CaseAPIs {
         // initialize our sandbox's logged in user
         for (IStorageIterator<User> iterator = sandbox.getUserStorage().iterate(); iterator.hasMore(); ) {
             User u = iterator.nextRecord();
-            String wrappedUsername = UserUtils.unwrapUsername(restoreFactory.getWrappedUsername());
-            if (wrappedUsername.equalsIgnoreCase(u.getUsername())) {
+            String unwrappedUsername = UserUtils.unwrapUsername(restoreFactory.getWrappedUsername());
+            if (unwrappedUsername.equalsIgnoreCase(u.getUsername())) {
                 // set last sync token
                 u.setLastSyncToken(sandbox.getSyncToken());
                 sandbox.getUserStorage().write(u);

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -15,6 +15,7 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.xmlpull.v1.XmlPullParserException;
 import services.RestoreFactory;
+import util.UserUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +36,7 @@ public class CaseAPIs {
     // This function will only wipe user DBs when they have expired, otherwise will incremental sync
     public static UserSqlSandbox performSync(RestoreFactory restoreFactory, boolean overwriteCache) throws Exception {
         if (restoreFactory.isRestoreXmlExpired()) {
-            SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());;
+            SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
         }
         // Create parent dirs if needed
         if(restoreFactory.getSqlSandbox().getLoggedInUser() != null){
@@ -48,7 +49,7 @@ public class CaseAPIs {
     // This function will attempt to get the user DBs without syncing if they exist, sync if not
     public static UserSqlSandbox getSandbox(RestoreFactory restoreFactory, boolean overwriteCache) throws Exception {
         if (restoreFactory.isRestoreXmlExpired()) {
-            SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());;
+            SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
         }
         if(restoreFactory.getSqlSandbox().getLoggedInUser() != null){
             return restoreFactory.getSqlSandbox();
@@ -76,7 +77,8 @@ public class CaseAPIs {
         // initialize our sandbox's logged in user
         for (IStorageIterator<User> iterator = sandbox.getUserStorage().iterate(); iterator.hasMore(); ) {
             User u = iterator.nextRecord();
-            if (restoreFactory.getWrappedUsername().equalsIgnoreCase(u.getUsername())) {
+            String wrappedUsername = UserUtils.unwrapUsername(restoreFactory.getWrappedUsername());
+            if (wrappedUsername.equalsIgnoreCase(u.getUsername())) {
                 // set last sync token
                 u.setLastSyncToken(sandbox.getSyncToken());
                 sandbox.getUserStorage().write(u);

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -361,7 +361,7 @@ public class RestoreFactory implements ConnectionHandler{
             builder.append("&overwrite_cache=true");
         }
         String syncToken = getSyncToken(getWrappedUsername());
-        if (syncToken != null) {
+        if (syncToken != null && !"".equals(syncToken)) {
             builder.append("&since=").append(syncToken);
         }
         if( asUsername != null) {

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -3,7 +3,6 @@ package services;
 import application.SQLiteProperties;
 import auth.HqAuth;
 import beans.AuthenticatedRequestBean;
-import com.getsentry.raven.Raven;
 import com.getsentry.raven.event.BreadcrumbBuilder;
 import exceptions.AsyncRetryException;
 import org.apache.commons.io.IOUtils;
@@ -32,6 +31,7 @@ import sandbox.SqlSandboxUtils;
 import sandbox.SqliteIndexedStorageUtility;
 import sandbox.UserSqlSandbox;
 import util.FormplayerRaven;
+import util.UserUtils;
 
 import javax.annotation.Resource;
 import javax.sql.DataSource;
@@ -338,6 +338,9 @@ public class RestoreFactory implements ConnectionHandler{
         if (username == null) {
             return null;
         }
+
+        username = UserUtils.unwrapUsername(username);
+
         SqliteIndexedStorageUtility<User> storage = getSqlSandbox().getUserStorage();
         Vector<Integer> users = storage.getIDsForValue(User.META_USERNAME, username);
         //should be exactly one user

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -357,12 +357,10 @@ public class RestoreFactory implements ConnectionHandler{
         if (overwriteCache) {
             builder.append("&overwrite_cache=true");
         }
-        /*
         String syncToken = getSyncToken(getWrappedUsername());
         if (syncToken != null) {
             builder.append("&since=").append(syncToken);
         }
-        */
         if( asUsername != null) {
             builder.append("&as=" + asUsername + "@" + domain + ".commcarehq.org");
         }

--- a/src/main/java/util/UserUtils.java
+++ b/src/main/java/util/UserUtils.java
@@ -14,4 +14,11 @@ public class UserUtils {
     public static String anonymousUsername(String domain) {
         return Constants.ANONYMOUS_USERNAME + "@" + domain + "." + Constants.COMMCARE_USER_SUFFIX;
     }
+
+    // If given a domained username, return the un-domained username, otherwise return @param username
+    public static String unwrapUsername(String wrappedUsername) {
+        return wrappedUsername.contains("@")
+                ? wrappedUsername.substring(0, wrappedUsername.indexOf("@"))
+                : wrappedUsername;
+    }
 }


### PR DESCRIPTION
Re-implements Incremental Restore with a couple fixes.

I think the main one causing the issue we saw was with disagreement between username formatting when getting the syncToken. Specifically, User objects don't have a domained username while the SqlSandbox would. This would cause a mismatch resulting in the `syncToken` being empty and since we weren't overriding the cache this would result in the (stale) cached XML being returned instead of the differential. I was able to reproduce and fix this behavior locally. 

I've also added checks for empty (non-null) syncToken and returned the "Sync" button to forcing a full restore.