### PR TITLE
Revert "clean up builder syntax for sentry breadcrumbs"

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -1,16 +1,17 @@
 package application;
 
 import aspects.*;
+import com.getsentry.raven.Raven;
 import com.getsentry.raven.RavenFactory;
 import com.getsentry.raven.dsn.InvalidDsnException;
 import com.getsentry.raven.event.BreadcrumbBuilder;
-import com.google.common.collect.ImmutableMap;
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import engine.FormplayerArchiveFileRoot;
 import installers.FormplayerInstallerFactory;
 import org.apache.tomcat.jdbc.pool.DataSource;
 import org.commcare.modern.reference.ArchiveFileRoot;
+import org.lightcouch.CouchDbClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -33,15 +34,14 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
-import repo.impl.PostgresFormSessionRepo;
-import repo.impl.PostgresMenuSessionRepo;
-import repo.impl.PostgresMigratedFormSessionRepo;
-import repo.impl.PostgresUserRepo;
+import repo.impl.*;
 import services.*;
 import services.impl.*;
 import util.Constants;
 import util.FormplayerRaven;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 //have to exclude this to use two DataSources (HQ and Formplayer dbs)
@@ -241,15 +241,17 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     @Bean
     @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public FormplayerRaven raven() {
+        Map<String, String> data = new HashMap<String, String>();
+        data.put("environment", environment);
+        BreadcrumbBuilder builder = new BreadcrumbBuilder();
+        builder.setData(data);
         FormplayerRaven raven;
         try {
             raven = new FormplayerRaven(RavenFactory.ravenInstance(ravenDsn));
         } catch (InvalidDsnException e) {
             raven = new FormplayerRaven(null);
         }
-        raven.recordBreadcrumb(new BreadcrumbBuilder()
-                .setData(ImmutableMap.of("environment", environment))
-                .build());
+        raven.recordBreadcrumb(builder.build());
         return raven;
     }
 

--- a/src/main/java/aspects/AppInstallAspect.java
+++ b/src/main/java/aspects/AppInstallAspect.java
@@ -3,7 +3,6 @@ package aspects;
 import beans.InstallFromSessionRequestBean;
 import beans.InstallRequestBean;
 import com.getsentry.raven.event.BreadcrumbBuilder;
-import com.google.common.collect.ImmutableMap;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -13,6 +12,8 @@ import services.FormplayerStorageFactory;
 import util.FormplayerRaven;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Aspect to configure the FormplayerStorageManager
@@ -33,16 +34,18 @@ public class AppInstallAspect {
         if (!(args[0] instanceof InstallRequestBean)) {
             throw new RuntimeException("Could not configure StorageFactory with args " + Arrays.toString(args));
         }
-        final InstallRequestBean requestBean = (InstallRequestBean) args[0];
+        InstallRequestBean requestBean = (InstallRequestBean) args[0];
         storageFactory.configure(requestBean);
 
-        raven.recordBreadcrumb(new BreadcrumbBuilder()
-                .setData(ImmutableMap.of(
-                        "appId", requestBean.getAppId(),
-                        "installReference", requestBean.getInstallReference(),
-                        "locale", requestBean.getLocale()))
-                        .setCategory("application_install")
-                .build());
+        Map<String, String> data = new HashMap<String, String>();
+        data.put("appId", requestBean.getAppId());
+        data.put("installReference", requestBean.getInstallReference());
+        data.put("locale", requestBean.getLocale());
+
+        BreadcrumbBuilder builder = new BreadcrumbBuilder();
+        builder.setData(data);
+        builder.setCategory("application_install");
+        raven.recordBreadcrumb(builder.build());
         raven.setAppId(requestBean.getAppId());
     }
 

--- a/src/main/java/aspects/LoggingAspect.java
+++ b/src/main/java/aspects/LoggingAspect.java
@@ -2,7 +2,6 @@ package aspects;
 
 import beans.AuthenticatedRequestBean;
 import com.getsentry.raven.event.BreadcrumbBuilder;
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -15,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import util.FormplayerRaven;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Aspect to log the inputs and return of each API method
@@ -45,15 +46,16 @@ public class LoggingAspect {
 
         if (requestBean != null && requestBean instanceof AuthenticatedRequestBean) {
             AuthenticatedRequestBean authenticatedRequestBean = (AuthenticatedRequestBean) requestBean;
-            raven.recordBreadcrumb(new BreadcrumbBuilder()
-                    .setData(ImmutableMap.<String, String>builder()
-                            .put("path", requestPath)
-                            .put("domain", authenticatedRequestBean.getDomain())
-                            .put("username", authenticatedRequestBean.getUsername())
-                            .put("restoreAs", authenticatedRequestBean.getRestoreAs())
-                            .put("bean", authenticatedRequestBean.toString())
-                            .build())
-                    .build());
+            Map<String, String> data = new HashMap<String, String>();
+            data.put("path", requestPath);
+            data.put("domain", authenticatedRequestBean.getDomain());
+            data.put("username", authenticatedRequestBean.getUsername());
+            data.put("restoreAs", authenticatedRequestBean.getRestoreAs());
+            data.put("bean", authenticatedRequestBean.toString());
+
+            BreadcrumbBuilder builder = new BreadcrumbBuilder();
+            builder.setData(data);
+            raven.recordBreadcrumb(builder.build());
         }
 
         Object result = joinPoint.proceed();

--- a/src/main/java/aspects/MetricsAspect.java
+++ b/src/main/java/aspects/MetricsAspect.java
@@ -4,7 +4,6 @@ import beans.AuthenticatedRequestBean;
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.event.BreadcrumbBuilder;
 import com.getsentry.raven.event.Event;
-import com.google.common.collect.ImmutableMap;
 import com.timgroup.statsd.StatsDClient;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -17,6 +16,7 @@ import util.Constants;
 import util.FormplayerRaven;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
 
 /**
  * This aspect records various metrics for every request.
@@ -71,11 +71,13 @@ public class MetricsAspect {
     }
 
     private void sendTimingWarningToSentry(final long timeInMs) {
-        raven.recordBreadcrumb(new BreadcrumbBuilder()
-                .setCategory("long_request")
-                .setLevel(Breadcrumb.Level.WARNING)
-                .setData(ImmutableMap.of("duration", String.format("%.3fs", timeInMs / 1000.)))
-                .build());
+        raven.recordBreadcrumb(new BreadcrumbBuilder() {{
+            setCategory("long_request");
+            setLevel(Breadcrumb.Level.WARNING);
+            setData(new HashMap<String, String>() {{
+                put("duration", String.format("%.3fs", timeInMs / 1000.));
+            }});
+        }}.build());
         raven.sendRavenException(new Exception("This request took a long time"), Event.Level.WARNING);
     }
 

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -3,7 +3,6 @@ package services;
 import auth.HqAuth;
 import beans.AuthenticatedRequestBean;
 import com.getsentry.raven.event.BreadcrumbBuilder;
-import com.google.common.collect.ImmutableMap;
 import exceptions.AsyncRetryException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
@@ -42,6 +41,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.TimeUnit;
 
@@ -177,11 +178,13 @@ public class RestoreFactory {
     }
 
     private void recordSentryData(String restoreUrl) {
-        raven.recordBreadcrumb(new BreadcrumbBuilder()
-                .setData(ImmutableMap.of("restoreUrl", restoreUrl))
-                .setCategory("restore")
-                .setMessage("Restoring from URL " + restoreUrl)
-                .build());
+        Map<String, String> data = new HashMap<String, String>();
+        data.put("restoreUrl", restoreUrl);
+        BreadcrumbBuilder builder = new BreadcrumbBuilder();
+        builder.setData(data);
+        builder.setCategory("restore");
+        builder.setMessage("Restoring from URL " + restoreUrl);
+        raven.recordBreadcrumb(builder.build());
     }
 
     private void setLastSyncTime() {


### PR DESCRIPTION
Fixes https://sentry.io/dimagi/formplayer/issues/346089672/ introduced here https://github.com/dimagi/formplayer/pull/468

@dannyroberts looks like ImmutableMap does not allow null values which some of these can be https://github.com/google/guava/issues/1782