### PR TITLE
Only restore once

### DIFF
--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -93,6 +93,7 @@ public class RestoreFactory {
 
     private SQLiteDB sqLiteDB = new SQLiteDB(null);
     private boolean useLiveQuery;
+    private boolean hasRestored;
 
     public void configure(AuthenticatedRequestBean authenticatedRequestBean, HqAuth auth, boolean useLiveQuery) {
         this.setUsername(authenticatedRequestBean.getUsername());
@@ -100,6 +101,7 @@ public class RestoreFactory {
         this.setAsUsername(authenticatedRequestBean.getRestoreAs());
         this.setHqAuth(auth);
         this.setUseLiveQuery(useLiveQuery);
+        this.hasRestored = false;
         sqLiteDB = new UserDB(domain, username, asUsername);
         log.info(String.format("configuring RestoreFactory with arguments " +
                 "username = %s, asUsername = %s, domain = %s, useLiveQuery = %s", username, asUsername, domain, useLiveQuery));
@@ -145,6 +147,7 @@ public class RestoreFactory {
                 InputStream restoreStream = getRestoreXml();
                 setAutoCommit(false);
                 ParseUtils.parseIntoSandbox(restoreStream, factory, true, true);
+                hasRestored = true;
                 commit();
                 setAutoCommit(true);
                 parseTimer.end();
@@ -465,5 +468,9 @@ public class RestoreFactory {
 
     public void setUseLiveQuery(boolean useLiveQuery) {
         this.useLiveQuery = useLiveQuery;
+    }
+
+    public boolean getHasRestored() {
+        return hasRestored;
     }
 }

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -103,7 +103,7 @@ public class MenuSession {
         resolveInstallReference(installReference, appId, host);
         Pair<FormplayerConfigEngine, Boolean> install = installService.configureApplication(this.installReference);
         this.engine = install.first;
-        if (install.second && !preview) {
+        if (install.second && !preview && !restoreFactory.getHasRestored()) {
             this.sandbox = restoreFactory.performTimedSync();
         }
         this.sandbox = restoreFactory.getSandbox();


### PR DESCRIPTION
Ugly, but the code [here](https://github.com/dimagi/formplayer/blob/b26414f48500e0243dc9db4e6d84970a1c09ec6e/src/main/java/session/MenuSession.java#L107-L107) that enforced a sync every time a new application was installed conflicted with the `mustRestore` param [here](https://github.com/dimagi/formplayer/blob/80dec1294b6510ed82e93f3bd94240a79492355d/src/main/java/aspects/UserRestoreAspect.java#L55-L55) added to ensure a sync happens after case claim. This was resulting in a sync being kicked off twice on requests that were asyncronous *and* the triggered the installation of a new application. Haven't worked out all the details yet, but this tripped out my local environment when I got it reproducing. 