### PR TITLE
Change how we load up params map into variables

### DIFF
--- a/src/main/java/services/FormplayerFormSendCalloutHandler.java
+++ b/src/main/java/services/FormplayerFormSendCalloutHandler.java
@@ -1,6 +1,5 @@
 package services;
 
-import auth.HqAuth;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
@@ -33,7 +32,9 @@ public class FormplayerFormSendCalloutHandler implements FormSendCalloutHandler 
         ResponseEntity<String> response = null;
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url);
-        builder.buildAndExpand(paramMap);
+        for (String key: paramMap.keySet()) {
+            builder.queryParam(key, paramMap.get(key));
+        }
 
         try {
             response = restTemplate.exchange(


### PR DESCRIPTION
Previous method was loading these as query parameters rather than URL parameters. I must've only tested this with the values loaded directly into the URL.

@ctsims