### PR TITLE
improve README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ Make sure you have the formplayer database created
 
     $ createdb formplayer -U commcarehq -h localhost  // Update connection info as necessary
 
-To run:
+To run (with tests):
 
-    $ ./gradlew build; java -jar build/libs/formplayer.jar
+    $ ./gradlew build && java -jar build/libs/formplayer.jar
+
+To run without tests:
+
+    $ ./gradlew build -x test && java -jar build/libs/formplayer.jar
 
 To test:
 


### PR DESCRIPTION
to use `&&` instead of `;` (to abort if the build fails)
and include instructions for skipping test on build