### PR TITLE
Use '*' as separator in URL

### DIFF
--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -305,7 +305,7 @@ public class RestoreFactory {
         if (asUsername == null) {
             return DEVICE_ID_SLUG;
         }
-        return String.format("%s|%s|as|%s", DEVICE_ID_SLUG, username, asUsername);
+        return String.format("%s*%s*as*%s", DEVICE_ID_SLUG, username, asUsername);
     }
 
     public String getRestoreUrl() {


### PR DESCRIPTION
Use `*` instead of `|` as separator in URL because [`|` is not safe][1] and [`*` is][2].

  [1]: https://manage.dimagi.com/default.asp?263058#BugEvent.1401215
  [2]: https://perishablepress.com/stop-using-unsafe-characters-in-urls/
