### PR TITLE
Formplayer to attempt to re-use downloaded CCZ files for install

### DIFF
--- a/src/main/java/engine/FormplayerArchiveFileRoot.java
+++ b/src/main/java/engine/FormplayerArchiveFileRoot.java
@@ -25,8 +25,8 @@ public class FormplayerArchiveFileRoot extends ArchiveFileRoot {
     private int MAX_RECENT = 5;
 
     @Override
-    public String addArchiveFile(ZipFile zip) {
-        String mGUID = super.addArchiveFile(zip);
+    public String addArchiveFile(ZipFile zip, String appId) {
+        String mGUID = super.addArchiveFile(zip, appId);
         redisTemplate.opsForValue().set(
                 String.format("formplayer:archive:%s", mGUID),
                 zip.getName()
@@ -37,15 +37,16 @@ public class FormplayerArchiveFileRoot extends ArchiveFileRoot {
     // Given an encoded path (IE jr://archive/ABC123) return a Reference to be used to access the actual filesystem
     @Override
     public Reference derive(String guidPath) throws InvalidReferenceException {
-        if (guidToFolderMap.containsKey(getGUID(guidPath))) {
-            return new ArchiveFileReference(guidToFolderMap.get(getGUID(guidPath)), getGUID(guidPath), getPath(guidPath));
+        String GUID = getGUID(guidPath);
+        if (guidToFolderMap.containsKey(GUID)) {
+            return new ArchiveFileReference(guidToFolderMap.get(GUID), GUID, getPath(guidPath));
         }
         try {
-            String zipName = redisTemplate.opsForValue().get(String.format("formplayer:archive:%s", getGUID(guidPath)));
-            return new ArchiveFileReference(new ZipFile(zipName), getGUID(guidPath), getPath(guidPath));
+            String zipName = redisTemplate.opsForValue().get(String.format("formplayer:archive:%s", GUID));
+            return new ArchiveFileReference(new ZipFile(zipName), GUID, getPath(guidPath));
         } catch (IOException e) {
             e.printStackTrace();
-            throw new InvalidReferenceException(String.format("Error deriving reference with exception %s."), guidPath);
+            throw new InvalidReferenceException(String.format("Error deriving reference with exception %s.", guidPath), guidPath);
         }
     }
 }

--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -6,20 +6,29 @@ import installers.FormplayerInstallerFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
 import org.commcare.modern.reference.ArchiveFileRoot;
 import org.commcare.modern.reference.JavaHttpRoot;
+import org.commcare.resources.model.InstallCancelledException;
+import org.commcare.resources.model.UnresolvedResourceException;
 import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.io.BufferedInputStream;
 import org.javarosa.core.io.StreamsUtil;
+import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.json.JSONObject;
 
 import java.io.*;
 import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.List;
+import java.util.zip.ZipFile;
 
 /**
  * Created by willpride on 11/22/16.
@@ -34,6 +43,48 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         super(storageFactory, formplayerInstallerFactory);
         this.mArchiveRoot = formplayerArchiveFileRoot;
         ReferenceManager.instance().addReferenceFactory(formplayerArchiveFileRoot);
+    }
+    
+    private String parseAppId(String url) {
+        String appId = null;
+        try {
+            List<NameValuePair> params = new URIBuilder(url).getQueryParams();
+            for (NameValuePair param: params) {
+                if (param.getName().equals("app_id")) {
+                    appId = param.getValue();
+                }
+            }
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+        return appId;
+    }
+
+    @Override
+    public void initFromArchive(String archiveURL) throws InstallCancelledException,
+            UnresolvedResourceException, UnfullfilledRequirementsException {
+        String appId = parseAppId(archiveURL);
+
+        try {
+            mArchiveRoot.derive("jr://archive/" + appId + "/");
+            init("jr://archive/" + appId + "/profile.ccpr");
+            log.info(String.format("Successfully re-used installation CCZ for appId %s", appId));
+            return;
+        } catch (InvalidReferenceException e) {
+            // Expected in many cases, pass
+        }
+
+        String fileName = downloadToTemp(archiveURL);
+        ZipFile zip;
+        try {
+            zip = new ZipFile(fileName);
+        } catch (IOException e) {
+            print.println("File at " + archiveURL + ": is not a valid CommCare Package. Downloaded to: " + fileName);
+            e.printStackTrace(print);
+            return;
+        }
+        String archiveGUID = this.mArchiveRoot.addArchiveFile(zip, appId);
+        init("jr://archive/" + archiveGUID + "/profile.ccpr");
     }
 
     @Override

--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -63,18 +63,22 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
     @Override
     public void initFromArchive(String archiveURL) throws InstallCancelledException,
             UnresolvedResourceException, UnfullfilledRequirementsException {
-        String appId = parseAppId(archiveURL);
-
-        try {
-            mArchiveRoot.derive("jr://archive/" + appId + "/");
-            init("jr://archive/" + appId + "/profile.ccpr");
-            log.info(String.format("Successfully re-used installation CCZ for appId %s", appId));
-            return;
-        } catch (InvalidReferenceException e) {
-            // Expected in many cases, pass
+        String fileName;
+        String appId = null;
+        if (archiveURL.startsWith("http")) {
+            appId = parseAppId(archiveURL);
+            try {
+                mArchiveRoot.derive("jr://archive/" + appId + "/");
+                init("jr://archive/" + appId + "/profile.ccpr");
+                log.info(String.format("Successfully re-used installation CCZ for appId %s", appId));
+                return;
+            } catch (InvalidReferenceException e) {
+                // Expected in many cases, pass
+            }
+            fileName = downloadToTemp(archiveURL);
+        } else {
+            fileName = archiveURL;
         }
-
-        String fileName = downloadToTemp(archiveURL);
         ZipFile zip;
         try {
             zip = new ZipFile(fileName);


### PR DESCRIPTION
This is a pretty nifty refactor wherein app install requests will first check whether the CCZ has already been downloaded to the file system before attempting to download a new copy and re-use that file if so. We accomplish this by updating the `FormplayerArchiveFileRoot` class, which already handled mapping between `jr://` paths and the actual file during install, to use the versioned `app_id` (as passed by the install request URL) of the application as the archive's GUID instead of a randomly generated UUID. Then subsequent requests simply use the FileRoot to check whether a mapping is already available for that UUID in the static mapping or in Redis and re-use the file if so. If the mapping isn't present or it is but the file has been deleted we fail gracefully to the old code path. 

I think there's the potential for pretty significant speed boosts here as well as taking some load off HQ/request IO. 