### PR TITLE
Refactor to get auth from restoreFactory

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -111,17 +111,6 @@ public abstract class AbstractBaseController {
         return getNextMenu(menuSession, 0, "", 0);
     }
 
-    protected HqAuth getAuthHeaders(String domain, String username, String sessionToken) {
-        HqAuth auth;
-        if (UserUtils.isAnonymous(domain, username)) {
-            PostgresUser postgresUser = postgresUserRepo.getUserByUsername(username);
-            auth = new TokenAuth(postgresUser.getAuthToken());
-        } else {
-            auth = new DjangoAuth(sessionToken);
-        }
-        return auth;
-    }
-
     protected BaseResponseBean getNextMenu(MenuSession menuSession,
                                            int offset,
                                            String searchText,
@@ -302,17 +291,11 @@ public abstract class AbstractBaseController {
 
     protected MenuSession getMenuSession(String domain, String username, String menuSessionId, String authToken) throws Exception {
         MenuSession menuSession = null;
-        HqAuth auth = getAuthHeaders(
-                domain,
-                username,
-                authToken
-        );
 
         menuSession = new MenuSession(
                 menuSessionRepo.findOneWrapped(menuSessionId),
                 installService,
                 restoreFactory,
-                auth,
                 host
         );
         menuSession.getSessionWrapper().syncState();

--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -289,10 +289,8 @@ public abstract class AbstractBaseController {
         return response;
     }
 
-    protected MenuSession getMenuSession(String domain, String username, String menuSessionId, String authToken) throws Exception {
-        MenuSession menuSession = null;
-
-        menuSession = new MenuSession(
+    protected MenuSession getMenuSession(String menuSessionId) throws Exception {
+        MenuSession menuSession = new MenuSession(
                 menuSessionRepo.findOneWrapped(menuSessionId),
                 installService,
                 restoreFactory,

--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -1,6 +1,5 @@
 package application;
 
-import annotations.AppInstall;
 import annotations.AppInstallFromSession;
 import annotations.UserLock;
 import annotations.UserRestore;
@@ -80,14 +79,10 @@ public class DebuggerController extends AbstractBaseController {
     @UserRestore
     @AppInstallFromSession
     public MenuDebuggerContentResponseBean menuDebuggerContent(
-            @RequestBody MenuDebuggerRequestBean debuggerMenuRequest,
-            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+            @RequestBody MenuDebuggerRequestBean debuggerMenuRequest) throws Exception {
 
         MenuSession menuSession = getMenuSession(
-                debuggerMenuRequest.getDomain(),
-                debuggerMenuRequest.getUsername(),
-                debuggerMenuRequest.getMenuSessionId(),
-                authToken
+                debuggerMenuRequest.getMenuSessionId()
         );
 
         return new MenuDebuggerContentResponseBean(
@@ -129,13 +124,9 @@ public class DebuggerController extends AbstractBaseController {
     @UserLock
     @UserRestore
     @AppInstallFromSession
-    public EvaluateXPathResponseBean menuEvaluateXpath(@RequestBody EvaluateXPathMenuRequestBean evaluateXPathRequestBean,
-                                                   @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+    public EvaluateXPathResponseBean menuEvaluateXpath(@RequestBody EvaluateXPathMenuRequestBean evaluateXPathRequestBean) throws Exception {
         MenuSession menuSession = getMenuSession(
-                evaluateXPathRequestBean.getDomain(),
-                evaluateXPathRequestBean.getUsername(),
-                evaluateXPathRequestBean.getMenuSessionId(),
-                authToken
+                evaluateXPathRequestBean.getMenuSessionId()
         );
 
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(

--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -3,7 +3,6 @@ package application;
 import annotations.AppInstall;
 import annotations.UserLock;
 import annotations.UserRestore;
-import auth.HqAuth;
 import beans.InstallRequestBean;
 import beans.NewFormResponse;
 import beans.NotificationMessage;
@@ -212,10 +211,7 @@ public class MenuController extends AbstractBaseController {
         String menuSessionId = sessionNavigationBean.getMenuSessionId();
         if (menuSessionId != null && !"".equals(menuSessionId)) {
             menuSession = getMenuSession(
-                    sessionNavigationBean.getDomain(),
-                    sessionNavigationBean.getUsername(),
-                    menuSessionId,
-                    authToken
+                    menuSessionId
             );
         } else {
             // If we have a preview command, load that up

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -75,14 +75,14 @@ public class MenuSession {
     ArrayList<String> titles;
 
     public MenuSession(SerializableMenuSession session, InstallService installService,
-                       RestoreFactory restoreFactory, HqAuth auth, String host) throws Exception {
+                       RestoreFactory restoreFactory, String host) throws Exception {
         this.username = TableBuilder.scrubName(session.getUsername());
         this.domain = session.getDomain();
         this.asUser = session.getAsUser();
         this.locale = session.getLocale();
         this.uuid = session.getId();
         this.installReference = session.getInstallReference();
-        this.auth = auth;
+        this.auth = restoreFactory.getHqAuth();
 
         resolveInstallReference(installReference, appId, host);
         this.engine = installService.configureApplication(this.installReference);
@@ -100,11 +100,11 @@ public class MenuSession {
     }
 
     public MenuSession(String username, String domain, String appId, String installReference, String locale,
-                       InstallService installService, RestoreFactory restoreFactory, HqAuth auth, String host,
+                       InstallService installService, RestoreFactory restoreFactory, String host,
                        boolean oneQuestionPerScreen, String asUser) throws Exception {
         this.username = TableBuilder.scrubName(username);
         this.domain = domain;
-        this.auth = auth;
+        this.auth = restoreFactory.getHqAuth();
         this.appId = appId;
         this.asUser = asUser;
         resolveInstallReference(installReference, appId, host);


### PR DESCRIPTION
HQ Auth was already available through the `RestoreFactory` so instantiating and passing around through methods was unnecessary. 