### PR TITLE
add /navigate_menu_start as alias to /navigate_menu

### DIFF
--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -181,7 +181,7 @@ public class MenuController extends AbstractBaseController {
      * @return A MenuBean or a NewFormResponse
      * @throws Exception
      */
-    @RequestMapping(value = Constants.URL_MENU_NAVIGATION, method = RequestMethod.POST)
+    @RequestMapping(value = {Constants.URL_MENU_NAVIGATION, Constants.URL_INITIAL_MENU_NAVIGATION}, method = RequestMethod.POST)
     @UserLock
     @UserRestore
     @AppInstall

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     public final static String URL_GET_SESSION = "get_session";
     public static final String URL_INSTALL = "install";
     public static final String URL_UPDATE = "update";
+    public static final String URL_INITIAL_MENU_NAVIGATION = "navigate_menu_start";
     public static final String URL_MENU_NAVIGATION = "navigate_menu";
     public static final String URL_GET_DETAILS = "get_details";
     public static final String URL_GET_SESSIONS = "get_sessions";


### PR DESCRIPTION
web apps will use the new endpoint when entering an app and the main one for everything else.
this will help us break out the first click, which often includes lots of app installs,
from all the other menu navigation