### PR TITLE
Always use the sync token, never overwrite cache

### DIFF
--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -398,7 +398,7 @@ public class MenuController extends AbstractBaseController {
             return new NotificationMessage("Session error, expected sync block but didn't get one.", true);
         }
         if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            CaseAPIs.performSync(restoreFactory, false);
+            CaseAPIs.performSync(restoreFactory);
             return new NotificationMessage("Case claim successful.", false);
         } else {
             return new NotificationMessage(

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -37,11 +37,7 @@ public class UtilController extends AbstractBaseController {
     @UserRestore
     public SyncDbResponseBean syncUserDb(@RequestBody SyncDbRequestBean syncRequest,
                                          @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
-        if (syncRequest.isPreserveCache()) {
-            CaseAPIs.getSandbox(restoreFactory, false);
-        } else {
-            CaseAPIs.forceRestore(restoreFactory);
-        }
+        CaseAPIs.performSync(restoreFactory);
         return new SyncDbResponseBean();
     }
 

--- a/src/main/java/aspects/UserRestoreAspect.java
+++ b/src/main/java/aspects/UserRestoreAspect.java
@@ -43,7 +43,7 @@ public class UserRestoreAspect {
         HqAuth auth = getAuthHeaders(requestBean.getDomain(), requestBean.getUsername(), (String) args[1]);
         restoreFactory.configure((AuthenticatedRequestBean)args[0], auth, requestBean.getUseLiveQuery());
         if (requestBean.isMustRestore()) {
-            CaseAPIs.performSync(restoreFactory, false);
+            CaseAPIs.performSync(restoreFactory);
         }
     }
 

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -26,16 +26,8 @@ import java.io.InputStream;
  */
 public class CaseAPIs {
 
-    // This function will always wipe all user DBs and perform a fresh restore
-    public static UserSqlSandbox forceRestore(RestoreFactory restoreFactory) throws Exception {
-        SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
-        restoreFactory.closeConnection();
-        return getSandbox(restoreFactory, true);
-    }
-
     // This function will only wipe user DBs when they have expired, otherwise will incremental sync
-    public static UserSqlSandbox performSync(RestoreFactory restoreFactory,
-                                             boolean overwriteCache) throws Exception {
+    public static UserSqlSandbox performSync(RestoreFactory restoreFactory) throws Exception {
         if (restoreFactory.isRestoreXmlExpired()) {
             SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
         }
@@ -43,13 +35,12 @@ public class CaseAPIs {
         if(restoreFactory.getSqlSandbox().getLoggedInUser() != null){
             new File(restoreFactory.getDbFile()).getParentFile().mkdirs();
         }
-        InputStream xml = restoreFactory.getRestoreXml(overwriteCache);
+        InputStream xml = restoreFactory.getRestoreXml();
         return restoreUser(restoreFactory, xml);
     }
 
     // This function will attempt to get the user DBs without syncing if they exist, sync if not
-    public static UserSqlSandbox getSandbox(RestoreFactory restoreFactory,
-                                            boolean overwriteCache) throws Exception {
+    public static UserSqlSandbox getSandbox(RestoreFactory restoreFactory) throws Exception {
         if (restoreFactory.isRestoreXmlExpired()) {
             SqlSandboxUtils.deleteDatabaseFolder(restoreFactory.getDbFile());
         }
@@ -57,7 +48,7 @@ public class CaseAPIs {
             return restoreFactory.getSqlSandbox();
         } else{
             new File(restoreFactory.getDbFile()).getParentFile().mkdirs();
-            InputStream xml = restoreFactory.getRestoreXml(overwriteCache);
+            InputStream xml = restoreFactory.getRestoreXml();
             return restoreUser(restoreFactory, xml);
         }
     }

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -36,7 +36,7 @@ public class NewFormResponseFactory {
     public NewFormResponse getResponse(NewSessionRequestBean bean, String postUrl, HqAuth auth) throws Exception {
 
         String formXml = getFormXml(bean.getFormUrl(), auth);
-        UserSqlSandbox sandbox = CaseAPIs.performSync(restoreFactory, false);
+        UserSqlSandbox sandbox = CaseAPIs.performSync(restoreFactory);
 
         FormSession formSession = new FormSession(
                 sandbox,

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -215,9 +215,9 @@ public class RestoreFactory implements ConnectionHandler{
         }
     }
 
-    public InputStream getRestoreXml(boolean overwriteCache) {
+    public InputStream getRestoreXml() {
         ensureValidParameters();
-        String restoreUrl = getRestoreUrl(overwriteCache);
+        String restoreUrl = getRestoreUrl();
         recordSentryData(restoreUrl);
         log.info("Restoring from URL " + restoreUrl);
         InputStream restoreStream = getRestoreXmlHelper(restoreUrl, hqAuth);
@@ -364,15 +364,12 @@ public class RestoreFactory implements ConnectionHandler{
         return String.format("%s|%s|as|%s", DEVICE_ID_SLUG, username, asUsername);
     }
 
-    public String getRestoreUrl(boolean overwriteCache) {
+    public String getRestoreUrl() {
         StringBuilder builder = new StringBuilder();
         builder.append(host);
         builder.append("/a/");
         builder.append(domain);
         builder.append("/phone/restore/?version=2.0");
-        if (overwriteCache) {
-            builder.append("&overwrite_cache=true");
-        }
         String syncToken = getSyncToken(getWrappedUsername());
         if (syncToken != null && !"".equals(syncToken)) {
             builder.append("&since=").append(syncToken);

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -97,7 +97,7 @@ public class FormSession {
         this.asUser = session.getAsUser();
         this.appId = session.getAppId();
         this.domain = session.getDomain();
-        this.sandbox = CaseAPIs.getSandbox(restoreFactory, false);
+        this.sandbox = CaseAPIs.getSandbox(restoreFactory);
         this.postUrl = session.getPostUrl();
         this.sessionData = session.getSessionData();
         this.oneQuestionPerScreen = session.getOneQuestionPerScreen();

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -87,7 +87,7 @@ public class MenuSession {
         resolveInstallReference(installReference, appId, host);
         this.engine = installService.configureApplication(this.installReference);
 
-        this.sandbox = CaseAPIs.getSandbox(restoreFactory, false);
+        this.sandbox = CaseAPIs.getSandbox(restoreFactory);
 
         this.sessionWrapper = new FormplayerSessionWrapper(deserializeSession(engine.getPlatform(), session.getCommcareSession()),
                 engine.getPlatform(), sandbox);
@@ -109,7 +109,7 @@ public class MenuSession {
         this.asUser = asUser;
         resolveInstallReference(installReference, appId, host);
         this.engine = installService.configureApplication(this.installReference);
-        this.sandbox = CaseAPIs.getSandbox(restoreFactory, false);
+        this.sandbox = CaseAPIs.getSandbox(restoreFactory);
         this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox);
         this.locale = locale;
         SessionUtils.setLocale(this.locale);

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -144,7 +144,7 @@ public class BaseTestClass {
         mockMenuController = MockMvcBuilders.standaloneSetup(menuController).build();
         mockDebuggerController = MockMvcBuilders.standaloneSetup(debuggerController).build();
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer(this.getMockRestoreFileName());
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
         Mockito.doReturn(new ResponseEntity<>(HttpStatus.OK))
                 .when(submitServiceMock).submitForm(anyString(), anyString(), any(HqAuth.class));
         Mockito.doReturn(false)

--- a/src/test/java/tests/CaseClaimTests.java
+++ b/src/test/java/tests/CaseClaimTests.java
@@ -61,7 +61,7 @@ public class CaseClaimTests extends BaseTestClass {
 
         // When we sync afterwards, include new case and case-claim 
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim2.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         CommandListResponseBean commandResponse = sessionNavigateWithQuery(new String[]{"1", "action 1", "0156fa3e-093e-4136-b95c-01b13dae66c6"},
                 "caseclaim",
@@ -84,7 +84,7 @@ public class CaseClaimTests extends BaseTestClass {
         configureQueryMockOwned();
         configureSyncMock();
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         CommandListResponseBean response = sessionNavigateWithQuery(new String[]{"1", "action 1", "3512eb7c-7a58-4a95-beda-205eb0d7f163"},
                 "caseclaim",


### PR DESCRIPTION
Removes the `override_cache=true` parameter in favor of using the `since` token parameter in all cases. This brings Formplayer in line with how Android handles restores.

Worth noting that this removes all paths for blowing away user DBs manually - now this will only happen when the DBs have expired (as determined by the sync frequent property).