### PR TITLE
Formplayer 2.42

### DIFF
--- a/src/main/java/screens/FormplayerQueryScreen.java
+++ b/src/main/java/screens/FormplayerQueryScreen.java
@@ -1,18 +1,9 @@
 package screens;
 
-import auth.HqAuth;
 import org.commcare.util.screen.QueryScreen;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Hashtable;
 
 /**
@@ -21,7 +12,7 @@ import java.util.Hashtable;
 public class FormplayerQueryScreen extends QueryScreen {
 
     public FormplayerQueryScreen(){
-        super();
+        super(null, null, null);
     }
 
     public String getUriString() {

--- a/src/main/java/screens/FormplayerSyncScreen.java
+++ b/src/main/java/screens/FormplayerSyncScreen.java
@@ -20,14 +20,13 @@ public class FormplayerSyncScreen extends SyncScreen {
     private String url;
 
     public FormplayerSyncScreen(String asUser) {
-        super();
+        super(null, null, System.out);
         this.asUser = asUser;
     }
 
     @Override
     public void init (SessionWrapper sessionWrapper) throws CommCareSessionException {
-
-        super.init(sessionWrapper);
+        this.sessionWrapper = sessionWrapper;
         String command = sessionWrapper.getCommand();
         Entry commandEntry = sessionWrapper.getPlatform().getEntry(command);
         if (commandEntry instanceof RemoteRequestEntry) {

--- a/src/main/java/services/MenuSessionRunnerService.java
+++ b/src/main/java/services/MenuSessionRunnerService.java
@@ -264,7 +264,7 @@ public class MenuSessionRunnerService {
         NotificationMessage notificationMessage = null;
         screen.answerPrompts(queryDictionary);
         String responseString = queryRequester.makeQueryRequest(screen.getUriString(), restoreFactory.getUserHeaders());
-        boolean success = screen.processSuccess(new ByteArrayInputStream(responseString.getBytes(StandardCharsets.UTF_8)));
+        boolean success = screen.processResponse(new ByteArrayInputStream(responseString.getBytes(StandardCharsets.UTF_8)));
         if (success) {
             if (screen.getCurrentMessage() != null) {
                 notificationMessage = new NotificationMessage(screen.getCurrentMessage(), false);

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -36,6 +36,7 @@ import services.FormplayerStorageFactory;
 import services.InstallService;
 import services.RestoreFactory;
 import util.*;
+import util.SessionUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -210,7 +211,7 @@ public class MenuSession implements HereFunctionHandlerListener {
             menuScreen.init(sessionWrapper);
             return menuScreen;
         } else if (next.equals(SessionFrame.STATE_DATUM_VAL)) {
-            EntityScreen entityScreen = new EntityScreen();
+            EntityScreen entityScreen = new EntityScreen(false);
             entityScreen.init(sessionWrapper);
             if (entityScreen.shouldBeSkipped()) {
                 return getNextScreen();


### PR DESCRIPTION
Backmerge of 2.42 into formplayer and compatibility.

The big compatibility fix was making `EntityScreen` handle *either* a case-id *or* a case index. I decided this was necessary (rather than trying both) because I've seen errors where the front end will send a command index (ie `1`) twice and so the `EntityScreen` would receive a `1` as input. Currently we'll error on this because there's no case with Id `1` but if we were permissive of indexes this error would successfully select some random case. 

cross-request: https://github.com/dimagi/commcare-core/pull/753