### PR TITLE
Version sqlite dbs

### DIFF
--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -56,7 +56,7 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory, Connect
     public Connection getConnection() {
         try {
             if (connection == null || connection.isClosed()) {
-                DataSource dataSource = SqlSandboxUtils.getDataSource("application", databasePath);
+                DataSource dataSource = SqlSandboxUtils.getDataSource(ApplicationUtils.getApplicationDBName(), databasePath);
                 connection = dataSource.getConnection();
             } else {
                 if (connection instanceof SQLiteConnection) {
@@ -65,7 +65,7 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory, Connect
                         log.error(String.format("Had connection with path %s in StorageFactory %s",
                                 sqLiteConnection.url(),
                                 toString()));
-                        DataSource dataSource = SqlSandboxUtils.getDataSource("application", databasePath);
+                        DataSource dataSource = SqlSandboxUtils.getDataSource(ApplicationUtils.getApplicationDBName(), databasePath);
                         connection = dataSource.getConnection();
                     }
                 }

--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -1,5 +1,6 @@
 package services;
 
+import application.Application;
 import beans.InstallRequestBean;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -47,15 +48,8 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory, Connect
         this.asUsername = asUsername;
         this.domain = domain;
         this.appId = appId;
-        this.databasePath = ApplicationUtils.getApplicationDBPath(domain, getUsernameDetail(), appId);
+        this.databasePath = ApplicationUtils.getApplicationDBPath(domain, username, asUsername, appId);
         closeConnection();
-    }
-
-    public String getUsernameDetail() {
-        if (asUsername != null) {
-            return username + "_" + asUsername;
-        }
-        return username;
     }
 
     @Override
@@ -123,7 +117,7 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory, Connect
     }
 
     public String getDatabaseFile() {
-        return databasePath + "/application.db";
+        return ApplicationUtils.getApplicationDBFile(domain, username, asUsername, appId);
     }
 
     public String getAsUsername() {

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -1,5 +1,6 @@
 package services;
 
+import application.Application;
 import application.SQLiteProperties;
 import auth.HqAuth;
 import beans.AuthenticatedRequestBean;
@@ -30,6 +31,7 @@ import org.xml.sax.SAXException;
 import sandbox.SqlSandboxUtils;
 import sandbox.SqliteIndexedStorageUtility;
 import sandbox.UserSqlSandbox;
+import util.ApplicationUtils;
 import util.FormplayerRaven;
 import util.UserUtils;
 
@@ -156,11 +158,11 @@ public class RestoreFactory implements ConnectionHandler{
         }
     }
     public String getDbFile() {
-        return getDbPath() + "/user.db";
+        return ApplicationUtils.getUserDBFile(domain, username, asUsername);
     }
 
     private String getDbPath() {
-        return SQLiteProperties.getDataDir() + domain + "/" + getUsernameDetail();
+        return ApplicationUtils.getUserDBPath(domain, username, asUsername);
     }
 
     public String getWrappedUsername() {

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -111,7 +111,7 @@ public class RestoreFactory implements ConnectionHandler{
     public Connection getConnection() {
         try {
             if (connection == null || connection.isClosed()) {
-                DataSource dataSource = SqlSandboxUtils.getDataSource("user", getDbPath());
+                DataSource dataSource = SqlSandboxUtils.getDataSource(ApplicationUtils.getUserDBName(), getDbPath());
                 connection = dataSource.getConnection();
             } else {
                 if (connection instanceof SQLiteConnection) {
@@ -120,7 +120,7 @@ public class RestoreFactory implements ConnectionHandler{
                         log.error(String.format("Had connection with path %s in StorageFactory %s",
                                 sqLiteConnection.url(),
                                 toString()));
-                        DataSource dataSource = SqlSandboxUtils.getDataSource("user", getDbPath());
+                        DataSource dataSource = SqlSandboxUtils.getDataSource(ApplicationUtils.getUserDBName(), getDbPath());
                         connection = dataSource.getConnection();
                     }
                 }

--- a/src/main/java/util/ApplicationUtils.java
+++ b/src/main/java/util/ApplicationUtils.java
@@ -1,6 +1,7 @@
 package util;
 
 import application.SQLiteProperties;
+import org.apache.tomcat.util.bcel.Const;
 import sandbox.SqlSandboxUtils;
 import org.commcare.modern.database.TableBuilder;
 
@@ -26,7 +27,7 @@ public class ApplicationUtils {
     }
 
     public static String getApplicationDBFile(String domain, String username, String asUsername, String appId) {
-        return getApplicationDBPath(domain, username, asUsername, appId) + "/application.db";
+        return getApplicationDBPath(domain, username, asUsername, appId) + "/" + getApplicationDBName() + ".db";
     }
 
     public static String getUserDBPath(String domain, String username, String asUsername) {
@@ -34,7 +35,15 @@ public class ApplicationUtils {
     }
 
     public static String getUserDBFile(String domain, String username, String asUsername) {
-        return getUserDBPath(domain, username, asUsername) + "/user.db";
+        return getUserDBPath(domain, username, asUsername) + "/" + getUserDBName() + ".db";
+    }
+
+    public static String getUserDBName() {
+        return "user_" + Constants.SQLITE_DB_VERSION;
+    }
+
+    public static String getApplicationDBName() {
+        return "application_" + Constants.SQLITE_DB_VERSION;
     }
 
     private static String getUsernameDetail(String username, String asUsername) {

--- a/src/main/java/util/ApplicationUtils.java
+++ b/src/main/java/util/ApplicationUtils.java
@@ -13,7 +13,7 @@ public class ApplicationUtils {
         Boolean success = true;
 
         try {
-            SqlSandboxUtils.deleteDatabaseFolder(getApplicationDBPath(domain, getUsernameDetail(username, asUsername), appId));
+            SqlSandboxUtils.deleteDatabaseFolder(getApplicationDBPath(domain, username, asUsername, appId));
         } catch (Exception e) {
             e.printStackTrace();
             success = false;
@@ -21,11 +21,23 @@ public class ApplicationUtils {
         return success;
     }
 
-    public static String getApplicationDBPath(String domain, String username, String appId) {
-        return SQLiteProperties.getDataDir() + domain + "/" + TableBuilder.scrubName(username) + "/" + appId;
+    public static String getApplicationDBPath(String domain, String username, String asUsername, String appId) {
+        return SQLiteProperties.getDataDir() + domain + "/" + TableBuilder.scrubName(getUsernameDetail(username, asUsername)) + "/" + appId;
     }
 
-    public static String getUsernameDetail(String username, String asUsername) {
+    public static String getApplicationDBFile(String domain, String username, String asUsername, String appId) {
+        return getApplicationDBPath(domain, username, asUsername, appId) + "/application.db";
+    }
+
+    public static String getUserDBPath(String domain, String username, String asUsername) {
+        return SQLiteProperties.getDataDir() + domain + "/" + TableBuilder.scrubName(getUsernameDetail(username, asUsername));
+    }
+
+    public static String getUserDBFile(String domain, String username, String asUsername) {
+        return getUserDBPath(domain, username, asUsername) + "/user.db";
+    }
+
+    private static String getUsernameDetail(String username, String asUsername) {
         if (asUsername != null) {
             return username + "_" + asUsername;
         }

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -36,6 +36,10 @@ public class Constants {
     // Debugger URLS
     public static final String URL_DEBUGGER_FORMATTED_QUESTIONS = "formatted_questions";
 
+    // Change this version when a backwards incompatible change is made to the
+    // mobile sqlite dbs.
+    public static final String SQLITE_DB_VERSION = "V1";
+
     //Menus
     public static final String MENU_MODULE = "modules";
     public static final String MENU_ENTITY = "entity";

--- a/src/test/java/tests/ApplicationUtilsTests.java
+++ b/src/test/java/tests/ApplicationUtilsTests.java
@@ -20,7 +20,7 @@ public class ApplicationUtilsTests {
 
     @Test
     public void testDeleteApplicationDbs() throws Exception {
-        String dbPath = ApplicationUtils.getApplicationDBPath("dummy-domain", "dummy-username", "dummy-app-id");
+        String dbPath = ApplicationUtils.getApplicationDBPath("dummy-domain", "dummy-username", null, "dummy-app-id");
         File file = new File(dbPath);
         file.mkdirs();
 

--- a/src/test/java/tests/DeleteApplicationDbsTests.java
+++ b/src/test/java/tests/DeleteApplicationDbsTests.java
@@ -34,7 +34,7 @@ public class DeleteApplicationDbsTests extends BaseTestClass{
     @Test
     public void testDeleteApplicationDbsView() throws Exception {
         // Create application db by making an install request
-        String dbPath = ApplicationUtils.getApplicationDBPath("casetestdomain", "casetestuser", "casetestappid");
+        String dbPath = ApplicationUtils.getApplicationDBPath("casetestdomain", "casetestuser", null, "casetestappid");
         CommandListResponseBean menuResponseBean = doInstall("requests/install/install.json");
 
         File file = new File(dbPath);
@@ -54,7 +54,7 @@ public class DeleteApplicationDbsTests extends BaseTestClass{
      */
     @Test
     public void testDeleteApplicationDbsWithNoDbView() throws Exception {
-        String dbPath = ApplicationUtils.getApplicationDBPath("casetestdomain", "casetestuser", "casetestappid");
+        String dbPath = ApplicationUtils.getApplicationDBPath("casetestdomain", "casetestuser", null, "casetestappid");
         File file = new File(dbPath);
         assert !file.exists();
 

--- a/src/test/java/tests/sandbox/TestConnectionHandler.java
+++ b/src/test/java/tests/sandbox/TestConnectionHandler.java
@@ -2,6 +2,7 @@ package tests.sandbox;
 
 import sandbox.SqlSandboxUtils;
 import services.ConnectionHandler;
+import util.ApplicationUtils;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -21,7 +22,7 @@ public class TestConnectionHandler implements ConnectionHandler {
     @Override
     public Connection getConnection() {
         try {
-            return SqlSandboxUtils.getDataSource("user", dbPath).getConnection();
+            return SqlSandboxUtils.getDataSource(ApplicationUtils.getUserDBName(), dbPath).getConnection();
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
@wpride this cleans up the application user db path creation quite a bit. it now all happens in one class. before we were generating the same path in multiple places, making it very hard to actually change the db name. the second commit actually add `V1` to the end of the db file. if we ever want to wipe dbs on deploy, we should just bump change that string

buddy: @mkangia 