### PR TITLE
Attempt to parse message in submission response and send to browser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
     compile project(path: ':commcare', configuration: 'translate')
+    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.0'
     testCompile project(path: ':commcare', configuration: 'api')
     testCompile("org.springframework.boot:spring-boot-starter-test:1.4.3.RELEASE")
     testCompile("com.jayway.jsonpath:json-path:2.2.0")

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
     compile project(path: ':commcare', configuration: 'translate')
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.0'
+    compile 'org.simpleframework:simple-xml:2.7.1'
     testCompile project(path: ':commcare', configuration: 'api')
     testCompile("org.springframework.boot:spring-boot-starter-test:1.4.3.RELEASE")
     testCompile("com.jayway.jsonpath:json-path:2.2.0")

--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -210,9 +210,7 @@ public class FormController extends AbstractBaseController{
                 Serializer serializer = new Persister();
                 OpenRosaResponse openRosaResponse = serializer.read(OpenRosaResponse.class, responseBody);
                 if (openRosaResponse != null && openRosaResponse.getMessage() != null) {
-                    submitResponseBean.setNotification(
-                            new NotificationMessage(openRosaResponse.getMessage(), false)
-                    );
+                    submitResponseBean.setSubmitResponseMessage(openRosaResponse.getMessage());
                 }
             } catch (Exception e) {
                 log.error("Exception parsing submission response body", e);

--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -9,6 +9,7 @@ import api.util.ApiConstants;
 import beans.*;
 import beans.menus.ErrorBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import engine.FormplayerTransactionParserFactory;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -154,6 +155,17 @@ public class FormController extends AbstractBaseController{
                             "Form submission failed with error response" + submitResponse, true));
                     log.error("Submit response bean: " + submitResponseBean);
                     return submitResponseBean;
+                } else {
+                    try {
+                        String responseBody = submitResponse.getBody();
+                        XmlMapper xmlMapper = new XmlMapper();
+                        OpenRosaResponse orResponse = xmlMapper.readValue(responseBody, OpenRosaResponse.class);
+                        if (orResponse != null && orResponse.getMessage() != null) {
+                            submitResponseBean.setNotification(new NotificationMessage(orResponse.getMessage(), false));
+                        }
+                    } catch (IOException e) {
+                        log.error("Exception parsing submission response body", e);
+                    }
                 }
                 // Only delete session immediately after successful submit
                 deleteSession(submitRequestBean.getSessionId());

--- a/src/main/java/beans/OpenRosaResponse.java
+++ b/src/main/java/beans/OpenRosaResponse.java
@@ -1,0 +1,15 @@
+package beans;
+
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+public class OpenRosaResponse {
+
+    OpenRosaResponse() {}
+
+    @JacksonXmlProperty(localName = "message")
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/beans/OpenRosaResponse.java
+++ b/src/main/java/beans/OpenRosaResponse.java
@@ -1,12 +1,14 @@
 package beans;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
 
+@Root
 public class OpenRosaResponse {
 
     OpenRosaResponse() {}
 
-    @JacksonXmlProperty(localName = "message")
+    @Element
     private String message;
 
     public String getMessage() {

--- a/src/main/java/beans/SubmitResponseBean.java
+++ b/src/main/java/beans/SubmitResponseBean.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
  */
 public class SubmitResponseBean extends SessionResponseBean {
     private String status;
-    private String message;
+    private String submitResponseMessage;
     private HashMap<String, ErrorBean> errors;
     private Object nextScreen;
 
@@ -48,5 +48,13 @@ public class SubmitResponseBean extends SessionResponseBean {
 
     public void setNextScreen(Object nextScreen) {
         this.nextScreen = nextScreen;
+    }
+
+    public String getSubmitResponseMessage() {
+        return submitResponseMessage;
+    }
+
+    public void setSubmitResponseMessage(String submitResponseMessage) {
+        this.submitResponseMessage = submitResponseMessage;
     }
 }

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -159,8 +159,7 @@ public class BaseTestClass {
         mockDebuggerController = MockMvcBuilders.standaloneSetup(debuggerController).build();
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer(this.getMockRestoreFileName());
         Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
-        Mockito.doReturn(new ResponseEntity<>(HttpStatus.OK))
-                .when(submitServiceMock).submitForm(anyString(), anyString());
+        setupSubmitServiceMock();
         Mockito.doReturn(false)
                 .when(restoreFactoryMock).isRestoreXmlExpired();
         mapper = new ObjectMapper();
@@ -168,6 +167,16 @@ public class BaseTestClass {
         restoreFactoryMock.getSQLiteDB().closeConnection();
         PrototypeUtils.setupPrototypes();
         new SQLiteProperties().setDataDir("testdbs/");
+    }
+
+    private void setupSubmitServiceMock() {
+        Mockito.doReturn(ResponseEntity.ok(
+                "<OpenRosaResponse>" +
+                        "<message nature='status'>" +
+                        "OK" +
+                        "</message>" +
+                        "</OpenRosaResponse>"))
+                .when(submitServiceMock).submitForm(anyString(), anyString());
     }
 
     @After

--- a/src/test/java/tests/FormEntryTest.java
+++ b/src/test/java/tests/FormEntryTest.java
@@ -96,6 +96,7 @@ public class FormEntryTest extends BaseTestClass{
 
         //Test Submission
         SubmitResponseBean submitResponseBean = submitForm("requests/submit/submit_request.json", sessionId);
+        assert submitResponseBean.getSubmitResponseMessage().equals("OK");
     }
 
 

--- a/src/test/java/tests/SubmitTests.java
+++ b/src/test/java/tests/SubmitTests.java
@@ -1,34 +1,20 @@
 package tests;
 
-import beans.FormEntryResponseBean;
 import beans.NewFormResponse;
-import beans.QuestionBean;
 import beans.SubmitResponseBean;
-import beans.menus.CommandListResponseBean;
-import beans.menus.EntityListResponse;
 import org.commcare.cases.model.Case;
-import org.javarosa.xml.util.InvalidStructureException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import sandbox.SqlStorage;
 import sandbox.UserSqlSandbox;
-import sqlitedb.UserDB;
-import utils.FileUtils;
 import utils.TestContext;
 
-import java.util.Hashtable;
-
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
 
 /**
  * Regression tests for submission behaviors


### PR DESCRIPTION
Parse the `OpenRosaResponse` message block from submissions (currently always a `√`) and send to the browser

@orangejenny this ends up in the extant notifications JSON attribute (which we use for pop-ups), if you don't want to re-purpose this for this case we can add a new attribute:

`{..."notification":{"message":"   √   ","error":false}, ...}`