### PR TITLE
Refactor EntityDetailList to separate list from detail

### DIFF
--- a/src/main/java/beans/menus/EntityBean.java
+++ b/src/main/java/beans/menus/EntityBean.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 public class EntityBean {
     private String id;
     private Object[] data;
-    private EntityDetailResponse[] details;
 
     public EntityBean(){}
 
@@ -30,14 +29,6 @@ public class EntityBean {
 
     public void setData(Object[] data) {
         this.data = data;
-    }
-
-    public EntityDetailResponse[] getDetails() {
-        return details;
-    }
-
-    public void setDetails(EntityDetailResponse[] detail) {
-        this.details = detail;
     }
 
     @Override

--- a/src/main/java/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/beans/menus/EntityDetailListResponse.java
@@ -39,7 +39,7 @@ public class EntityDetailListResponse {
     }
 
     private EntityDetailResponse[] processDetails(EntityScreen screen, EvaluationContext ec, TreeReference ref) {
-        return processDetails(screen.getLongDetailList(), ec, ref);
+        return processDetails(screen.getLongDetailList(ref), ec, ref);
     }
 
     private EntityDetailResponse[] processDetails(Detail[] detailList,


### PR DESCRIPTION
Fixes https://manage.dimagi.com/default.asp?258552

That error was occurring because we were attempting to load up the long details (detail tabs) before we had selected a case so variables in the detail that expected to be contextualized by a reference were not. I think we were only doing that preloading for legacy reasons (IE before we split out the navigation and getDetails calls) so I've just refactored that . 