### PR TITLE
Retry for InvalidStructureException

### DIFF
--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -76,7 +76,7 @@ public class CaseAPIs {
                 sandbox.writeSyncToken();
                 return sandbox;
             } catch (InvalidStructureException | SQLiteRuntimeException e) {
-                if (e instanceof InvalidStructureException || ++counter >= maxRetries) {
+                if (++counter >= maxRetries) {
                     // Before throwing exception, rollback any changes to relinquish SQLite lock
                     restoreFactory.rollback();
                     restoreFactory.setAutoCommit(true);

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -76,15 +76,17 @@ public class CaseAPIs {
                 sandbox.writeSyncToken();
                 return sandbox;
             } catch (InvalidStructureException | SQLiteRuntimeException e) {
+
+                // Before throwing exception, rollback any changes to relinquish SQLite lock
+                restoreFactory.rollback();
+                restoreFactory.setAutoCommit(true);
+                restoreFactory.getSQLiteDB().deleteDatabaseFile();
+                restoreFactory.getSQLiteDB().createDatabaseFolder();
+                
                 if (++counter >= maxRetries) {
-                    // Before throwing exception, rollback any changes to relinquish SQLite lock
-                    restoreFactory.rollback();
-                    restoreFactory.setAutoCommit(true);
-                    restoreFactory.getSQLiteDB().deleteDatabaseFile();
-                    restoreFactory.getSQLiteDB().createDatabaseFolder();
                     throw e;
                 } else {
-                    log.info(String.format("Retrying restore for user %s after receiving exception.",
+                    log.error(String.format("Retrying restore for user %s after receiving exception.",
                             restoreFactory.getEffectiveUsername()),
                             e);
                 }


### PR DESCRIPTION
Oversight, we should retry for `InvalidStructureException`. We should also blow away the databases in both cases.