### PR TITLE
Remove dependecies from commcare-core, exlude jmh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ ext {
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+idea {
+    module {
+        excludeDirs += [file("libs/commcare/src/jmh")]
+    }
+}
+
 dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot', version: '1.4.3.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '1.4.3.RELEASE'
@@ -44,11 +50,8 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '1.4.3.RELEASE'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.8.6'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.6'
-    compile 'com.carrotsearch:hppc:0.7.2'
     compile group: 'io.sentry', name: 'sentry', version: '1.5.6'
     compile("org.apache.directory.studio:org.apache.commons.io:2.0.1")
-    compile 'net.sf.kxml:kxml2:2.3.0'
-    compile 'xpp3:xpp3:1.1.4c'
     compile 'org.json:json:20131018'
     compile 'redis.clients:jedis:2.8.0'
     compile 'org.apache.commons:commons-pool2:2.4.2'
@@ -71,8 +74,6 @@ dependencies {
     compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
     compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '4.3.9.RELEASE'
     compile 'org.xerial:sqlite-jdbc:3.16.1'
-    compile group: 'joda-time', name: 'joda-time', version: '2.9.9'
-    compile group: 'regexp', name: 'regexp', version: '1.3'
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
     compile project(path: ':commcare', configuration: 'translate')
@@ -80,7 +81,6 @@ dependencies {
     testCompile("org.springframework.boot:spring-boot-starter-test:1.4.3.RELEASE")
     testCompile("com.jayway.jsonpath:json-path:2.2.0")
     testCompile("com.jayway.jsonpath:json-path-assert:2.2.0")
-    testCompile 'com.carrotsearch:hppc:0.7.2'
     testRuntime("org.skyscreamer:jsonassert:1.4.0")
 }
 


### PR DESCRIPTION
@amstone326 This codifies some of the IDE changes we had to make in Gradle. Specifically

1. Exclude `jmh` directory in `commcare-core`
2. Defer to `commcare-core` library versions

@dannyroberts should clear up recurring `regex.me` dependency issue