### PR TITLE
Shorten user lock timeout

### DIFF
--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -25,10 +25,11 @@ public class LockAspect {
     @Autowired
     private StatsDClient datadogStatsDClient;
 
-    private class LockError extends Exception {}
+    // needs to be accessible from WebAppContext.exceptionResolver
+    public class LockError extends Exception {}
 
     @Around(value = "@annotation(annotations.UserLock)")
-    public Object beforeLock(ProceedingJoinPoint joinPoint) throws Throwable {
+    public Object aroundLock(ProceedingJoinPoint joinPoint) throws Throwable {
         Object[] args = joinPoint.getArgs();
 
         if (!(args[0] instanceof AuthenticatedRequestBean)) {
@@ -48,8 +49,7 @@ public class LockAspect {
             lock = getLockAndBlock(username);
         } catch (LockError e) {
             logLockError(bean, joinPoint, "timed_out");
-            throw new RuntimeException("Timed out trying to obtain lock for username " + username  +
-                    ". Please try your request again in a moment.");
+            throw e;
         }
 
         try {

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -61,7 +61,6 @@ public class LockAspect {
                 } catch (IllegalStateException e) {
                     // Lock was released after expiration
                     logLockError(bean, joinPoint, "expired");
-                    throw new IllegalStateException("That request took too long to process, please try again.", e);
                 }
             }
         }

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -93,7 +93,7 @@ public class Constants {
             Pattern.compile("v2/.*")
     ));
 
-    public static final int USER_LOCK_TIMEOUT = 120;
+    public static final int USER_LOCK_TIMEOUT = 7;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;
 

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -93,7 +93,7 @@ public class Constants {
             Pattern.compile("v2/.*")
     ));
 
-    public static final int USER_LOCK_TIMEOUT = 7;
+    public static final int USER_LOCK_TIMEOUT = 21;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;
 


### PR DESCRIPTION
and change response behavior on the lock timeout and lock expiry.

EDIT: I originally was going to change it to 7 seconds, but @ctsims convinced me to try 21 seconds instead, as thousands of requests a day fall into the < 20s bucket.

The impetus here is that the _vast_ majority of requests take under 20 seconds, so if you can't obtain a lock in 21 seconds, chances are you're waiting on a loooong process or a deadlock, and it's relatively likely you won't be able to obtain it in 120 seconds either—so there's no point in presenting that baffling behavior where you do some super simple thing and hangs for 2 minutes, and then fails anyway.

This should only get merged after https://github.com/dimagi/commcare-hq/pull/17639, which improves the behavior of server errors like this one to be less disruptive to the user's workflow.

It will be easy to tell if I've set the timeout too low: my hypothesis is that the lock timemout numbers in https://app.datadoghq.com/dash/232351/formplayer-error-tracking?live=true&page=0&is_auto=false&from_ts=1503867265434&to_ts=1504040065434&tile_size=m&tpl_var_environment=enikshay will rise only slightly; if they spike, then we need to increase the timeout, because it means that a ton of things that were waiting 21+ seconds but eventually obtaining the lock before are now timing out and erroring.