### PR TITLE
Fix for FixtureIndex update failing

### DIFF
--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -259,11 +259,9 @@ public class SqlHelper {
         }
     }
 
-    public static void basicInsert(Connection c, String storageKey,
-                                   Map<String, String> contentVals) {
+    public static void performInsert(Connection c,
+                                     Pair<List<String>, String> valsAndInsertStatement) {
         PreparedStatement preparedStatement = null;
-        Pair<List<String>, String> valsAndInsertStatement =
-                buildInsertStatement(storageKey, contentVals);
         try {
             preparedStatement = c.prepareStatement(valsAndInsertStatement.second);
             int i = 1;
@@ -284,30 +282,20 @@ public class SqlHelper {
         }
     }
 
+    public static void basicInsert(Connection c,
+                                   String storageKey,
+                                   Map<String, String> contentVals) {
+        Pair<List<String>, String> valsAndInsertStatement =
+                buildInsertStatement(storageKey, contentVals);
+        performInsert(c, valsAndInsertStatement);
+    }
+
     public static void insertOrReplace(Connection c,
                                        String storageKey,
                                        Map<String, String> contentValues) {
-        PreparedStatement preparedStatement = null;
         Pair<List<String>, String> valsAndInsertStatement =
                 buildInsertOrReplaceStatement(storageKey, contentValues);
-        try {
-            preparedStatement = c.prepareStatement(valsAndInsertStatement.second);
-            int i = 1;
-            for (String val : valsAndInsertStatement.first) {
-                preparedStatement.setString(i++, val);
-            }
-            preparedStatement.executeUpdate();
-        } catch (SQLException e) {
-            throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
+        performInsert(c, valsAndInsertStatement);
     }
 
     private static Pair<List<String>, String> buildInsertStatement(String storageKey,

--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -259,7 +259,7 @@ public class SqlHelper {
         }
     }
 
-    public static void performInsert(Connection c,
+    private static void performInsert(Connection c,
                                      Pair<List<String>, String> valsAndInsertStatement) {
         PreparedStatement preparedStatement = null;
         try {

--- a/src/main/java/sandbox/SqlStorage.java
+++ b/src/main/java/sandbox/SqlStorage.java
@@ -97,6 +97,11 @@ public class SqlStorage<T extends Persistable>
         SqlHelper.basicInsert(connection, tableName, contentVals);
     }
 
+    public void insertOrReplace(Map<String, String> contentVals) {
+        Connection connection = getConnection();
+        SqlHelper.insertOrReplace(connection, tableName, contentVals);
+    }
+
     private void buildTableFromInstance(T instance) throws ClassNotFoundException {
         Connection connection = getConnection();
         SqlHelper.createTable(connection, tableName, instance);

--- a/src/main/java/sandbox/UserSqlSandbox.java
+++ b/src/main/java/sandbox/UserSqlSandbox.java
@@ -135,7 +135,7 @@ public class UserSqlSandbox extends UserSandbox implements ConnectionHandler {
         contentVals.put(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_BASE, baseName);
         contentVals.put(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_CHILD, childName);
         contentVals.put(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_COL_NAME, fixtureName);
-        sqlUtil.basicInsert(contentVals);
+        sqlUtil.insertOrReplace(contentVals);
     }
 
     /**

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -284,9 +284,10 @@ public class BaseTestClass {
     }
 
     SyncDbResponseBean syncDb() throws Exception {
-        String syncDbRequestPayload = FileUtils.getFile(this.getClass(), "requests/sync_db/sync_db.json");
-        SyncDbRequestBean syncDbRequestBean = mapper.readValue(syncDbRequestPayload,
-                SyncDbRequestBean.class);
+        SyncDbRequestBean syncDbRequestBean = new SyncDbRequestBean();
+        syncDbRequestBean.setDomain(restoreFactoryMock.getDomain());
+        syncDbRequestBean.setUsername(restoreFactoryMock.getUsername());
+        syncDbRequestBean.setRestoreAs(restoreFactoryMock.getAsUsername());
         return generateMockQuery(ControllerType.UTIL,
                 RequestType.POST,
                 Constants.URL_SYNC_DB,

--- a/src/test/java/tests/Enikshay2bTests.java
+++ b/src/test/java/tests/Enikshay2bTests.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import utils.TestContext;
@@ -76,5 +77,7 @@ public class Enikshay2bTests extends BaseTestClass {
                         NewFormResponse.class);
         assert newFormResponse.getPersistentCaseTile() != null;
         assert newFormResponse.getPersistentCaseTile().getDetails().length == 5;
+        // Sync again to confirm whether we can update indexed fixtures
+        syncDb();
     }
 }

--- a/src/test/java/tests/Enikshay2bTests.java
+++ b/src/test/java/tests/Enikshay2bTests.java
@@ -1,22 +1,17 @@
 package tests;
 
 import beans.NewFormResponse;
-import beans.SubmitRequestBean;
 import beans.SubmitResponseBean;
 import beans.menus.CommandListResponseBean;
-import beans.menus.EntityDetailListResponse;
 import beans.menus.EntityListResponse;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import utils.TestContext;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 
 /**
  * Tests specific to Enikshay

--- a/src/test/resources/requests/sync_db/sync_db.json
+++ b/src/test/resources/requests/sync_db/sync_db.json
@@ -1,6 +1,0 @@
-{
-  "action": "sync-db",
-  "username": "synctestuser",
-  "domain": "synctestdomain",
-  "app_id": "synctestappid"
-}


### PR DESCRIPTION
Noticed this in Sentry, looks like this statement should be an insert-or-replace rather than a basic insert. Added a line to the tests that would trigger this failure. 