### PR TITLE
Fold most CaseAPIs fucntionality into RestoreFactory

### DIFF
--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -194,6 +194,7 @@ public class MenuController extends AbstractBaseController {
 
         categoryTimingHelper.recordCategoryTiming(appInstallTiming, Constants.TimingCategories.APP_INSTALL);
         categoryTimingHelper.recordCategoryTiming(menuSession.getPurgeCasesTiming(), Constants.TimingCategories.PURGE_CASES);
+        categoryTimingHelper.recordCategoryTiming(menuSession.getParseRestoreTiming(), Constants.TimingCategories.PARSE_RESTORE);
         BaseResponseBean response = advanceSessionWithSelections(
                 menuSession,
                 selections,

--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -399,7 +399,7 @@ public class MenuController extends AbstractBaseController {
             return new NotificationMessage("Session error, expected sync block but didn't get one.", true);
         }
         if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            CaseAPIs.performSync(restoreFactory);
+            restoreFactory.performTimedSync();
             return new NotificationMessage("Case claim successful.", false);
         } else {
             return new NotificationMessage(

--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -185,16 +185,7 @@ public class MenuController extends AbstractBaseController {
                                                     @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
         String[] selections = sessionNavigationBean.getSelections();
         MenuSession menuSession;
-        SimpleTimer timer = new SimpleTimer();
-        timer.start();
         menuSession = getMenuSessionFromBean(sessionNavigationBean, authToken);
-        timer.end();
-
-        Timing appInstallTiming = Timing.constant(timer.durationInMs() - menuSession.getPurgeCasesTiming().durationInMs());
-
-        categoryTimingHelper.recordCategoryTiming(appInstallTiming, Constants.TimingCategories.APP_INSTALL);
-        categoryTimingHelper.recordCategoryTiming(menuSession.getPurgeCasesTiming(), Constants.TimingCategories.PURGE_CASES);
-        categoryTimingHelper.recordCategoryTiming(menuSession.getParseRestoreTiming(), Constants.TimingCategories.PARSE_RESTORE);
         BaseResponseBean response = advanceSessionWithSelections(
                 menuSession,
                 selections,

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -44,8 +44,7 @@ public class UtilController extends AbstractBaseController {
     @UserRestore
     public SyncDbResponseBean syncUserDb(@RequestBody SyncDbRequestBean syncRequest,
                                          @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
-        Timing purgeCasesTiming = CaseAPIs.performTimedSync(restoreFactory).getPurgeCasesTimer();
-        categoryTimingHelper.recordCategoryTiming(purgeCasesTiming, Constants.TimingCategories.PURGE_CASES);
+        restoreFactory.performTimedSync();
         return new SyncDbResponseBean();
     }
 

--- a/src/main/java/aspects/UserRestoreAspect.java
+++ b/src/main/java/aspects/UserRestoreAspect.java
@@ -52,12 +52,17 @@ public class UserRestoreAspect {
         restoreFactory.configure((AuthenticatedRequestBean)args[0], auth, requestBean.getUseLiveQuery());
 
         Timing purgeCasesTiming;
+        Timing parseRestoreTiming;
         if (requestBean.isMustRestore()) {
-            purgeCasesTiming = CaseAPIs.performTimedSync(restoreFactory).getPurgeCasesTimer();
+            CaseAPIs.TimedSyncResult syncResult = CaseAPIs.performTimedSync(restoreFactory);
+            purgeCasesTiming = syncResult.getPurgeCasesTimer();
+            parseRestoreTiming = syncResult.getParseRestoreTimer();
         } else {
             purgeCasesTiming = Timing.constant(0);
+            parseRestoreTiming = Timing.constant(0);
         }
         categoryTimingHelper.recordCategoryTiming(purgeCasesTiming, Constants.TimingCategories.PURGE_CASES);
+        categoryTimingHelper.recordCategoryTiming(parseRestoreTiming, Constants.TimingCategories.PARSE_RESTORE);
     }
 
     private HqAuth getAuthHeaders(String domain, String username, String sessionToken) {

--- a/src/main/java/aspects/UserRestoreAspect.java
+++ b/src/main/java/aspects/UserRestoreAspect.java
@@ -51,18 +51,9 @@ public class UserRestoreAspect {
         HqAuth auth = getAuthHeaders(requestBean.getDomain(), requestBean.getUsername(), (String) args[1]);
         restoreFactory.configure((AuthenticatedRequestBean)args[0], auth, requestBean.getUseLiveQuery());
 
-        Timing purgeCasesTiming;
-        Timing parseRestoreTiming;
         if (requestBean.isMustRestore()) {
-            CaseAPIs.TimedSyncResult syncResult = CaseAPIs.performTimedSync(restoreFactory);
-            purgeCasesTiming = syncResult.getPurgeCasesTimer();
-            parseRestoreTiming = syncResult.getParseRestoreTimer();
-        } else {
-            purgeCasesTiming = Timing.constant(0);
-            parseRestoreTiming = Timing.constant(0);
+            restoreFactory.performTimedSync();
         }
-        categoryTimingHelper.recordCategoryTiming(purgeCasesTiming, Constants.TimingCategories.PURGE_CASES);
-        categoryTimingHelper.recordCategoryTiming(parseRestoreTiming, Constants.TimingCategories.PARSE_RESTORE);
     }
 
     private HqAuth getAuthHeaders(String domain, String username, String sessionToken) {

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -1,31 +1,10 @@
 package hq;
 
-import api.process.FormRecordProcessorHelper;
 import beans.CaseBean;
-import engine.FormplayerTransactionParserFactory;
-import exceptions.SQLiteRuntimeException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.cases.model.Case;
-import org.commcare.core.parse.ParseUtils;
-import org.commcare.modern.database.TableBuilder;
-import org.javarosa.core.api.ClassNameHasher;
-import org.javarosa.core.model.User;
-import org.javarosa.core.services.storage.IStorageIterator;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.javarosa.xml.util.InvalidStructureException;
-import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.sqlite.SQLiteException;
-import org.xmlpull.v1.XmlPullParserException;
 import sandbox.SqliteIndexedStorageUtility;
-import sandbox.UserSqlSandbox;
-import services.RestoreFactory;
-import util.SimpleTimer;
-import util.UserUtils;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.sql.SQLException;
 
 /**
  * Created by willpride on 1/7/16.
@@ -34,94 +13,8 @@ public class CaseAPIs {
 
     private static final Log log = LogFactory.getLog(CaseAPIs.class);
 
-    public static class TimedSyncResult {
-        private UserSqlSandbox sandbox;
-        private SimpleTimer purgeCasesTimer;
-        private SimpleTimer parseRestoreTimer;
-
-        private TimedSyncResult(UserSqlSandbox sandbox, SimpleTimer parseRestoreTimer, SimpleTimer purgeCasesTimer) {
-            this.sandbox = sandbox;
-            this.purgeCasesTimer = purgeCasesTimer;
-            this.parseRestoreTimer = parseRestoreTimer;
-        }
-
-        public UserSqlSandbox getSandbox() {
-            return sandbox;
-        }
-
-        public SimpleTimer getPurgeCasesTimer() {
-            return purgeCasesTimer;
-        }
-
-        public SimpleTimer getParseRestoreTimer() {return parseRestoreTimer;}
-    }
-
-    public static UserSqlSandbox performSync(RestoreFactory restoreFactory) throws Exception {
-        return performTimedSync(restoreFactory).getSandbox();
-    }
-
-    // This function will only wipe user DBs when they have expired, otherwise will incremental sync
-    public static TimedSyncResult performTimedSync(RestoreFactory restoreFactory) throws Exception {
-        // Create parent dirs if needed
-        if(restoreFactory.getSqlSandbox().getLoggedInUser() != null){
-            restoreFactory.getSQLiteDB().createDatabaseFolder();
-        }
-        SimpleTimer parseTimer = new SimpleTimer();
-        parseTimer.start();
-        UserSqlSandbox sandbox = restoreUser(restoreFactory);
-        parseTimer.end();
-        SimpleTimer purgeTimer = new SimpleTimer();
-        purgeTimer.start();
-        FormRecordProcessorHelper.purgeCases(sandbox);
-        purgeTimer.end();
-        return new TimedSyncResult(sandbox, parseTimer, purgeTimer);
-    }
-
-    // This function will attempt to get the user DBs without syncing if they exist, sync if not
-    public static UserSqlSandbox getSandbox(RestoreFactory restoreFactory) throws Exception {
-        if(restoreFactory.getSqlSandbox().getLoggedInUser() != null
-                && !restoreFactory.isRestoreXmlExpired()){
-            return restoreFactory.getSqlSandbox();
-        } else {
-            restoreFactory.getSQLiteDB().createDatabaseFolder();
-            return restoreUser(restoreFactory);
-        }
-    }
-
     public static CaseBean getFullCase(String caseId, SqliteIndexedStorageUtility<Case> caseStorage){
         Case cCase = caseStorage.getRecordForValue("case-id", caseId);
         return new CaseBean(cCase);
-    }
-
-    private static UserSqlSandbox restoreUser(RestoreFactory restoreFactory) throws
-            UnfullfilledRequirementsException, InvalidStructureException, IOException, XmlPullParserException {
-        PrototypeFactory.setStaticHasher(new ClassNameHasher());
-        int maxRetries = 2;
-        int counter = 0;
-        while (true) {
-            try {
-                UserSqlSandbox sandbox = restoreFactory.getSqlSandbox();
-                FormplayerTransactionParserFactory factory = new FormplayerTransactionParserFactory(sandbox, true);
-                restoreFactory.setAutoCommit(false);
-                ParseUtils.parseIntoSandbox(restoreFactory.getRestoreXml(), factory, true, true);
-                restoreFactory.commit();
-                restoreFactory.setAutoCommit(true);
-                sandbox.writeSyncToken();
-                return sandbox;
-            } catch (InvalidStructureException | SQLiteRuntimeException e) {
-                if (e instanceof InvalidStructureException || ++counter >= maxRetries) {
-                    // Before throwing exception, rollback any changes to relinquish SQLite lock
-                    restoreFactory.rollback();
-                    restoreFactory.setAutoCommit(true);
-                    restoreFactory.getSQLiteDB().deleteDatabaseFile();
-                    restoreFactory.getSQLiteDB().createDatabaseFolder();
-                    throw e;
-                } else {
-                    log.info(String.format("Retrying restore for user %s after receiving exception.",
-                            restoreFactory.getEffectiveUsername()),
-                            e);
-                }
-            }
-        }
     }
 }

--- a/src/main/java/hq/CaseAPIs.java
+++ b/src/main/java/hq/CaseAPIs.java
@@ -37,10 +37,12 @@ public class CaseAPIs {
     public static class TimedSyncResult {
         private UserSqlSandbox sandbox;
         private SimpleTimer purgeCasesTimer;
+        private SimpleTimer parseRestoreTimer;
 
-        private TimedSyncResult(UserSqlSandbox sandbox, SimpleTimer purgeCasesTimer) {
+        private TimedSyncResult(UserSqlSandbox sandbox, SimpleTimer parseRestoreTimer, SimpleTimer purgeCasesTimer) {
             this.sandbox = sandbox;
             this.purgeCasesTimer = purgeCasesTimer;
+            this.parseRestoreTimer = parseRestoreTimer;
         }
 
         public UserSqlSandbox getSandbox() {
@@ -50,6 +52,8 @@ public class CaseAPIs {
         public SimpleTimer getPurgeCasesTimer() {
             return purgeCasesTimer;
         }
+
+        public SimpleTimer getParseRestoreTimer() {return parseRestoreTimer;}
     }
 
     public static UserSqlSandbox performSync(RestoreFactory restoreFactory) throws Exception {
@@ -62,12 +66,15 @@ public class CaseAPIs {
         if(restoreFactory.getSqlSandbox().getLoggedInUser() != null){
             restoreFactory.getSQLiteDB().createDatabaseFolder();
         }
+        SimpleTimer parseTimer = new SimpleTimer();
+        parseTimer.start();
         UserSqlSandbox sandbox = restoreUser(restoreFactory);
-        SimpleTimer timer = new SimpleTimer();
-        timer.start();
+        parseTimer.end();
+        SimpleTimer purgeTimer = new SimpleTimer();
+        purgeTimer.start();
         FormRecordProcessorHelper.purgeCases(sandbox);
-        timer.end();
-        return new TimedSyncResult(sandbox, timer);
+        purgeTimer.end();
+        return new TimedSyncResult(sandbox, parseTimer, purgeTimer);
     }
 
     // This function will attempt to get the user DBs without syncing if they exist, sync if not

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -45,13 +45,7 @@ public class NewFormResponseFactory {
     public NewFormResponse getResponse(NewSessionRequestBean bean, String postUrl) throws Exception {
 
         String formXml = getFormXml(bean.getFormUrl());
-        CaseAPIs.TimedSyncResult timedSyncResult = CaseAPIs.performTimedSync(restoreFactory);
-        UserSqlSandbox sandbox = timedSyncResult.getSandbox();
-        SimpleTimer purgeCasesTimer = timedSyncResult.getPurgeCasesTimer();
-        SimpleTimer parseRestoreTimer = timedSyncResult.getParseRestoreTimer();
-
-        categoryTimingHelper.recordCategoryTiming(purgeCasesTimer, Constants.TimingCategories.PURGE_CASES);
-        categoryTimingHelper.recordCategoryTiming(parseRestoreTimer, Constants.TimingCategories.PARSE_RESTORE);
+        UserSqlSandbox sandbox = restoreFactory.performTimedSync();
 
         FormSession formSession = new FormSession(
                 sandbox,

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -48,8 +48,10 @@ public class NewFormResponseFactory {
         CaseAPIs.TimedSyncResult timedSyncResult = CaseAPIs.performTimedSync(restoreFactory);
         UserSqlSandbox sandbox = timedSyncResult.getSandbox();
         SimpleTimer purgeCasesTimer = timedSyncResult.getPurgeCasesTimer();
+        SimpleTimer parseRestoreTimer = timedSyncResult.getParseRestoreTimer();
 
         categoryTimingHelper.recordCategoryTiming(purgeCasesTimer, Constants.TimingCategories.PURGE_CASES);
+        categoryTimingHelper.recordCategoryTiming(parseRestoreTimer, Constants.TimingCategories.PARSE_RESTORE);
 
         FormSession formSession = new FormSession(
                 sandbox,

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -1,14 +1,24 @@
 package services;
 
+import api.process.FormRecordProcessorHelper;
 import auth.HqAuth;
 import beans.AuthenticatedRequestBean;
+import beans.CaseBean;
+import engine.FormplayerTransactionParserFactory;
 import exceptions.AsyncRetryException;
+import exceptions.SQLiteRuntimeException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.commcare.cases.model.Case;
+import org.commcare.core.parse.ParseUtils;
 import org.commcare.modern.database.TableBuilder;
+import org.javarosa.core.api.ClassNameHasher;
 import org.javarosa.core.model.User;
 import org.javarosa.core.services.PropertyManager;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -24,6 +34,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import org.xmlpull.v1.XmlPullParserException;
 import sandbox.AbstractSqlIterator;
 import sandbox.SqliteIndexedStorageUtility;
 import sandbox.UserSqlSandbox;
@@ -94,6 +105,72 @@ public class RestoreFactory {
         sqLiteDB = new UserDB(domain, username, asUsername);
         log.info(String.format("configuring RestoreFactory with arguments " +
                 "username = %s, asUsername = %s, domain = %s, useLiveQuery = %s", username, asUsername, domain, useLiveQuery));
+    }
+
+    public UserSqlSandbox performSync() throws Exception {
+        return performTimedSync();
+    }
+
+    // This function will only wipe user DBs when they have expired, otherwise will incremental sync
+    public UserSqlSandbox performTimedSync() throws Exception {
+        // Create parent dirs if needed
+        if(getSqlSandbox().getLoggedInUser() != null){
+            getSQLiteDB().createDatabaseFolder();
+        }
+        UserSqlSandbox sandbox = restoreUser();
+        SimpleTimer purgeTimer = new SimpleTimer();
+        purgeTimer.start();
+        FormRecordProcessorHelper.purgeCases(sandbox);
+        purgeTimer.end();
+        categoryTimingHelper.recordCategoryTiming(purgeTimer, Constants.TimingCategories.PURGE_CASES);
+        return sandbox;
+    }
+
+    // This function will attempt to get the user DBs without syncing if they exist, sync if not
+    public UserSqlSandbox getSandbox() throws Exception {
+        if(getSqlSandbox().getLoggedInUser() != null
+                && !isRestoreXmlExpired()){
+            return getSqlSandbox();
+        } else {
+            getSQLiteDB().createDatabaseFolder();
+            return restoreUser();
+        }
+    }
+
+    private UserSqlSandbox restoreUser() throws
+            UnfullfilledRequirementsException, InvalidStructureException, IOException, XmlPullParserException {
+        PrototypeFactory.setStaticHasher(new ClassNameHasher());
+        int maxRetries = 2;
+        int counter = 0;
+        while (true) {
+            try {
+                UserSqlSandbox sandbox = getSqlSandbox();
+                SimpleTimer parseTimer = new SimpleTimer();
+                parseTimer.start();
+                FormplayerTransactionParserFactory factory = new FormplayerTransactionParserFactory(sandbox, true);
+                setAutoCommit(false);
+                ParseUtils.parseIntoSandbox(getRestoreXml(), factory, true, true);
+                commit();
+                setAutoCommit(true);
+                parseTimer.end();
+                categoryTimingHelper.recordCategoryTiming(parseTimer, Constants.TimingCategories.PARSE_RESTORE);
+                sandbox.writeSyncToken();
+                return sandbox;
+            } catch (InvalidStructureException | SQLiteRuntimeException e) {
+                if (e instanceof InvalidStructureException || ++counter >= maxRetries) {
+                    // Before throwing exception, rollback any changes to relinquish SQLite lock
+                    rollback();
+                    setAutoCommit(true);
+                    getSQLiteDB().deleteDatabaseFile();
+                    getSQLiteDB().createDatabaseFolder();
+                    throw e;
+                } else {
+                    log.info(String.format("Retrying restore for user %s after receiving exception.",
+                            getEffectiveUsername()),
+                            e);
+                }
+            }
+        }
     }
 
     public UserSqlSandbox getSqlSandbox() {
@@ -353,6 +430,7 @@ public class RestoreFactory {
         }
         return builder.toString();
     }
+
 
     public String getUsername() {
         return username;

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -107,10 +107,6 @@ public class RestoreFactory {
                 "username = %s, asUsername = %s, domain = %s, useLiveQuery = %s", username, asUsername, domain, useLiveQuery));
     }
 
-    public UserSqlSandbox performSync() throws Exception {
-        return performTimedSync();
-    }
-
     // This function will only wipe user DBs when they have expired, otherwise will incremental sync
     public UserSqlSandbox performTimedSync() throws Exception {
         // Create parent dirs if needed

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -102,7 +102,7 @@ public class FormSession {
         this.asUser = session.getAsUser();
         this.appId = session.getAppId();
         this.domain = session.getDomain();
-        this.sandbox = CaseAPIs.getSandbox(restoreFactory);
+        this.sandbox = restoreFactory.getSandbox();
         this.postUrl = session.getPostUrl();
         this.sessionData = session.getSessionData();
         this.oneQuestionPerScreen = session.getOneQuestionPerScreen();

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -32,10 +32,7 @@ import screens.FormplayerQueryScreen;
 import screens.FormplayerSyncScreen;
 import services.InstallService;
 import services.RestoreFactory;
-import util.Constants;
-import util.SessionUtils;
-import util.StringUtils;
-import util.Timing;
+import util.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -76,6 +73,7 @@ public class MenuSession {
     ArrayList<String> titles;
 
     private Timing purgeCasesTiming = Timing.constant(0);
+    private Timing parseRestoreTiming = Timing.constant(0);
 
     public MenuSession(SerializableMenuSession session, InstallService installService,
                        RestoreFactory restoreFactory, String host) throws Exception {
@@ -112,6 +110,7 @@ public class MenuSession {
             CaseAPIs.TimedSyncResult timedSyncResult = CaseAPIs.performTimedSync(restoreFactory);
             this.sandbox = timedSyncResult.getSandbox();
             this.purgeCasesTiming = timedSyncResult.getPurgeCasesTimer();
+            this.parseRestoreTiming = timedSyncResult.getParseRestoreTimer();
         }
         this.sandbox = CaseAPIs.getSandbox(restoreFactory);
         this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox);
@@ -364,5 +363,9 @@ public class MenuSession {
 
     public Timing getPurgeCasesTiming() {
         return purgeCasesTiming;
+    }
+
+    public Timing getParseRestoreTiming() {
+        return parseRestoreTiming;
     }
 }

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -72,9 +72,6 @@ public class MenuSession {
     private boolean oneQuestionPerScreen;
     ArrayList<String> titles;
 
-    private Timing purgeCasesTiming = Timing.constant(0);
-    private Timing parseRestoreTiming = Timing.constant(0);
-
     public MenuSession(SerializableMenuSession session, InstallService installService,
                        RestoreFactory restoreFactory, String host) throws Exception {
         this.username = TableBuilder.scrubName(session.getUsername());
@@ -356,13 +353,5 @@ public class MenuSession {
         String[] ret = new String[titles.size()];
         titles.toArray(ret);
         return ret;
-    }
-
-    public Timing getPurgeCasesTiming() {
-        return purgeCasesTiming;
-    }
-
-    public Timing getParseRestoreTiming() {
-        return parseRestoreTiming;
     }
 }

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -85,7 +85,7 @@ public class MenuSession {
         this.installReference = session.getInstallReference();
         resolveInstallReference(installReference, appId, host);
         this.engine = installService.configureApplication(this.installReference).first;
-        this.sandbox = CaseAPIs.getSandbox(restoreFactory);
+        this.sandbox = restoreFactory.getSandbox();
         this.sessionWrapper = new FormplayerSessionWrapper(deserializeSession(engine.getPlatform(), session.getCommcareSession()),
                 engine.getPlatform(), sandbox);
         SessionUtils.setLocale(this.locale);
@@ -107,12 +107,9 @@ public class MenuSession {
         Pair<FormplayerConfigEngine, Boolean> install = installService.configureApplication(this.installReference);
         this.engine = install.first;
         if (install.second && !preview) {
-            CaseAPIs.TimedSyncResult timedSyncResult = CaseAPIs.performTimedSync(restoreFactory);
-            this.sandbox = timedSyncResult.getSandbox();
-            this.purgeCasesTiming = timedSyncResult.getPurgeCasesTimer();
-            this.parseRestoreTiming = timedSyncResult.getParseRestoreTimer();
+            this.sandbox = restoreFactory.performTimedSync();
         }
-        this.sandbox = CaseAPIs.getSandbox(restoreFactory);
+        this.sandbox = restoreFactory.getSandbox();
         this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox);
         this.locale = locale;
         SessionUtils.setLocale(this.locale);

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -108,6 +108,8 @@ public class Constants {
         public static final String SUBMIT_FORM_TO_HQ = "submit_form_to_hq";
         public static final String APP_INSTALL = "app_install";
         public static final String PURGE_CASES = "purge_cases";
+        public static final String PARSE_RESTORE = "parse_restore";
+        public static final String DOWNLOAD_RESTORE = "download_restore";
     }
 
     // Errors


### PR DESCRIPTION
After dealing with the timing objects in https://github.com/dimagi/formplayer/pull/523 decided it might be better just to centralize this logic in the `RestoreFactory` where we already have the `CategoriesTiming` class Autowired. Downside is this makes `RestoreFactory` even more of a god class. I think the upside is worth it though; removing the whole `SyncTimings` class, removing the un-DRY calls to `recordTimings`. The CaseAPIs static functions all took a `RestoreFactory` as an argument anyways which just seems silly/un-static.