### PR TITLE
Gzip archiving

### DIFF
--- a/scripts/archive_dbs.sh
+++ b/scripts/archive_dbs.sh
@@ -25,6 +25,12 @@ do
     lock="${line}.lock"
     gz="${line}.gz"
 
+    if [ -f ${lock} ]
+    then
+        echo >&2 "skipping due to ${lock}"
+        continue
+    fi
+
     touch ${lock}
     gzip ${db}
     rm ${lock}

--- a/scripts/archive_dbs.sh
+++ b/scripts/archive_dbs.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# example usage
+# ./scripts/archive_dbs.sh dbs +2d
+# to archive all dbs in the dbs/ directory that haven't been accessed for more than 2 days
+
+
+dir=${1}
+atime=${2}
+
+if [ $(echo $atime | cut -c1) != "+" ]
+then
+    echo >&2 "atime must start with +: ${atime}"
+    exit 1
+fi
+
+test -d ${dir} || {
+    echo >&2 "dir must be a directory: ${dir}"
+    exit 1
+}
+
+while read line
+do
+    db="${line}"
+    lock="${line}.lock"
+    gz="${line}.gz"
+
+    touch ${lock}
+    gzip ${db}
+    rm ${lock}
+done < <(find ${dir} -name '*.db' -type f -atime ${atime})

--- a/src/main/java/sandbox/ArchivableFile.java
+++ b/src/main/java/sandbox/ArchivableFile.java
@@ -25,6 +25,16 @@ public class ArchivableFile extends File {
         return super.exists() || getGzipFile().exists();
     }
 
+    @Override
+    public boolean delete() {
+        boolean gzipDeleted = false;
+        waitOnLock();
+        if (getGzipFile().exists()) {
+            gzipDeleted = getGzipFile().delete();
+        }
+        return super.delete() || gzipDeleted;
+    }
+
     private static void decompressGzipFile(File gzipFile, File newFile) throws IOException {
         // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
         FileInputStream fis = new FileInputStream(gzipFile);

--- a/src/main/java/sandbox/ArchivableFile.java
+++ b/src/main/java/sandbox/ArchivableFile.java
@@ -1,0 +1,71 @@
+package sandbox;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+
+public class ArchivableFile extends File {
+
+    public ArchivableFile(String pathname) {
+        super(pathname);
+    }
+
+    @Override
+    public boolean exists() {
+        return super.exists() || new File(getPath() + ".gz").exists();
+    }
+
+    private static void decompressGzipFile(String gzipFile, String newFile) throws IOException {
+        // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
+        FileInputStream fis = new FileInputStream(gzipFile);
+        GZIPInputStream gis = new GZIPInputStream(fis);
+        FileOutputStream fos = new FileOutputStream(newFile);
+        byte[] buffer = new byte[1024];
+        int len;
+        while((len = gis.read(buffer)) != -1){
+            fos.write(buffer, 0, len);
+        }
+        //close resources
+        fis.close();
+        fos.close();
+        gis.close();
+    }
+
+    public void unarchiveIfArchived() throws IOException {
+        String dbPath = getPath();
+        String dbLockPath = getPath() + ".lock";
+        String dbGzipPath = getPath() + ".db.gz";
+        File databaseFile = new File(dbPath);
+        File databaseLockFile = new File(dbLockPath);
+        File databaseGzipFile = new File(dbGzipPath);
+
+        while (databaseLockFile.exists()) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (!databaseFile.exists() && databaseGzipFile.exists()) {
+            try {
+                boolean lockCreated = databaseLockFile.createNewFile();
+                if (!lockCreated) {
+                    throw new IOException("Could not create lock file");
+                }
+                decompressGzipFile(dbGzipPath, dbPath);
+                boolean gzipDeleted = databaseGzipFile.delete();
+                if (!gzipDeleted) {
+                    throw new IOException("Could not delete gzipFile");
+                }
+            } finally {
+                boolean lockDeleted = databaseLockFile.delete();
+                if (!lockDeleted && databaseLockFile.exists()) {
+                    throw new IOException("Could not delete lock file. This can result in a deadlock");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/sandbox/ArchivableFile.java
+++ b/src/main/java/sandbox/ArchivableFile.java
@@ -36,7 +36,7 @@ public class ArchivableFile extends File {
     public void unarchiveIfArchived() throws IOException {
         String dbPath = getPath();
         String dbLockPath = getPath() + ".lock";
-        String dbGzipPath = getPath() + ".db.gz";
+        String dbGzipPath = getPath() + ".gz";
         File databaseFile = new File(dbPath);
         File databaseLockFile = new File(dbLockPath);
         File databaseGzipFile = new File(dbGzipPath);

--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -3,9 +3,13 @@ package sandbox;
 import org.sqlite.javax.SQLiteConnectionPoolDataSource;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.SQLException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
 /**
  * Methods that mostly are used around the mocks that replicate stuff from
@@ -57,5 +61,73 @@ public class SqlSandboxUtils {
         } catch (ClassNotFoundException|SQLException |IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static void unarchiveIfArchived(String databaseName, String databasePath) throws IOException {
+        String dbPath = databasePath + '/' + databaseName + ".db";
+        String dbLockPath = databasePath + '/' + databaseName + ".db.lock";
+        String dbGzipPath = databasePath + '/' + databaseName + ".db.gz";
+        File databaseFile = new File(dbPath);
+        File databaseLockFile = new File(dbLockPath);
+        File databaseGzipFile = new File(dbGzipPath);
+
+        while (databaseLockFile.exists()) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (!databaseFile.exists() && databaseGzipFile.exists()) {
+            try {
+                boolean lockCreated = databaseLockFile.createNewFile();
+                if (!lockCreated) {
+                    throw new IOException("Could not create lock file");
+                }
+                decompressGzipFile(dbGzipPath, dbPath);
+                boolean gzipDeleted = databaseGzipFile.delete();
+                if (!gzipDeleted) {
+                    throw new IOException("Could not delete gzipFile");
+                }
+            } finally {
+                boolean lockDeleted = databaseLockFile.delete();
+                if (!lockDeleted && databaseLockFile.exists()) {
+                    throw new IOException("Could not delete lock file. This can result in a deadlock");
+                }
+            }
+        }
+    }
+
+    private static void decompressGzipFile(String gzipFile, String newFile) throws IOException {
+        // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
+        FileInputStream fis = new FileInputStream(gzipFile);
+        GZIPInputStream gis = new GZIPInputStream(fis);
+        FileOutputStream fos = new FileOutputStream(newFile);
+        byte[] buffer = new byte[1024];
+        int len;
+        while((len = gis.read(buffer)) != -1){
+            fos.write(buffer, 0, len);
+        }
+        //close resources
+        fis.close();
+        fos.close();
+        gis.close();
+    }
+
+    private static void compressGzipFile(String file, String gzipFile) throws IOException {
+        // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
+        FileInputStream fis = new FileInputStream(file);
+        FileOutputStream fos = new FileOutputStream(gzipFile);
+        GZIPOutputStream gzipOS = new GZIPOutputStream(fos);
+        byte[] buffer = new byte[1024];
+        int len;
+        while((len=fis.read(buffer)) != -1){
+            gzipOS.write(buffer, 0, len);
+        }
+        //close resources
+        gzipOS.close();
+        fos.close();
+        fis.close();
     }
 }

--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -18,6 +18,10 @@ public class SqlSandboxUtils {
 
     public static void deleteDatabaseFolder(String path) {
         File databaseFolder = new File(path);
+        deleteDatabaseFolder(databaseFolder);
+    }
+
+    public static void deleteDatabaseFolder(File databaseFolder) {
         if (databaseFolder.exists()) {
             deleteFolder(databaseFolder);
         }

--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -3,13 +3,9 @@ package sandbox;
 import org.sqlite.javax.SQLiteConnectionPoolDataSource;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.SQLException;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Methods that mostly are used around the mocks that replicate stuff from
@@ -46,88 +42,19 @@ public class SqlSandboxUtils {
         folder.delete();
     }
 
-    public static SQLiteConnectionPoolDataSource getDataSource(String databaseName, String databasePath) {
-        File databaseFolder = new File(databasePath);
-
+    public static SQLiteConnectionPoolDataSource getDataSource(File databasePath) {
+        File databaseFolder = new File(databasePath.getParent());
         try {
             if (!databaseFolder.exists()) {
                 Files.createDirectories(databaseFolder.toPath());
             }
             Class.forName("org.sqlite.JDBC");
             SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
-            dataSource.setUrl("jdbc:sqlite:" + databasePath + "/" + databaseName + ".db?journal_mode=MEMORY");
+            dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=MEMORY");
             dataSource.getConnection().setAutoCommit(false);
             return dataSource;
         } catch (ClassNotFoundException|SQLException |IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static void unarchiveIfArchived(String databaseName, String databasePath) throws IOException {
-        String dbPath = databasePath + '/' + databaseName + ".db";
-        String dbLockPath = databasePath + '/' + databaseName + ".db.lock";
-        String dbGzipPath = databasePath + '/' + databaseName + ".db.gz";
-        File databaseFile = new File(dbPath);
-        File databaseLockFile = new File(dbLockPath);
-        File databaseGzipFile = new File(dbGzipPath);
-
-        while (databaseLockFile.exists()) {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        if (!databaseFile.exists() && databaseGzipFile.exists()) {
-            try {
-                boolean lockCreated = databaseLockFile.createNewFile();
-                if (!lockCreated) {
-                    throw new IOException("Could not create lock file");
-                }
-                decompressGzipFile(dbGzipPath, dbPath);
-                boolean gzipDeleted = databaseGzipFile.delete();
-                if (!gzipDeleted) {
-                    throw new IOException("Could not delete gzipFile");
-                }
-            } finally {
-                boolean lockDeleted = databaseLockFile.delete();
-                if (!lockDeleted && databaseLockFile.exists()) {
-                    throw new IOException("Could not delete lock file. This can result in a deadlock");
-                }
-            }
-        }
-    }
-
-    private static void decompressGzipFile(String gzipFile, String newFile) throws IOException {
-        // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
-        FileInputStream fis = new FileInputStream(gzipFile);
-        GZIPInputStream gis = new GZIPInputStream(fis);
-        FileOutputStream fos = new FileOutputStream(newFile);
-        byte[] buffer = new byte[1024];
-        int len;
-        while((len = gis.read(buffer)) != -1){
-            fos.write(buffer, 0, len);
-        }
-        //close resources
-        fis.close();
-        fos.close();
-        gis.close();
-    }
-
-    private static void compressGzipFile(String file, String gzipFile) throws IOException {
-        // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
-        FileInputStream fis = new FileInputStream(file);
-        FileOutputStream fos = new FileOutputStream(gzipFile);
-        GZIPOutputStream gzipOS = new GZIPOutputStream(fos);
-        byte[] buffer = new byte[1024];
-        int len;
-        while((len=fis.read(buffer)) != -1){
-            gzipOS.write(buffer, 0, len);
-        }
-        //close resources
-        gzipOS.close();
-        fos.close();
-        fis.close();
     }
 }

--- a/src/main/java/sqlitedb/ApplicationDBPath.java
+++ b/src/main/java/sqlitedb/ApplicationDBPath.java
@@ -2,7 +2,7 @@ package sqlitedb;
 
 import util.Constants;
 
-class ApplicationDBPath implements DBPath {
+class ApplicationDBPath extends DBPath {
 
     private String domain;
     private String username;
@@ -24,10 +24,5 @@ class ApplicationDBPath implements DBPath {
     @Override
     public String getDatabaseName() {
         return "application_" + Constants.SQLITE_DB_VERSION;
-    }
-
-    @Override
-    public String getDatabaseFile() {
-        return getDatabasePath() + "/" + getDatabaseName() + ".db";
     }
 }

--- a/src/main/java/sqlitedb/DBPath.java
+++ b/src/main/java/sqlitedb/DBPath.java
@@ -1,7 +1,10 @@
 package sqlitedb;
 
-public interface DBPath {
-    String getDatabasePath();
-    String getDatabaseName();
-    String getDatabaseFile();
+abstract class DBPath {
+    abstract String getDatabasePath();
+    abstract String getDatabaseName();
+
+    String getDatabaseFile() {
+        return getDatabasePath() + "/" + getDatabaseName() + ".db";
+    }
 }

--- a/src/main/java/sqlitedb/SQLiteDB.java
+++ b/src/main/java/sqlitedb/SQLiteDB.java
@@ -8,6 +8,7 @@ import services.ConnectionHandler;
 
 import javax.sql.DataSource;
 import java.io.File;
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -21,6 +22,11 @@ public class SQLiteDB implements ConnectionHandler {
     }
 
     private Connection getNewConnection() throws SQLException {
+        try {
+            SqlSandboxUtils.unarchiveIfArchived(dbPath.getDatabaseName(), dbPath.getDatabasePath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
         DataSource dataSource = SqlSandboxUtils.getDataSource(dbPath.getDatabaseName(), dbPath.getDatabasePath());
         return dataSource.getConnection();
     }

--- a/src/main/java/sqlitedb/SQLiteDB.java
+++ b/src/main/java/sqlitedb/SQLiteDB.java
@@ -79,7 +79,7 @@ public class SQLiteDB implements ConnectionHandler {
     }
 
     public boolean databaseFileExists() {
-        return new File(dbPath.getDatabaseFile()).exists();
+        return new File(dbPath.getDatabaseFile()).exists() || new File(dbPath.getDatabaseFile() + ".gz").exists();
     }
 
     public boolean databaseFolderExists() {

--- a/src/main/java/sqlitedb/SQLiteDB.java
+++ b/src/main/java/sqlitedb/SQLiteDB.java
@@ -8,7 +8,6 @@ import sandbox.SqlSandboxUtils;
 import services.ConnectionHandler;
 
 import javax.sql.DataSource;
-import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -77,11 +76,11 @@ public class SQLiteDB implements ConnectionHandler {
     }
 
     public void deleteDatabaseFile() {
-        SqlSandboxUtils.deleteDatabaseFolder(dbPath.getDatabaseFile());
+        SqlSandboxUtils.deleteDatabaseFolder(dbArchivableFile);
     }
 
     public void deleteDatabaseFolder() {
-        SqlSandboxUtils.deleteDatabaseFolder(dbPath.getDatabasePath());
+        SqlSandboxUtils.deleteDatabaseFolder(dbArchivableFile.getParentFile());
     }
 
     public boolean createDatabaseFolder() {
@@ -93,7 +92,7 @@ public class SQLiteDB implements ConnectionHandler {
     }
 
     public boolean databaseFolderExists() {
-        return new File(dbPath.getDatabasePath()).exists();
+        return dbArchivableFile.getParentFile().exists();
     }
 
     public String getDatabaseFileForDebugPurposes() {

--- a/src/main/java/sqlitedb/UserDBPath.java
+++ b/src/main/java/sqlitedb/UserDBPath.java
@@ -4,7 +4,7 @@ import application.SQLiteProperties;
 import org.commcare.modern.database.TableBuilder;
 import util.Constants;
 
-class UserDBPath implements DBPath {
+class UserDBPath extends DBPath {
 
     private String domain;
     private String username;
@@ -36,10 +36,5 @@ class UserDBPath implements DBPath {
     @Override
     public String getDatabaseName() {
         return "user_" + Constants.SQLITE_DB_VERSION;
-    }
-
-    @Override
-    public String getDatabaseFile() {
-        return getUserDBPath(domain, username, asUsername) + "/" + getDatabaseName() + ".db";
     }
 }


### PR DESCRIPTION
This PR provides
- functionality for detecting and unarchiving .gz archive when the original db file is not present, and working transparently from there as if it had been present all along
- a script that can be used in a cron job to archive all .db files in a directory that haven't been accessed for a given period of time. (This will not be "live" until we add such a cron job in ansible.)

Thus the only immediate effect of this PR is to turn on the ability to read from *.db.gz files, but doesn't actually turn on the archiving that will create them yet.

To test this out locally (with the archiving), you can (from the formplayer directory) run (assuming you're storing dbs in `formplayer/dbs`)

```bash
watch './scripts/archive_dbs.sh dbs +10s'
```

in one terminal window to archive all dbs not accessed in the last 10 seconds and

```bash
watch 'find dbs -type f'
```
in another to watch the files in that directory as they change. Then you can spin up formplayer and commcare-hq and play around with webapps and watch what happens to the .db and .db.gz files as you access (or don't access) certain dbs.

I've tested that this works very smoothly even when you're archiving files not used in the last second realtime and clicking around webapps, submitting forms, switching apps, using login-as, etc. Of course, this is with tiny db files where gzipping and ungzipping is instantaneous, so I would recommend a much larger `-atime` of `+15m` or so.

That said, I've carefully designed both processes (java unarchiving and bash archiving) to create a .lock file before any gzip steps, and delete it after (even if the gzip step fails). The only risk I can see here is that if a .lock file _does_ somehow end up there with no process around to delete it, accessing that db will hang forever. The only way I know of that that could happen is if someone manually creates that file, or I suppose if the java or bash process is hard-killed at exactly the wrong time.