### PR TITLE
Refactor syncToken management

### DIFF
--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -67,18 +67,6 @@ public class CaseAPIs {
         ParseUtils.parseIntoSandbox(restorePayload, factory, true, true);
         restoreFactory.commit();
         restoreFactory.setAutoCommit(true);
-        // initialize our sandbox's logged in user
-        for (IStorageIterator<User> iterator = sandbox.getUserStorage().iterate(); iterator.hasMore(); ) {
-            User u = iterator.nextRecord();
-            String unwrappedUsername = UserUtils.getUsernameBeforeAtSymbol(restoreFactory.getWrappedUsername());
-            // Need to scrub username as the wrapped username will have been scrubbed
-            if (unwrappedUsername.equalsIgnoreCase(TableBuilder.scrubName(u.getUsername()))) {
-                // set last sync token
-                u.setLastSyncToken(sandbox.getSyncToken());
-                sandbox.getUserStorage().write(u);
-                sandbox.setLoggedInUser(u);
-            }
-        }
         return sandbox;
     }
 }

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -5,6 +5,7 @@ import beans.CaseBean;
 import engine.FormplayerTransactionParserFactory;
 import org.commcare.cases.model.Case;
 import org.commcare.core.parse.ParseUtils;
+import org.commcare.modern.database.TableBuilder;
 import org.javarosa.core.api.ClassNameHasher;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.storage.IStorageIterator;
@@ -70,7 +71,8 @@ public class CaseAPIs {
         for (IStorageIterator<User> iterator = sandbox.getUserStorage().iterate(); iterator.hasMore(); ) {
             User u = iterator.nextRecord();
             String unwrappedUsername = UserUtils.getUsernameBeforeAtSymbol(restoreFactory.getWrappedUsername());
-            if (unwrappedUsername.equalsIgnoreCase(u.getUsername())) {
+            // Need to scrub username as the wrapped username will have been scrubbed
+            if (unwrappedUsername.equalsIgnoreCase(TableBuilder.scrubName(u.getUsername()))) {
                 // set last sync token
                 u.setLastSyncToken(sandbox.getSyncToken());
                 sandbox.getUserStorage().write(u);

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -67,6 +67,7 @@ public class CaseAPIs {
         ParseUtils.parseIntoSandbox(restorePayload, factory, true, true);
         restoreFactory.commit();
         restoreFactory.setAutoCommit(true);
+        sandbox.writeSyncToken();
         return sandbox;
     }
 }

--- a/src/main/java/sandbox/UserSqlSandbox.java
+++ b/src/main/java/sandbox/UserSqlSandbox.java
@@ -192,4 +192,12 @@ public class UserSqlSandbox extends UserSandbox implements ConnectionHandler {
     public Connection getConnection() {
         return handler.getConnection();
     }
+
+    @Override
+    public void setSyncToken(String syncToken) {
+        super.setSyncToken(syncToken);
+        User user = getLoggedInUser();
+        user.setLastSyncToken(syncToken);
+        getUserStorage().update(user.getID(), user);
+    }
 }

--- a/src/main/java/sandbox/UserSqlSandbox.java
+++ b/src/main/java/sandbox/UserSqlSandbox.java
@@ -193,11 +193,9 @@ public class UserSqlSandbox extends UserSandbox implements ConnectionHandler {
         return handler.getConnection();
     }
 
-    @Override
-    public void setSyncToken(String syncToken) {
-        super.setSyncToken(syncToken);
+    public void writeSyncToken() {
         User user = getLoggedInUser();
-        user.setLastSyncToken(syncToken);
+        user.setLastSyncToken(getSyncToken());
         getUserStorage().update(user.getID(), user);
     }
 }

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -24,6 +24,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import sandbox.AbstractSqlIterator;
 import sandbox.SqliteIndexedStorageUtility;
 import sandbox.UserSqlSandbox;
 import sqlitedb.SQLiteDB;
@@ -290,22 +291,13 @@ public class RestoreFactory {
     }
 
     public String getSyncToken() {
-        String username = getWrappedUsername();
-
-        if (username == null) {
-            return null;
-        }
-
-        username = UserUtils.getUsernameBeforeAtSymbol(username);
-
         SqliteIndexedStorageUtility<User> storage = getSqlSandbox().getUserStorage();
-        Vector<Integer> users = storage.getIDsForValue(User.META_USERNAME, username);
+        AbstractSqlIterator<User> iterator = storage.iterate();
         //should be exactly one user
-        if (users.size() != 1) {
+        if (!iterator.hasNext()) {
             return null;
         }
-
-        return storage.getMetaDataFieldForRecord(users.firstElement(), User.META_SYNC_TOKEN);
+        return iterator.next().getLastSyncToken();
     }
 
     // Device ID for tracking usage in the same way Android uses IMEI


### PR DESCRIPTION
Resolves https://manage.dimagi.com/default.asp?261905

Convoluted but straightforward bug. When looking up the current user in the users database we compare the name strings. ~~The target name is escaped (`-` and `.` become `_`) but the names stored in the database are not. So if we are looking for the user named EG `district.support.test` we will never find this user and thus never set the sync token. This causes subsequent restores to use the cached lookup as we do not have a sync token.~~

Turned this into a bigger refactor. Formplayer borrowed a lot of unnecessary code from Android here - namely, our DBs will only have one user on them (Which we rely on elsewhere in the code) so iterating over the users comparing names is unnecessary.

I've also made a change so that we update the user's sync token directly in storage once the sync token is parsed rather than at the end - @ctsims ~~is there a good reason Android waits until pa~~ duh, because we don't know if the sync has succeeded yet.