### PR TITLE
Delete form session right after submit success

### DIFF
--- a/src/main/java/api/process/FormRecordProcessorHelper.java
+++ b/src/main/java/api/process/FormRecordProcessorHelper.java
@@ -105,8 +105,6 @@ public class FormRecordProcessorHelper extends XmlFormRecordProcessor {
 
         int removedCaseCount = -1;
         int removedLedgers = -1;
-        try {
-            sandbox.getConnection().setAutoCommit(false);
             SqlStorage<Case> storage = sandbox.getCaseStorage();
             DAG<String, int[], String> fullCaseGraph = getFullCaseGraph(storage, new FormplayerCaseIndexTable(sandbox), owners);
 
@@ -133,21 +131,7 @@ public class FormRecordProcessorHelper extends XmlFormRecordProcessor {
             SqlStorage<Ledger> stockStorage = sandbox.getLedgerStorage();
             LedgerPurgeFilter stockFilter = new LedgerPurgeFilter(stockStorage, storage);
             removedLedgers = stockStorage.removeAll(stockFilter).size();
-            sandbox.getConnection().commit();
-        } catch (SQLException e) {
-            try {
-                sandbox.getConnection().rollback();
-            } catch (SQLException e1) {
-                throw new RuntimeException(e1);
-            }
-            throw new RuntimeException(e);
-        } finally {
-            try {
-                sandbox.getConnection().setAutoCommit(true);
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
-        }
+
 
         long taken = System.currentTimeMillis() - start;
 

--- a/src/main/java/api/process/FormRecordProcessorHelper.java
+++ b/src/main/java/api/process/FormRecordProcessorHelper.java
@@ -105,36 +105,37 @@ public class FormRecordProcessorHelper extends XmlFormRecordProcessor {
 
         int removedCaseCount = -1;
         int removedLedgers = -1;
-            SqlStorage<Case> storage = sandbox.getCaseStorage();
-            DAG<String, int[], String> fullCaseGraph = getFullCaseGraph(storage, new FormplayerCaseIndexTable(sandbox), owners);
 
-            CasePurgeFilter filter = new CasePurgeFilter(fullCaseGraph);
-            if (filter.invalidEdgesWereRemoved()) {
-                Logger.log(LogTypes.SOFT_ASSERT, "An invalid edge was created in the internal " +
-                        "case DAG of a case purge filter, meaning that at least 1 case on the " +
-                        "device had an index into another case that no longer exists on the device");
-                Logger.log(LogTypes.TYPE_ERROR_ASSERTION, "Case lists on the server and device" +
-                        " were out of sync. The following cases were expected to be on the device, " +
-                        "but were missing: " + filter.getMissingCasesString() + ". As a result, the " +
-                        "following cases were also removed from the device: " + filter.getRemovedCasesString());
-            }
+        SqlStorage<Case> storage = sandbox.getCaseStorage();
+        DAG<String, int[], String> fullCaseGraph = getFullCaseGraph(storage, new FormplayerCaseIndexTable(sandbox), owners);
 
-            Vector<Integer> casesRemoved = storage.removeAll(filter.getCasesToRemove());
-            removedCaseCount = casesRemoved.size();
+        CasePurgeFilter filter = new CasePurgeFilter(fullCaseGraph);
+        if (filter.invalidEdgesWereRemoved()) {
+            Logger.log(LogTypes.SOFT_ASSERT, "An invalid edge was created in the internal " +
+                    "case DAG of a case purge filter, meaning that at least 1 case on the " +
+                    "device had an index into another case that no longer exists on the device");
+            Logger.log(LogTypes.TYPE_ERROR_ASSERTION, "Case lists on the server and device" +
+                    " were out of sync. The following cases were expected to be on the device, " +
+                    "but were missing: " + filter.getMissingCasesString() + ". As a result, the " +
+                    "following cases were also removed from the device: " + filter.getRemovedCasesString());
+        }
 
-            FormplayerCaseIndexTable indexTable = new FormplayerCaseIndexTable(sandbox);
-            for (int recordId : casesRemoved) {
-                indexTable.clearCaseIndices(recordId);
-            }
+        Vector<Integer> casesRemoved = storage.removeAll(filter.getCasesToRemove());
+        removedCaseCount = casesRemoved.size();
+
+        FormplayerCaseIndexTable indexTable = new FormplayerCaseIndexTable(sandbox);
+        for (int recordId : casesRemoved) {
+            indexTable.clearCaseIndices(recordId);
+        }
 
 
-            SqlStorage<Ledger> stockStorage = sandbox.getLedgerStorage();
-            LedgerPurgeFilter stockFilter = new LedgerPurgeFilter(stockStorage, storage);
-            removedLedgers = stockStorage.removeAll(stockFilter).size();
+        SqlStorage<Ledger> stockStorage = sandbox.getLedgerStorage();
+        LedgerPurgeFilter stockFilter = new LedgerPurgeFilter(stockStorage, storage);
+        removedLedgers = stockStorage.removeAll(stockFilter).size();
 
 
         long taken = System.currentTimeMillis() - start;
-
+        System.out.println("Purged.");
         log.info(String.format(
                 "Purged [%d Case, %d Ledger] records in %dms",
                 removedCaseCount, removedLedgers, taken));

--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -161,9 +161,11 @@ public class FormController extends AbstractBaseController{
                 }
                 // Only delete session immediately after successful submit
                 deleteSession(submitRequestBean.getSessionId());
+                restoreFactory.commit();
 
             }
             catch (InvalidStructureException e) {
+                restoreFactory.rollback();
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 submitResponseBean.setNotification(new NotificationMessage(e.getMessage(), true));
                 log.error("Submission failed with structure exception " + e);

--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -5,8 +5,6 @@ import annotations.UserRestore;
 import api.json.JsonActionUtils;
 import api.process.FormRecordProcessorHelper;
 import api.util.ApiConstants;
-import auth.DjangoAuth;
-import auth.HqAuth;
 import beans.*;
 import beans.menus.ErrorBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -160,12 +158,12 @@ public class FormController extends AbstractBaseController{
                 submitResponseBean.setStatus("error");
                 submitResponseBean.setNotification(new NotificationMessage(
                         "Form submission failed with error response" + submitResponse, true));
-                log.info("Submit response bean: " + submitResponseBean);
+                log.error("Submit response bean: " + submitResponseBean);
                 return submitResponseBean;
             }
 
             deleteSession(submitRequestBean.getSessionId());
-            
+
             if (formEntrySession.getMenuSessionId() != null &&
                     !("").equals(formEntrySession.getMenuSessionId().trim())) {
                 Object nav = doEndOfFormNav(menuSessionRepo.findOneWrapped(formEntrySession.getMenuSessionId()));

--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -164,6 +164,8 @@ public class FormController extends AbstractBaseController{
                 return submitResponseBean;
             }
 
+            deleteSession(submitRequestBean.getSessionId());
+            
             if (formEntrySession.getMenuSessionId() != null &&
                     !("").equals(formEntrySession.getMenuSessionId().trim())) {
                 Object nav = doEndOfFormNav(menuSessionRepo.findOneWrapped(formEntrySession.getMenuSessionId()));
@@ -171,7 +173,6 @@ public class FormController extends AbstractBaseController{
                     submitResponseBean.setNextScreen(nav);
                 }
             }
-            deleteSession(submitRequestBean.getSessionId());
         }
         return submitResponseBean;
     }

--- a/src/main/java/sandbox/JdbcSqlStorageIterator.java
+++ b/src/main/java/sandbox/JdbcSqlStorageIterator.java
@@ -40,8 +40,7 @@ public class JdbcSqlStorageIterator<T extends Persistable> implements IStorageIt
         this.preparedStatement = preparedStatement;
         try {
             if(!resultSet.next()) {
-                resultSet.close();
-                preparedStatement.close();
+                close();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -117,7 +116,11 @@ public class JdbcSqlStorageIterator<T extends Persistable> implements IStorageIt
     public boolean hasMore() {
         try {
             if (!resultSet.isClosed()) {
-                return !resultSet.isAfterLast();
+                if (resultSet.isAfterLast()) {
+                    close();
+                    return false;
+                }
+                return true;
             } else {
                 return false;
             }

--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -284,12 +284,18 @@ public class SqlHelper {
             }
 
             try (ResultSet generatedKeys = preparedStatement.getGeneratedKeys()) {
-                if (generatedKeys.next()) {
-                    int id = generatedKeys.getInt(1);
-                    p.setID(id);
-                    return id;
-                } else {
-                    throw new SQLException("Creating user failed, no ID obtained.");
+                try {
+                    if (generatedKeys.next()) {
+                        int id = generatedKeys.getInt(1);
+                        p.setID(id);
+                        return id;
+                    } else {
+                        throw new SQLException("Creating user failed, no ID obtained.");
+                    }
+                } finally {
+                    if (generatedKeys != null) {
+                        generatedKeys.close();
+                    }
                 }
             }
         } catch (SQLException e) {

--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -54,7 +54,7 @@ public class SqlSandboxUtils {
             }
             Class.forName("org.sqlite.JDBC");
             SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
-            dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=WAL");
+            dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=MEMORY");
             dataSource.getConnection().setAutoCommit(false);
             return dataSource;
         } catch (ClassNotFoundException|SQLException |IOException e) {

--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -54,7 +54,7 @@ public class SqlSandboxUtils {
             }
             Class.forName("org.sqlite.JDBC");
             SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
-            dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=MEMORY");
+            dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=WAL");
             dataSource.getConnection().setAutoCommit(false);
             return dataSource;
         } catch (ClassNotFoundException|SQLException |IOException e) {

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -182,6 +182,14 @@ public class RestoreFactory {
         }
     }
 
+    public boolean getAutoCommit() {
+        try {
+            return sqLiteDB.getConnection().getAutoCommit();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void commit() {
         try {
             sqLiteDB.getConnection().commit();

--- a/src/main/java/services/SubmitService.java
+++ b/src/main/java/services/SubmitService.java
@@ -20,21 +20,16 @@ public class SubmitService extends DefaultResponseErrorHandler {
     RestoreFactory restoreFactory;
 
     public ResponseEntity<String> submitForm(String formXml, String submitUrl) {
-        restoreFactory.setAutoCommit(false);
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.setErrorHandler(this);
         HttpEntity<?> entity = new HttpEntity<Object>(formXml, restoreFactory.getUserHeaders());
-        ResponseEntity<String> response = restTemplate.exchange(submitUrl,
+        return restTemplate.exchange(submitUrl,
                 HttpMethod.POST,
                 entity, String.class);
-        restoreFactory.commit();
-        restoreFactory.setAutoCommit(true);
-        return response;
     }
 
     @Override
     public void handleError(ClientHttpResponse response) throws IOException {
         restoreFactory.rollback();
-        restoreFactory.setAutoCommit(true);
     }
 }

--- a/src/main/java/services/SubmitService.java
+++ b/src/main/java/services/SubmitService.java
@@ -1,5 +1,7 @@
 package services;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -19,6 +21,8 @@ public class SubmitService extends DefaultResponseErrorHandler {
     @Autowired
     RestoreFactory restoreFactory;
 
+    private final Log log = LogFactory.getLog(SubmitService.class);
+
     public ResponseEntity<String> submitForm(String formXml, String submitUrl) {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.setErrorHandler(this);
@@ -28,8 +32,10 @@ public class SubmitService extends DefaultResponseErrorHandler {
                 entity, String.class);
     }
 
+    // Overriding the default error handler allows us to perform error handling in FormController
+    // rather than at the Spring level
     @Override
     public void handleError(ClientHttpResponse response) throws IOException {
-        restoreFactory.rollback();
+        log.error("Error submitting form: " + response);
     }
 }

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -580,6 +580,8 @@ public class BaseTestClass {
                                 .content((String) bean));
                 break;
         }
+        restoreFactoryMock.getSQLiteDB().closeConnection();
+        storageFactoryMock.getSQLiteDB().closeConnection();
         return mapper.readValue(
                 result.andReturn().getResponse().getContentAsString(),
                 clazz

--- a/src/test/java/tests/SubmitTests.java
+++ b/src/test/java/tests/SubmitTests.java
@@ -7,6 +7,7 @@ import beans.SubmitResponseBean;
 import beans.menus.CommandListResponseBean;
 import beans.menus.EntityListResponse;
 import org.commcare.cases.model.Case;
+import org.javarosa.xml.util.InvalidStructureException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;

--- a/src/test/java/tests/SubmitTests.java
+++ b/src/test/java/tests/SubmitTests.java
@@ -1,0 +1,61 @@
+package tests;
+
+import beans.FormEntryResponseBean;
+import beans.NewFormResponse;
+import beans.QuestionBean;
+import beans.SubmitResponseBean;
+import beans.menus.CommandListResponseBean;
+import beans.menus.EntityListResponse;
+import org.commcare.cases.model.Case;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import sandbox.SqlStorage;
+import sandbox.UserSqlSandbox;
+import sqlitedb.UserDB;
+import utils.FileUtils;
+import utils.TestContext;
+
+import java.util.Hashtable;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for submission behaviors
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestContext.class)
+public class SubmitTests extends BaseTestClass {
+
+    @Test
+    public void testCaseCreateFails() throws Exception {
+        // Start new session and submit create case form
+        NewFormResponse newSessionResponse = startNewForm("requests/new_form/new_form_3.json",
+                "xforms/cases/create_case.xml");
+
+        UserSqlSandbox sandbox = restoreFactoryMock.getSqlSandbox();
+        SqlStorage<Case> caseStorage =  sandbox.getCaseStorage();
+        assert(caseStorage.getNumRecords() == 15);
+
+        Mockito.doReturn(new ResponseEntity<>(HttpStatus.BAD_REQUEST))
+                .when(submitServiceMock).submitForm(anyString(), anyString());
+        // Assert that FormSession is not deleted
+        Mockito.doThrow(new RuntimeException())
+                .when(formSessionRepoMock).delete(anyString());
+
+        SubmitResponseBean submitResponseBean = submitForm("requests/submit/submit_request_case.json", "derp");
+        assert submitResponseBean.getStatus().equals("error");
+        // Assert that case is not created
+        assert(caseStorage.getNumRecords()== 15);
+    }
+
+}


### PR DESCRIPTION
Delete `FormSession` from Postgres immediately after getting a successful sync. Previously, we retrieved the next screen (for end of form navigation) before deleting the row. If we encountered an error here, we would have submitted the form but *not* have deleted the `FormSession`. The user would be redirected back to the home screen by the failed end of form nav, but in theory they could go to the Incomplete Forms page and re-open and re-submit that form, as appears to have happened here:

https://manage.dimagi.com/default.asp?265683

@ctsims turned this into a two-fer to include rolling back on failed submissions