### PR TITLE
Wsp/repeat expand fix

### DIFF
--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -170,6 +170,7 @@ public class FormSession {
         } else {
             initialize(true, sessionData, storageFactory.getStorageManager());
         }
+        
         if (this.oneQuestionPerScreen) {
             stepToNextIndex();
             this.currentIndex = formController.getFormIndex().toString();

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -120,8 +120,10 @@ public class FormSession {
         formDef.setSendCalloutHandler(formSendCalloutHandler);
         this.functionContext = session.getFunctionContext();
         setupJavaRosaObjects();
-        FormIndex formIndex = JsonActionUtils.indexFromString(currentIndex, this.formDef);
-        formController.jumpToIndex(formIndex);
+        if (this.oneQuestionPerScreen) {
+            FormIndex formIndex = JsonActionUtils.indexFromString(currentIndex, this.formDef);
+            formController.jumpToIndex(formIndex);
+        }
         setupFunctionContext();
         initialize(false, session.getSessionData(), storageFactory.getStorageManager());
         this.postUrl = session.getPostUrl();
@@ -168,7 +170,6 @@ public class FormSession {
         } else {
             initialize(true, sessionData, storageFactory.getStorageManager());
         }
-
         if (this.oneQuestionPerScreen) {
             stepToNextIndex();
             this.currentIndex = formController.getFormIndex().toString();


### PR DESCRIPTION
fixes https://manage.dimagi.com/default.asp?268760

When not in OQPS mode we never set the `formIndex` value because it should never be needed. However, before this fix we *were* moving the `FormEntryController` to this index with each answer. The FormIndex would always be `0` and moving the controller hasn't caused any issues; however, in this case there was a repeat group at index `0` that would be attempted to be expanded. This fix stops using `jumpToIndex` when not in OQPS mode. 