### PR TITLE
Don't re-use CCZ for Preview Mode

### DIFF
--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -71,7 +71,7 @@ public class MenuController extends AbstractBaseController {
     @AppInstall
     public BaseResponseBean installRequest(@RequestBody InstallRequestBean installRequestBean,
                                            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
-        return getNextMenu(performInstall(installRequestBean, authToken));
+        return getNextMenu(performInstall(installRequestBean));
     }
 
     @ApiOperation(value = "Update the application at the given reference")
@@ -81,7 +81,7 @@ public class MenuController extends AbstractBaseController {
     @AppInstall
     public BaseResponseBean updateRequest(@RequestBody UpdateRequestBean updateRequestBean,
                                           @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
-        MenuSession updatedSession = performUpdate(updateRequestBean, authToken);
+        MenuSession updatedSession = performUpdate(updateRequestBean);
         if (updateRequestBean.getSessionId() != null) {
             // Try restoring the old session, fail gracefully.
             try {
@@ -214,7 +214,7 @@ public class MenuController extends AbstractBaseController {
             if (sessionNavigationBean.getPreviewCommand() != null) {
                 menuSession = handlePreviewCommand(sessionNavigationBean, authToken);
             } else {
-                menuSession = performInstall(sessionNavigationBean, authToken);
+                menuSession = performInstall(sessionNavigationBean);
             }
         }
         return menuSession;
@@ -321,7 +321,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getRestoreAs(),
                 sessionNavigationBean.getAppId()
         ).deleteDatabaseFolder();
-        menuSession = performInstall(sessionNavigationBean, authToken);
+        menuSession = performInstall(sessionNavigationBean);
         try {
             menuSession.getSessionWrapper().setCommand(sessionNavigationBean.getPreviewCommand());
             menuSession.updateScreen();
@@ -412,7 +412,7 @@ public class MenuController extends AbstractBaseController {
         return newSelections;
     }
 
-    private MenuSession performInstall(InstallRequestBean bean, String authToken) throws Exception {
+    private MenuSession performInstall(InstallRequestBean bean) throws Exception {
         if ((bean.getAppId() == null || "".equals(bean.getAppId())) &&
                 bean.getInstallReference() == null || "".equals(bean.getInstallReference())) {
             throw new RuntimeException("Either app_id or installReference must be non-null.");
@@ -433,8 +433,8 @@ public class MenuController extends AbstractBaseController {
         );
     }
 
-    private MenuSession performUpdate(UpdateRequestBean updateRequestBean, String authToken) throws Exception {
-        MenuSession currentSession = performInstall(updateRequestBean, authToken);
+    private MenuSession performUpdate(UpdateRequestBean updateRequestBean) throws Exception {
+        MenuSession currentSession = performInstall(updateRequestBean);
         currentSession.updateApp(updateRequestBean.getUpdateMode());
         return currentSession;
     }

--- a/src/main/java/db/migration/V15__add_preview_menu_session.java
+++ b/src/main/java/db/migration/V15__add_preview_menu_session.java
@@ -1,0 +1,15 @@
+package db.migration;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Created by willpride on 11/9/17.
+ */
+public class V15__add_preview_menu_session implements SpringJdbcMigration {
+    @Override
+    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+        jdbcTemplate.execute("ALTER TABLE menu_sessions " +
+                "ADD preview boolean DEFAULT false");
+    }
+}

--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -63,20 +63,25 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
     @Override
     public void initFromArchive(String archiveURL) throws InstallCancelledException,
             UnresolvedResourceException, UnfullfilledRequirementsException {
+        initFromArchive(archiveURL, false);
+    }
+
+    public void initFromArchive(String archiveURL, boolean preview) throws InstallCancelledException,
+            UnresolvedResourceException, UnfullfilledRequirementsException {
         String fileName;
         String appId = null;
         if (archiveURL.startsWith("http")) {
             appId = parseAppId(archiveURL);
-            // Comment out for now - this breaks Live Preview updates :/
-            /*
-            try {
-                mArchiveRoot.derive("jr://archive/" + appId + "/");
-                init("jr://archive/" + appId + "/profile.ccpr");
-                log.info(String.format("Successfully re-used installation CCZ for appId %s", appId));
-                return;
-            } catch (InvalidReferenceException e) {
-                // Expected in many cases, pass
-            }*/
+            if (!preview) {
+                try {
+                    mArchiveRoot.derive("jr://archive/" + appId + "/");
+                    init("jr://archive/" + appId + "/profile.ccpr");
+                    log.info(String.format("Successfully re-used installation CCZ for appId %s", appId));
+                    return;
+                } catch (InvalidReferenceException e) {
+                    // Expected in many cases, pass
+                }
+            }
             fileName = downloadToTemp(archiveURL);
         } else {
             fileName = archiveURL;

--- a/src/main/java/repo/SerializableMenuSession.java
+++ b/src/main/java/repo/SerializableMenuSession.java
@@ -16,6 +16,7 @@ public class SerializableMenuSession {
     private byte[] commcareSession;
     private String asUser;
     private boolean oneQuestionPerScreen;
+    private boolean preview;
 
     public SerializableMenuSession(){}
 
@@ -29,13 +30,14 @@ public class SerializableMenuSession {
         this.commcareSession = session.getCommcareSession();
         this.asUser = session.getAsUser();
         this.oneQuestionPerScreen = session.isOneQuestionPerScreen();
+        this.preview = session.getPreview();
 
     }
 
     public SerializableMenuSession(String id, String username, String domain, String appId,
                                    String installReference, String locale, byte[] commcareSession,
                                    boolean oneQuestionPerScreen,
-                                   String asUser){
+                                   String asUser, boolean preview){
         this.uuid = id;
         this.username = username;
         this.domain = domain;
@@ -45,6 +47,7 @@ public class SerializableMenuSession {
         this.commcareSession = commcareSession;
         this.asUser = asUser;
         this.oneQuestionPerScreen = oneQuestionPerScreen;
+        this.preview = preview;
     }
 
     public String getId() {
@@ -123,5 +126,13 @@ public class SerializableMenuSession {
 
     public void setOneQuestionPerScreen(boolean oneQuestionPerScreen) {
         this.oneQuestionPerScreen = oneQuestionPerScreen;
+    }
+
+    public boolean getPreview() {
+        return preview;
+    }
+
+    public void setPreview(boolean preview) {
+        this.preview = preview;
     }
 }

--- a/src/main/java/repo/impl/PostgresMenuSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresMenuSessionRepo.java
@@ -56,13 +56,13 @@ public class PostgresMenuSessionRepo implements MenuSessionRepo {
 
         String query = replaceTableName("INSERT into %s " +
                 "(id, username, domain, appid, " +
-                "installreference, locale, commcaresession, asUser) " +
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+                "installreference, locale, commcaresession, asUser, preview) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
         this.jdbcTemplate.update(query,  new Object[] {session.getId(), session.getUsername(), session.getDomain(),
                 session.getAppId(), session.getInstallReference(), session.getLocale(), session.getCommcareSession(),
-        session.getAsUser()}, new int[] {
+        session.getAsUser(), session.getPreview()}, new int[] {
                 Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                Types.VARCHAR, Types.VARCHAR, Types.BINARY, Types.VARCHAR});
+                Types.VARCHAR, Types.VARCHAR, Types.BINARY, Types.VARCHAR, Types.BOOLEAN});
         return session;
     }
 
@@ -149,7 +149,8 @@ public class PostgresMenuSessionRepo implements MenuSessionRepo {
                     rs.getString("locale"),
                     (byte[]) rs.getObject("commcaresession"),
                     false,
-                    rs.getString("asUser"));
+                    rs.getString("asUser"),
+                    rs.getBoolean("preview"));
         }
     }
 

--- a/src/main/java/services/InstallService.java
+++ b/src/main/java/services/InstallService.java
@@ -36,7 +36,7 @@ public class InstallService {
 
     private final Log log = LogFactory.getLog(InstallService.class);
 
-    public Pair<FormplayerConfigEngine, Boolean> configureApplication(String reference) throws Exception {
+    public Pair<FormplayerConfigEngine, Boolean> configureApplication(String reference, boolean preview) throws Exception {
         boolean newInstall = true;
         SQLiteDB sqliteDB = storageFactory.getSQLiteDB();
         log.info("Configuring application with reference " + reference +
@@ -68,7 +68,7 @@ public class InstallService {
             if (reference.endsWith(".ccpr")) {
                 engine.initFromLocalFileResource(reference);
             } else {
-                engine.initFromArchive(reference);
+                engine.initFromArchive(reference, preview);
             }
             engine.initEnvironment();
             timer.end();

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -70,6 +70,7 @@ public class MenuSession {
     private final Log log = LogFactory.getLog(MenuSession.class);
     private String appId;
     private boolean oneQuestionPerScreen;
+    private boolean preview;
     ArrayList<String> titles;
 
     public MenuSession(SerializableMenuSession session, InstallService installService,
@@ -81,7 +82,7 @@ public class MenuSession {
         this.uuid = session.getId();
         this.installReference = session.getInstallReference();
         resolveInstallReference(installReference, appId, host);
-        this.engine = installService.configureApplication(this.installReference, false).first;
+        this.engine = installService.configureApplication(this.installReference, session.getPreview()).first;
         this.sandbox = restoreFactory.getSandbox();
         this.sessionWrapper = new FormplayerSessionWrapper(deserializeSession(engine.getPlatform(), session.getCommcareSession()),
                 engine.getPlatform(), sandbox);
@@ -115,6 +116,7 @@ public class MenuSession {
         this.oneQuestionPerScreen = oneQuestionPerScreen;
         this.titles = new ArrayList<>();
         this.titles.add(SessionUtils.getAppTitle());
+        this.preview = preview;
     }
     
     public void updateApp(String updateMode) {
@@ -353,5 +355,13 @@ public class MenuSession {
         String[] ret = new String[titles.size()];
         titles.toArray(ret);
         return ret;
+    }
+
+    public boolean getPreview() {
+        return preview;
+    }
+
+    public void setPreview(boolean preview) {
+        this.preview = preview;
     }
 }

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -81,7 +81,7 @@ public class MenuSession {
         this.uuid = session.getId();
         this.installReference = session.getInstallReference();
         resolveInstallReference(installReference, appId, host);
-        this.engine = installService.configureApplication(this.installReference).first;
+        this.engine = installService.configureApplication(this.installReference, false).first;
         this.sandbox = restoreFactory.getSandbox();
         this.sessionWrapper = new FormplayerSessionWrapper(deserializeSession(engine.getPlatform(), session.getCommcareSession()),
                 engine.getPlatform(), sandbox);
@@ -101,7 +101,7 @@ public class MenuSession {
         this.appId = appId;
         this.asUser = asUser;
         resolveInstallReference(installReference, appId, host);
-        Pair<FormplayerConfigEngine, Boolean> install = installService.configureApplication(this.installReference);
+        Pair<FormplayerConfigEngine, Boolean> install = installService.configureApplication(this.installReference, preview);
         this.engine = install.first;
         if (install.second && !preview && !restoreFactory.getHasRestored()) {
             this.sandbox = restoreFactory.performTimedSync();

--- a/src/test/java/mocks/TestInstallService.java
+++ b/src/test/java/mocks/TestInstallService.java
@@ -13,8 +13,8 @@ import java.net.URL;
 public class TestInstallService extends InstallService {
 
     @Override
-    public Pair<FormplayerConfigEngine, Boolean> configureApplication(String reference) throws Exception {
-        return super.configureApplication(getTestResourcePath(reference));
+    public Pair<FormplayerConfigEngine, Boolean> configureApplication(String reference, boolean preview) throws Exception {
+        return super.configureApplication(getTestResourcePath(reference), preview);
     }
 
     private String getTestResourcePath(String resourcePath){


### PR DESCRIPTION
Because App Preview uses the `appId` instead of the `buildId` we need to not re-use the CCZ when in preview mode (since the ID would remain the name). This PR does that and adds `preview` as part of the MenuSession database in support of this. 