### PR TITLE
Graphing refactor

### DIFF
--- a/src/main/java/beans/menus/EntityDetailResponse.java
+++ b/src/main/java/beans/menus/EntityDetailResponse.java
@@ -11,6 +11,7 @@ import org.commcare.suite.model.Style;
 import org.commcare.util.screen.EntityDetailSubscreen;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import util.FormplayerGraphUtil;
 
 import java.util.Arrays;
 import java.util.List;
@@ -53,7 +54,7 @@ public class EntityDetailResponse {
             Object datum = data[i];
             if (datum instanceof GraphData) {
                 try {
-                    datum = GraphUtil.getHTML((GraphData) datum, "").replace("\"", "'");
+                    datum = FormplayerGraphUtil.getHTML((GraphData) datum, "").replace("\"", "'");
                 } catch (GraphException e) {
                     datum = "Error loading graph " + e;
                 }

--- a/src/main/java/beans/menus/EntityDetailResponse.java
+++ b/src/main/java/beans/menus/EntityDetailResponse.java
@@ -1,6 +1,9 @@
 package beans.menus;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.commcare.core.graph.model.GraphData;
+import org.commcare.core.graph.util.GraphException;
+import org.commcare.core.graph.util.GraphUtil;
 import org.commcare.modern.util.Pair;
 import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.DetailField;
@@ -38,9 +41,26 @@ public class EntityDetailResponse {
 
     public EntityDetailResponse(EntityDetailSubscreen entityScreen, String title) {
         this.title = title;
-        this.details = entityScreen.getData();
+        this.details = processDetails(entityScreen.getData());
         this.headers = entityScreen.getHeaders();
         this.styles = entityScreen.getStyles();
+
+    }
+
+    private static Object[] processDetails(Object[] data) {
+        Object[] ret = new Object[data.length];
+        for (int i = 0; i < data.length; i++) {
+            Object datum = data[i];
+            if (datum instanceof GraphData) {
+                try {
+                    datum = GraphUtil.getHTML((GraphData) datum, "").replace("\"", "'");
+                } catch (GraphException e) {
+                    datum = "Error loading graph " + e;
+                }
+            }
+            ret[i] = datum;
+        }
+        return ret;
     }
 
     // Constructor used for persistent case tile

--- a/src/main/java/beans/menus/EntityListResponse.java
+++ b/src/main/java/beans/menus/EntityListResponse.java
@@ -14,6 +14,7 @@ import org.commcare.util.screen.EntityListSubscreen;
 import org.commcare.util.screen.EntityScreen;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import util.FormplayerGraphUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -233,7 +234,7 @@ public class EntityListResponse extends MenuBean {
             o = field.getTemplate().evaluate(context);
             if(o instanceof GraphData) {
                 try {
-                    data[i] = GraphUtil.getHTML((GraphData) o, "").replace("\"", "'");
+                    data[i] = FormplayerGraphUtil.getHTML((GraphData) o, "").replace("\"", "'");
                 } catch (GraphException e) {
                     data[i] = "<html><body>Error loading graph " + e + "</body></html>";
                 }

--- a/src/main/java/util/FormplayerGraphUtil.java
+++ b/src/main/java/util/FormplayerGraphUtil.java
@@ -1,0 +1,105 @@
+package util;
+
+import org.commcare.core.graph.c3.AxisConfiguration;
+import org.commcare.core.graph.c3.GridConfiguration;
+import org.commcare.core.graph.c3.LegendConfiguration;
+import org.commcare.core.graph.util.GraphException;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Utilities for displaying d3 graphs
+ */
+public class FormplayerGraphUtil {
+    /**
+     * Get the HTML that will comprise this graph.
+     *
+     * @param graphData The data to render.
+     * @return Full HTML page, including head, body, and all script and style tags
+     */
+    public static String getHTML(org.commcare.core.graph.model.GraphData graphData, String title) throws GraphException {
+        SortedMap<String, String> variables = new TreeMap<>();
+        JSONObject config = new JSONObject();
+        StringBuilder html = new StringBuilder();
+        try {
+            // Configure data first, as it may affect the other configurations
+            org.commcare.core.graph.c3.DataConfiguration data = new org.commcare.core.graph.c3.DataConfiguration(graphData);
+            config.put("data", data.getConfiguration());
+
+            AxisConfiguration axis = new AxisConfiguration(graphData);
+            config.put("axis", axis.getConfiguration());
+
+            GridConfiguration grid = new GridConfiguration(graphData);
+            config.put("grid", grid.getConfiguration());
+
+            LegendConfiguration legend = new LegendConfiguration(graphData);
+            config.put("legend", legend.getConfiguration());
+
+            variables.put("type", "'" + graphData.getType() + "'");
+            variables.put("config", config.toString());
+
+            // For debugging purposes, note that most minified files have un-minified equivalents in the same directory.
+            // To use them, switch affix to "max" and get rid of the ignoreAssetsPattern in build.gradle that
+            // filters them out of the APK.
+            String affix = "max";
+            html.append(
+                    "<!DOCTYPE html>" +
+                            "<html style=\"height: 100%\">" +
+                            "<head>" +
+                            "<link rel='stylesheet' type='text/css' href='https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.css'></link>" +
+                            "<link rel='stylesheet' type='text/css' href='https://cdn.rawgit.com/dimagi/commcare-android/master/app/assets/graphing/graph.max.css'></link>" +
+                            "<script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js'></script>" +
+                            "<script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js'></script>" +
+                            "<script type='text/javascript'>");
+
+            html.append(getVariablesHTML(variables, null));
+            html.append(getVariablesHTML(data.getVariables(), "data"));
+            html.append(getVariablesHTML(axis.getVariables(), "axis"));
+            html.append(getVariablesHTML(grid.getVariables(), "grid"));
+            html.append(getVariablesHTML(legend.getVariables(), "legend"));
+
+            String titleHTML = "<div id='chart-title'>" + title + "</div>";
+            String errorHTML = "<div id='error'></div>";
+            String chartHTML = "<div id='chart'></div>";
+            html.append("</script>" +
+                    "<script type='text/javascript' src='https://cdn.rawgit.com/dimagi/commcare-android/master/app/assets/graphing/graph.max.js'></script>" +
+                    "</head>" +
+                    "<body style=\"height: 90%; margin:0;\">" + titleHTML + errorHTML + chartHTML + "</body>" +
+                    "</html>");
+        } catch (JSONException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+
+        return html.toString();
+    }
+
+    /**
+     * Generate HTML to declare given variables in WebView.
+     *
+     * @param variables OrderedHashTable where keys are variable names and values are JSON
+     *                  representations of values.
+     * @param namespace Optional. If provided, instead of declaring a separate variable for each
+     *                  item in variables, one object will be declared with namespace for a name
+     *                  and a property corresponding to each item in variables.
+     * @return HTML string
+     */
+    private static String getVariablesHTML(SortedMap<String, String> variables, String namespace) {
+        StringBuilder html = new StringBuilder();
+        if (namespace != null && !namespace.equals("")) {
+            html.append("var ").append(namespace).append(" = {};\n");
+        }
+        for (String name : variables.keySet()) {
+            if (namespace == null || namespace.equals("")) {
+                html.append("var ").append(name);
+            } else {
+                html.append(namespace).append(".").append(name);
+            }
+            html.append(" = ").append(variables.get(name)).append(";\n");
+        }
+        return html.toString();
+    }
+}


### PR DESCRIPTION
Moves around a few pieces of graphing in Formplayer to allow for the deletion of some files

1. Move up evaluation of detail data to the `Formplayer` level so that we can use a `FormplayerGraphUtil` class instead of `GraphUtil` in `commcare-core`
2. This allows us to delete those methods from `GraphUtil` in commcare-core (we wouldn't have been able to unify these because Formplayer gets the D3 libs from a CDN while Android stores them locally)
3. This allows us to delete `Color.java` from `commcare-core` as well