### PR TITLE
JVM-level locking

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -373,6 +373,12 @@ public abstract class AbstractBaseController {
         return new ExceptionResponseBean("User lock timed out", req.getRequestURL().toString());
     }
 
+    @ExceptionHandler({InterruptedRuntimeException.class})
+    @ResponseBody
+    public ExceptionResponseBean handleInterruptException(FormplayerHttpRequest req, Exception exception) {
+        return new ExceptionResponseBean("Request interrupted, please try again.", req.getRequestURL().toString());
+    }
+
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ExceptionResponseBean handleError(FormplayerHttpRequest req, Exception exception) {

--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -376,7 +376,8 @@ public abstract class AbstractBaseController {
     @ExceptionHandler({InterruptedRuntimeException.class})
     @ResponseBody
     public ExceptionResponseBean handleInterruptException(FormplayerHttpRequest req, Exception exception) {
-        return new ExceptionResponseBean("Request interrupted, please try again.", req.getRequestURL().toString());
+        return new ExceptionResponseBean("An issue prevented us from processing your previous action, please try again",
+                req.getRequestURL().toString());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/application/FormplayerAuthFilter.java
+++ b/src/main/java/application/FormplayerAuthFilter.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import services.FormplayerLockRegistry;
 import services.HqUserDetailsService;
 import util.Constants;
 import util.FormplayerHttpRequest;
@@ -37,7 +38,7 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
     HqUserDetailsService userDetailsService;
 
     @Autowired
-    RedisLockRegistry userLockRegistry;
+    FormplayerLockRegistry userLockRegistry;
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -189,9 +189,8 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     }
 
     @Bean
-    public RedisLockRegistry userLockRegistry() {
-        JedisConnectionFactory jedisConnectionFactory = jedisConnFactory();
-        return new RedisLockRegistry(jedisConnectionFactory, "formplayer-user", Constants.LOCK_DURATION);
+    public FormplayerLockRegistry userLockRegistry() {
+        return new FormplayerLockRegistry();
     }
 
     @Bean

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -9,7 +9,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.commcare.modern.database.TableBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
-import org.springframework.integration.support.locks.LockRegistry;
 import services.CategoryTimingHelper;
 import services.FormplayerLockRegistry;
 import services.FormplayerLockRegistry.FormplayerReentrantLock;
@@ -18,7 +17,6 @@ import util.FormplayerSentry;
 import util.RequestUtils;
 
 import javax.servlet.http.HttpServletRequest;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 

--- a/src/main/java/exceptions/InterruptedRuntimeException.java
+++ b/src/main/java/exceptions/InterruptedRuntimeException.java
@@ -1,0 +1,10 @@
+package exceptions;
+
+/**
+ * Created by willpride on 10/5/17.
+ */
+public class InterruptedRuntimeException extends RuntimeException {
+    public InterruptedRuntimeException(InterruptedException e) {
+        super(e);
+    }
+}

--- a/src/main/java/exceptions/InterruptedRuntimeException.java
+++ b/src/main/java/exceptions/InterruptedRuntimeException.java
@@ -1,7 +1,7 @@
 package exceptions;
 
 /**
- * Created by willpride on 10/5/17.
+ * A RuntimeException to wrap InterruptedException, thrown when Thread is interrupted while sleeping or waiting
  */
 public class InterruptedRuntimeException extends RuntimeException {
     public InterruptedRuntimeException(InterruptedException e) {

--- a/src/main/java/services/FormplayerLockRegistry.java
+++ b/src/main/java/services/FormplayerLockRegistry.java
@@ -1,0 +1,85 @@
+package services;
+
+import org.joda.time.DateTime;
+import org.springframework.integration.support.locks.LockRegistry;
+import org.springframework.util.Assert;
+import util.Constants;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Created by willpride on 11/6/17.
+ */
+public class FormplayerLockRegistry implements LockRegistry {
+
+    private final FormplayerReentrantLock[] lockTable;
+
+    private final int mask;
+
+    public FormplayerLockRegistry() {
+        this(0xFF);
+    }
+
+    public FormplayerLockRegistry(int mask) {
+        String bits = Integer.toBinaryString(mask);
+        Assert.isTrue(bits.length() < 32 && (mask == 0 || bits.lastIndexOf('0') < bits.indexOf('1')), "Mask must be a power of 2 - 1");
+        this.mask = mask;
+        int arraySize = this.mask + 1;
+        this.lockTable = new FormplayerReentrantLock[arraySize];
+        for (int i = 0; i < arraySize; i++) {
+            this.lockTable[i] = new FormplayerReentrantLock();
+        }
+    }
+
+    private FormplayerReentrantLock setNewLock(Integer lockIndex) {
+        this.lockTable[lockIndex] = new FormplayerReentrantLock();
+        return this.lockTable[lockIndex];
+    }
+
+    private boolean threadLives(Thread thread) {
+        Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+        return threadSet.contains(thread);
+    }
+
+    @Override
+    public FormplayerReentrantLock obtain(Object lockKey) {
+        Assert.notNull(lockKey, "'lockKey' must not be null");
+        Integer lockIndex = lockKey.hashCode() & this.mask;
+        FormplayerReentrantLock lock = this.lockTable[lockIndex];
+
+        Thread ownerThread = lock.getOwner();
+
+        if (!threadLives(ownerThread)) {
+            lock = setNewLock(lockIndex);
+        }
+        if (lock.isExpired()) {
+            lock = setNewLock(lockIndex);
+        }
+        return lock;
+    }
+
+    public class FormplayerReentrantLock extends ReentrantLock {
+
+        DateTime lockTime;
+
+        @Override
+        public boolean tryLock(long timeout, TimeUnit unit)
+                throws InterruptedException {
+            boolean obtainedLock = super.tryLock(timeout, unit);
+            if (obtainedLock) {
+                lockTime = new DateTime();
+            }
+            return obtainedLock;
+        }
+
+        public Thread getOwner() {
+            return super.getOwner();
+        }
+
+        public boolean isExpired() {
+            return new DateTime().minusMillis(Constants.LOCK_DURATION).isAfter(lockTime);
+        }
+    }
+}

--- a/src/main/java/services/FormplayerLockRegistry.java
+++ b/src/main/java/services/FormplayerLockRegistry.java
@@ -50,8 +50,10 @@ public class FormplayerLockRegistry implements LockRegistry {
     }
 
     private FormplayerReentrantLock setNewLock(Integer lockIndex) {
-        this.lockTable[lockIndex] = new FormplayerReentrantLock();
-        return this.lockTable[lockIndex];
+        synchronized (this.lockTableLocks[lockIndex]) {
+            this.lockTable[lockIndex] = new FormplayerReentrantLock();
+            return this.lockTable[lockIndex];
+        }
     }
 
     @Override

--- a/src/main/java/services/FormplayerLockRegistry.java
+++ b/src/main/java/services/FormplayerLockRegistry.java
@@ -17,6 +17,9 @@ import java.util.concurrent.locks.ReentrantLock;
 public class FormplayerLockRegistry implements LockRegistry {
 
     private final FormplayerReentrantLock[] lockTable;
+    // Lock objects for accessing the FormplayerReentrantLock table above
+    // These objects do not change
+    private final Object[] lockTableLocks;
 
     private final int mask;
 
@@ -32,8 +35,10 @@ public class FormplayerLockRegistry implements LockRegistry {
         this.mask = mask;
         int arraySize = this.mask + 1;
         this.lockTable = new FormplayerReentrantLock[arraySize];
+        this.lockTableLocks = new Object[arraySize];
         for (int i = 0; i < arraySize; i++) {
             this.lockTable[i] = new FormplayerReentrantLock();
+            this.lockTableLocks[i] = new Object();
         }
     }
 
@@ -51,19 +56,31 @@ public class FormplayerLockRegistry implements LockRegistry {
     public FormplayerReentrantLock obtain(Object lockKey) {
         Assert.notNull(lockKey, "'lockKey' must not be null");
         Integer lockIndex = lockKey.hashCode() & this.mask;
-        FormplayerReentrantLock lock = this.lockTable[lockIndex];
 
-        Thread ownerThread = lock.getOwner();
+        synchronized (this.lockTableLocks[lockIndex]) {
+            FormplayerReentrantLock lock = this.lockTable[lockIndex];
 
-        if (!threadLives(ownerThread)) {
-            log.error(String.format("Evicted dead thread %s owning lockkey %s.", ownerThread, lockKey));
-            lock = setNewLock(lockIndex);
+            Thread ownerThread = lock.getOwner();
+
+            if (!threadLives(ownerThread)) {
+                log.error(String.format("Evicted dead thread %s owning lockkey %s.", ownerThread, lockKey));
+                lock = setNewLock(lockIndex);
+            }
+            if (lock.isExpired()) {
+                log.error(String.format("Evicting thread %s owning expired lock with lock key %s.", ownerThread, lockKey));
+                ownerThread.interrupt();
+                try {
+                    ownerThread.join(5000);
+                } catch (InterruptedException e) {
+                    // TODO WSP can I ignore this?
+                    throw new RuntimeException(e);
+                }
+                ownerThread.stop();
+                log.error(String.format("Evicted thread %s owning expired lock with lock key %s.", ownerThread, lockKey));
+                lock = setNewLock(lockIndex);
+            }
+            return lock;
         }
-        if (lock.isExpired()) {
-            log.error(String.format("Evicted thread %s owning expired lock with lockkey %s.", ownerThread, lockKey));
-            lock = setNewLock(lockIndex);
-        }
-        return lock;
     }
 
     public class FormplayerReentrantLock extends ReentrantLock {

--- a/src/main/java/services/FormplayerLockRegistry.java
+++ b/src/main/java/services/FormplayerLockRegistry.java
@@ -1,5 +1,7 @@
 package services;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.util.Assert;
@@ -17,6 +19,8 @@ public class FormplayerLockRegistry implements LockRegistry {
     private final FormplayerReentrantLock[] lockTable;
 
     private final int mask;
+
+    private final Log log = LogFactory.getLog(FormplayerLockRegistry.class);
 
     public FormplayerLockRegistry() {
         this(0xFF);
@@ -52,9 +56,11 @@ public class FormplayerLockRegistry implements LockRegistry {
         Thread ownerThread = lock.getOwner();
 
         if (!threadLives(ownerThread)) {
+            log.error(String.format("Evicted dead thread %s owning lockkey %s.", ownerThread, lockKey));
             lock = setNewLock(lockIndex);
         }
         if (lock.isExpired()) {
+            log.error(String.format("Evicted thread %s owning expired lock with lockkey %s.", ownerThread, lockKey));
             lock = setNewLock(lockIndex);
         }
         return lock;


### PR DESCRIPTION
Move locking off of Redis and onto the JVM since we know user requests are on one machine

Also add ability to evict locks owned by dead threads