### PR TITLE
Simplify timing

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -252,6 +252,12 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
 
     @Bean
     @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+    public CategoryTimingHelper categoryTimingHelper() {
+        return new CategoryTimingHelper();
+    }
+
+    @Bean
+    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public RestoreFactory restoreFactory() {
         return new RestoreFactory();
     }

--- a/src/main/java/aspects/MetricsAspect.java
+++ b/src/main/java/aspects/MetricsAspect.java
@@ -47,14 +47,13 @@ public class MetricsAspect {
         timer.start();
         Object result = joinPoint.proceed();
         timer.end();
-        String durationBucket = timer.getDurationBucket();
 
         datadogStatsDClient.increment(
                 Constants.DATADOG_REQUESTS,
                 "domain:" + domain,
                 "user:" + user,
                 "request:" + requestPath,
-                "duration:" + durationBucket
+                "duration:" + timer.getDurationBucket()
         );
 
         datadogStatsDClient.recordExecutionTime(
@@ -64,7 +63,7 @@ public class MetricsAspect {
                 "user:" + user,
                 "request:" + requestPath
         );
-        if (durationBucket.equals("lt_120s") || durationBucket.equals("over_120s")) {
+        if (timer.durationInMs() >= 60 * 1000) {
             sendTimingWarningToSentry(timer);
         }
         return result;

--- a/src/main/java/services/CategoryTimingHelper.java
+++ b/src/main/java/services/CategoryTimingHelper.java
@@ -1,0 +1,70 @@
+package services;
+
+import com.timgroup.statsd.StatsDClient;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import util.Constants;
+import util.FormplayerHttpRequest;
+import util.FormplayerRaven;
+import util.SimpleTimer;
+
+@Component
+public class CategoryTimingHelper {
+    @Autowired
+    private FormplayerHttpRequest request;
+
+    @Autowired
+    private StatsDClient datadogStatsDClient;
+
+    @Autowired
+    private FormplayerRaven raven;
+
+    public class RecordingTimer extends SimpleTimer {
+        private CategoryTimingHelper parent;
+        private String category, sentryMessage;
+
+        private RecordingTimer(CategoryTimingHelper parent, String category) {
+            this.parent = parent;
+            this.category = category;
+        }
+
+        @Override
+        public RecordingTimer end() {
+            super.end();
+            return this;
+        }
+
+        public RecordingTimer setMessage(String message) {
+            this.sentryMessage = message;
+            return this;
+        }
+
+        public void record() {
+            parent.recordCategoryTiming(this, category, sentryMessage);
+        }
+    }
+
+    public RecordingTimer newTimer(String category) {
+        return new RecordingTimer(this, category);
+    }
+
+    private void recordCategoryTiming(SimpleTimer timer, String category, String sentryMessage) {
+        raven.newBreadcrumb()
+                .setCategory(category)
+                .setMessage(sentryMessage)
+                .setData("duration", timer.formatDuration())
+                .record();
+
+        datadogStatsDClient.recordExecutionTime(
+                Constants.DATADOG_GRANULAR_TIMINGS,
+                timer.durationInMs(),
+                "category:" + category,
+                "request:" + getRequestEndpoint()
+        );
+    }
+
+    private String getRequestEndpoint() {
+        return StringUtils.strip(request.getRequestURI(), "/");
+    }
+}

--- a/src/main/java/util/SimpleTimer.java
+++ b/src/main/java/util/SimpleTimer.java
@@ -1,0 +1,39 @@
+package util;
+
+public class SimpleTimer {
+    private long startTimeInNs;
+    private long endTimeInNs;
+
+    public void start() {
+        startTimeInNs = System.nanoTime();
+    }
+
+    public void end() {
+        endTimeInNs = System.nanoTime();
+    }
+
+    public long durationInMs() {
+        return (endTimeInNs - startTimeInNs) / (1000000);
+    }
+
+    public String getDurationBucket() {
+        long timeInS = durationInMs() / 1000;
+        if (timeInS < 1) {
+            return "lt_001s";
+        } else if (timeInS < 5) {
+            return "lt_005s";
+        } else if (timeInS < 20) {
+            return "lt_020s";
+        } else if (timeInS < 60) {
+            return "lt_060s";
+        } else if (timeInS < 120) {
+            return "lt_120s";
+        } else {
+            return "over_120s";
+        }
+    }
+
+    public String formatDuration() {
+        return String.format("%.3fs", durationInMs() / 1000.);
+    }
+}

--- a/src/main/java/util/SimpleTimer.java
+++ b/src/main/java/util/SimpleTimer.java
@@ -8,8 +8,9 @@ public class SimpleTimer {
         startTimeInNs = System.nanoTime();
     }
 
-    public void end() {
+    public SimpleTimer end() {
         endTimeInNs = System.nanoTime();
+        return this;
     }
 
     public long durationInMs() {


### PR DESCRIPTION
Quick prefactor to make adding standardized category timings easier.

The idea with category timings is that they should be _mutually exclusive_, so that all together they add up to less than the total time a request took—i.e. don't time a function and then also time a smaller potion within it.

To add a timing now, it looks like this:

```
CategoryTimingHelper.RecordingTimer timer = categoryTimingHelper.newTimer("my_category");
timer.start();
# do the thing you want to time
timer.end()
        .setMessage("My message which can be a function of timer duration")
        .record();
```

(if there's one already there, if the thing is in a `try`-`catch`, consider putting the `timer.end()...` step in a `finally`).