### PR TITLE
Update command to run without tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run (with tests):
 
 To run without tests:
 
-    $ ./gradlew build -x test && java -jar build/libs/formplayer.jar
+    $ ./gradlew assemble -x test && java -jar build/libs/formplayer.jar
 
 To test:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To run (with tests):
 
 To run without tests:
 
-    $ ./gradlew assemble -x test && java -jar build/libs/formplayer.jar
+    $ ./gradlew assemble && java -jar build/libs/formplayer.jar
 
 To test:
 


### PR DESCRIPTION
`assemble` by default won't run any tests, so is preferable to `build -x test` which will skip the `test` task but run others like `lint` and `jenkinsTest` which are not desired here. 

cc @orangejenny 