### PR TITLE
SessionException back to typed

### DIFF
--- a/src/main/java/screens/FormplayerSyncScreen.java
+++ b/src/main/java/screens/FormplayerSyncScreen.java
@@ -4,6 +4,7 @@ import org.commcare.modern.session.SessionWrapper;
 import org.commcare.suite.model.Entry;
 import org.commcare.suite.model.PostRequest;
 import org.commcare.suite.model.RemoteRequestEntry;
+import org.commcare.util.screen.CommCareSessionException;
 import org.commcare.util.screen.SyncScreen;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -24,7 +25,7 @@ public class FormplayerSyncScreen extends SyncScreen {
     }
 
     @Override
-    public void init (SessionWrapper sessionWrapper){
+    public void init (SessionWrapper sessionWrapper) throws CommCareSessionException {
 
         super.init(sessionWrapper);
         String command = sessionWrapper.getCommand();

--- a/src/main/java/services/MenuSessionFactory.java
+++ b/src/main/java/services/MenuSessionFactory.java
@@ -47,7 +47,7 @@ public class MenuSessionFactory {
      * By re-walking the frame, we establish the set of selections the user 'would' have made to get
      * to this state without doing end of form navigation. Such a path must always exist in a valid app.
     */
-    public void rebuildSessionFromFrame(MenuSession menuSession) {
+    public void rebuildSessionFromFrame(MenuSession menuSession) throws CommCareSessionException {
         Vector<StackFrameStep> steps = menuSession.getSessionWrapper().getFrame().getSteps();
         menuSession.resetSession();
         Screen screen = menuSession.getNextScreen();


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/724

make `CommCareSessionException` typed again