### PR TITLE
fix request param in datadog

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -294,6 +294,7 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     }
 
     @Bean
+    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public LockAspect lockAspect() {
         return new LockAspect();
     }
@@ -303,6 +304,7 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     }
 
     @Bean
+    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public MetricsAspect metricsAspect() {
         return new MetricsAspect();
     }

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -12,7 +12,9 @@ import org.springframework.core.annotation.Order;
 import org.springframework.integration.support.locks.LockRegistry;
 import services.CategoryTimingHelper;
 import util.Constants;
+import util.FormplayerHttpRequest;
 import util.FormplayerRaven;
+import util.RequestUtils;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -35,6 +37,9 @@ public class LockAspect {
 
     @Autowired
     private CategoryTimingHelper categoryTimingHelper;
+
+    @Autowired
+    private FormplayerHttpRequest request;
 
     // needs to be accessible from WebAppContext.exceptionResolver
     public class LockError extends Exception {}
@@ -83,7 +88,7 @@ public class LockAspect {
                 Constants.DATADOG_ERRORS_LOCK,
                 "domain:" + bean.getDomain(),
                 "user:" + bean.getUsernameDetail(),
-                "request:" + MetricsAspect.getRequestPath(joinPoint),
+                "request:" + RequestUtils.getRequestEndpoint(request),
                 "lock_issue:" + lockIssue
         );
     }

--- a/src/main/java/aspects/MetricsAspect.java
+++ b/src/main/java/aspects/MetricsAspect.java
@@ -14,6 +14,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.web.bind.annotation.RequestMapping;
 import util.*;
 
+import javax.servlet.ServletRequest;
 import java.lang.reflect.Method;
 
 /**
@@ -29,7 +30,10 @@ public class MetricsAspect {
     @Autowired
     private FormplayerRaven raven;
 
-    @Autowired
+    @Autowired(required = false)
+    // not present in the mock server during tests
+    // I believe this is related to it being @Around @RequestMapping, as if you change that then it's present.
+    // Since it's only during tests, I'm letting this go.
     private FormplayerHttpRequest request;
 
     @Around(value = "@annotation(org.springframework.web.bind.annotation.RequestMapping)")

--- a/src/main/java/services/CategoryTimingHelper.java
+++ b/src/main/java/services/CategoryTimingHelper.java
@@ -4,10 +4,7 @@ import com.timgroup.statsd.StatsDClient;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import util.Constants;
-import util.FormplayerHttpRequest;
-import util.FormplayerRaven;
-import util.SimpleTimer;
+import util.*;
 
 @Component
 public class CategoryTimingHelper {
@@ -60,11 +57,7 @@ public class CategoryTimingHelper {
                 Constants.DATADOG_GRANULAR_TIMINGS,
                 timer.durationInMs(),
                 "category:" + category,
-                "request:" + getRequestEndpoint()
+                "request:" + RequestUtils.getRequestEndpoint(request)
         );
-    }
-
-    private String getRequestEndpoint() {
-        return StringUtils.strip(request.getRequestURI(), "/");
     }
 }

--- a/src/main/java/util/RequestUtils.java
+++ b/src/main/java/util/RequestUtils.java
@@ -1,5 +1,6 @@
 package util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 
 import javax.servlet.http.HttpServletRequest;
@@ -59,4 +60,7 @@ public class RequestUtils {
         return data;
     }
 
+    public static String getRequestEndpoint(FormplayerHttpRequest request) {
+        return StringUtils.strip(request.getRequestURI(), "/");
+    }
 }

--- a/src/main/java/util/RequestUtils.java
+++ b/src/main/java/util/RequestUtils.java
@@ -3,6 +3,7 @@ package util;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 
+import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -61,6 +62,11 @@ public class RequestUtils {
     }
 
     public static String getRequestEndpoint(FormplayerHttpRequest request) {
-        return StringUtils.strip(request.getRequestURI(), "/");
+        if (request != null) {
+            return StringUtils.strip(((FormplayerHttpRequest) request).getRequestURI(), "/");
+        } else {
+            // this is for tests, see comment on autowired request in MetricsAspect
+            return "";
+        }
     }
 }


### PR DESCRIPTION
the overall timing metric and lock metric were pulling
from the route name rather than the url.
this made navigate_menu vs navigate_menu_start indistinguishable