### PR TITLE
CommCareConfigEngine use PrintStream, Formplayer passes in dummy

### DIFF
--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -40,7 +40,7 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
     public FormplayerConfigEngine(IStorageIndexedFactory storageFactory,
                                   FormplayerInstallerFactory formplayerInstallerFactory,
                                   ArchiveFileRoot formplayerArchiveFileRoot) {
-        super(storageFactory, formplayerInstallerFactory, new DummyStream());
+        super(storageFactory, formplayerInstallerFactory, System.out);
         this.mArchiveRoot = formplayerArchiveFileRoot;
         ReferenceManager.instance().addReferenceFactory(formplayerArchiveFileRoot);
     }
@@ -183,16 +183,5 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         super.initEnvironment();
         Localization.registerLanguageReference("default",
                 "jr://springfile/formplayer_translatable_strings.txt");
-    }
-
-    private static class DummyStream extends PrintStream {
-        public DummyStream() {
-            super(new OutputStream() {
-                @Override
-                public void write(int b) throws IOException {
-                    // NO-OP
-                }
-            });
-        }
     }
 }

--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -40,7 +40,7 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
     public FormplayerConfigEngine(IStorageIndexedFactory storageFactory,
                                   FormplayerInstallerFactory formplayerInstallerFactory,
                                   ArchiveFileRoot formplayerArchiveFileRoot) {
-        super(storageFactory, formplayerInstallerFactory);
+        super(storageFactory, formplayerInstallerFactory, new DummyStream());
         this.mArchiveRoot = formplayerArchiveFileRoot;
         ReferenceManager.instance().addReferenceFactory(formplayerArchiveFileRoot);
     }
@@ -183,5 +183,16 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         super.initEnvironment();
         Localization.registerLanguageReference("default",
                 "jr://springfile/formplayer_translatable_strings.txt");
+    }
+
+    private static class DummyStream extends PrintStream {
+        public DummyStream() {
+            super(new OutputStream() {
+                @Override
+                public void write(int b) throws IOException {
+                    // NO-OP
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/742

Pass in a dummy `PrintStream` to `CommCareConfigEngine` since we do not care about the (mostly diagnostic) logging done there. Hard failures should be sent as Exceptions and logged at the Sentry level. 