### PR TITLE
fix double-running MetricAspect and LockAspect

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -294,7 +294,6 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public LockAspect lockAspect() {
         return new LockAspect();
     }
@@ -304,7 +303,6 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public MetricsAspect metricsAspect() {
         return new MetricsAspect();
     }

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -12,7 +12,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.integration.support.locks.LockRegistry;
 import services.CategoryTimingHelper;
 import util.Constants;
-import util.FormplayerHttpRequest;
 import util.FormplayerRaven;
 import util.RequestUtils;
 

--- a/src/main/java/aspects/MetricsAspect.java
+++ b/src/main/java/aspects/MetricsAspect.java
@@ -4,19 +4,14 @@ import beans.AuthenticatedRequestBean;
 import com.getsentry.raven.event.Breadcrumb;
 import com.getsentry.raven.event.Event;
 import com.timgroup.statsd.StatsDClient;
-import org.apache.commons.lang3.StringUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
-import org.springframework.web.bind.annotation.RequestMapping;
 import util.*;
 
-import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
-import java.lang.reflect.Method;
 
 /**
  * This aspect records various metrics for every request.


### PR DESCRIPTION
this was causing most requests to be double-counted in datadog

Not exactly clear _why_ that's the effect of request-scoping these (maybe two `MetricAspect` objects end up getting created somehow, one global-scoped, one request-scoped... or something), but this is definitely what was causing it and it turns out just removing them works. I'd originally put them there as part of a workaround for something that ended up not working anyway, before I settled on the better approach (injecting the spring `HttpServletRequest` request rather than our own wrapper of it: https://github.com/dimagi/formplayer/pull/486), and it turns out it's not needed anymore anyway.

There've been a bunch of PRs related to this, which has been confusing even for me, so I pulled the total diff of the original PR (https://github.com/dimagi/formplayer/pull/484) and the subsequent ones I made to fix it, including this one: https://github.com/dimagi/formplayer/compare/dimagi:a2fb570...dimagi:060774c. (That's essentially the PR I would have made instead of https://github.com/dimagi/formplayer/pull/484 knowing what I know now.)