### PR TITLE
Rollback SQL writes on exception

### DIFF
--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -75,8 +75,11 @@ public class CaseAPIs {
                 restoreFactory.setAutoCommit(true);
                 sandbox.writeSyncToken();
                 return sandbox;
-            } catch (SQLiteRuntimeException e) {
-                if (++counter >= maxRetries) {
+            } catch (InvalidStructureException | SQLiteRuntimeException e) {
+                if (e instanceof InvalidStructureException || ++counter >= maxRetries) {
+                    // Before throwing exception, rollback any changes to relinquish SQLite lock
+                    restoreFactory.rollback();
+                    restoreFactory.setAutoCommit(true);
                     throw e;
                 } else {
                     restoreFactory.getSQLiteDB().deleteDatabaseFile();

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -112,6 +112,14 @@ public class RestoreFactory {
         }
     }
 
+    public void rollback() {
+        try {
+            sqLiteDB.getConnection().rollback();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public SQLiteDB getSQLiteDB() {
         return sqLiteDB;
     }


### PR DESCRIPTION
I * think* this will resolve some of the issues seen [here](https://manage.dimagi.com/default.asp?263442)

I believe that when we encountered certain exceptions (chiefly `InvalidStructureException`) we would error out without closing the SQLite database. This would result in the user being locked out. Until the database was cleared out and could also result in incorrect data being present in the database. 