### PR TITLE
Add caseId property to FormSession to enable filling out a form as a case in SMS

### DIFF
--- a/src/main/java/aspects/UserRestoreAspect.java
+++ b/src/main/java/aspects/UserRestoreAspect.java
@@ -82,7 +82,12 @@ public class UserRestoreAspect {
         } else {
             // SMS users don't submit username and domain with each request, so obtain from session
             SerializableFormSession formSession = formSessionRepo.findOneWrapped(requestBean.getSessionId());
-            restoreFactory.configure(touchformsUsername, formSession.getDomain(), formSession.getAsUser(), auth);
+
+            if (formSession.getCaseId() != null) {
+                restoreFactory.configure(formSession.getDomain(), formSession.getCaseId(), auth);
+            } else {
+                restoreFactory.configure(touchformsUsername, formSession.getDomain(), formSession.getAsUser(), auth);
+            }
         }
     }
 

--- a/src/main/java/aspects/UserRestoreAspect.java
+++ b/src/main/java/aspects/UserRestoreAspect.java
@@ -71,9 +71,9 @@ public class UserRestoreAspect {
     }
 
     private void configureRestoreFactory(AuthenticatedRequestBean requestBean, HqAuth auth) {
-        if (requestBean.getCaseId() != null) {
+        if (requestBean.getRestoreAsCaseId() != null) {
             // SMS user filling out a form as a case
-            restoreFactory.configure(requestBean.getDomain(), requestBean.getCaseId(), auth);
+            restoreFactory.configure(requestBean.getDomain(), requestBean.getRestoreAsCaseId(), auth);
             return;
         }
         if (requestBean.getUsername() != null && requestBean.getDomain() != null) {
@@ -83,8 +83,8 @@ public class UserRestoreAspect {
             // SMS users don't submit username and domain with each request, so obtain from session
             SerializableFormSession formSession = formSessionRepo.findOneWrapped(requestBean.getSessionId());
 
-            if (formSession.getCaseId() != null) {
-                restoreFactory.configure(formSession.getDomain(), formSession.getCaseId(), auth);
+            if (formSession.getRestoreAsCaseId() != null) {
+                restoreFactory.configure(formSession.getDomain(), formSession.getRestoreAsCaseId(), auth);
             } else {
                 restoreFactory.configure(touchformsUsername, formSession.getDomain(), formSession.getAsUser(), auth);
             }

--- a/src/main/java/beans/AuthenticatedRequestBean.java
+++ b/src/main/java/beans/AuthenticatedRequestBean.java
@@ -17,7 +17,7 @@ public class AuthenticatedRequestBean {
     private boolean useLiveQuery;
 
     private String sessionId;
-    private String caseId;
+    private String restoreAsCaseId;
 
     private int timezoneOffsetMillis = -1;
 
@@ -94,12 +94,12 @@ public class AuthenticatedRequestBean {
         this.sessionId = sessionId;
     }
 
-    @JsonGetter(value = "case_id")
-    public String getCaseId() {
-        return caseId;
+    @JsonGetter(value = "restoreAsCaseId")
+    public String getRestoreAsCaseId() {
+        return restoreAsCaseId;
     }
-    @JsonSetter(value = "case_id")
-    public void setCaseId(String caseId) {
-        this.caseId = caseId;
+    @JsonSetter(value = "restoreAsCaseId")
+    public void setRestoreAsCaseId(String restoreAsCaseId) {
+        this.restoreAsCaseId = restoreAsCaseId;
     }
 }

--- a/src/main/java/db/migration/V17__add_case_id_field.java
+++ b/src/main/java/db/migration/V17__add_case_id_field.java
@@ -1,0 +1,15 @@
+package db.migration;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Created by willpride on 11/9/17.
+ */
+public class V17__add_case_id_field implements SpringJdbcMigration {
+    @Override
+    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+        jdbcTemplate.execute("ALTER TABLE formplayer_sessions " +
+                "ADD caseId VARCHAR DEFAULT NULL");
+    }
+}

--- a/src/main/java/objects/SerializableFormSession.java
+++ b/src/main/java/objects/SerializableFormSession.java
@@ -29,7 +29,7 @@ public class SerializableFormSession implements Serializable{
     private String appId;
     private Map<String, FunctionHandler[]> functionContext;
     private boolean inPromptMode;
-    private String caseId;
+    private String restoreAsCaseId;
 
     public String getInstanceXml() {
         return instanceXml;
@@ -191,11 +191,11 @@ public class SerializableFormSession implements Serializable{
         this.inPromptMode = inPromptMode;
     }
 
-    public void setCaseId(String caseId) {
-        this.caseId = caseId;
+    public void setRestoreAsCaseId(String restoreAsCaseId) {
+        this.restoreAsCaseId = restoreAsCaseId;
     }
 
-    public String getCaseId() {
-        return caseId;
+    public String getRestoreAsCaseId() {
+        return restoreAsCaseId;
     }
 }

--- a/src/main/java/objects/SerializableFormSession.java
+++ b/src/main/java/objects/SerializableFormSession.java
@@ -29,6 +29,7 @@ public class SerializableFormSession implements Serializable{
     private String appId;
     private Map<String, FunctionHandler[]> functionContext;
     private boolean inPromptMode;
+    private String caseId;
 
     public String getInstanceXml() {
         return instanceXml;
@@ -188,5 +189,13 @@ public class SerializableFormSession implements Serializable{
 
     public void setInPromptMode(boolean inPromptMode) {
         this.inPromptMode = inPromptMode;
+    }
+
+    public void setCaseId(String caseId) {
+        this.caseId = caseId;
+    }
+
+    public String getCaseId() {
+        return caseId;
     }
 }

--- a/src/main/java/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresFormSessionRepo.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -129,7 +128,7 @@ public class PostgresFormSessionRepo implements FormSessionRepo{
                         session.getAppId(),
                         functionContextBytes,
                         session.getInPromptMode(),
-                        session.getCaseId()
+                        session.getRestoreAsCaseId()
                 },
                 new int[] {
                         Types.VARCHAR,
@@ -247,7 +246,7 @@ public class PostgresFormSessionRepo implements FormSessionRepo{
             session.setAsUser(rs.getString("asUser"));
             session.setAppId(rs.getString("appid"));
             session.setInPromptMode(rs.getBoolean("inPromptMode"));
-            session.setCaseId(rs.getString("caseId"));
+            session.setRestoreAsCaseId(rs.getString("caseId"));
 
             byte[] st = (byte[]) rs.getObject("sessionData");
             if (st != null) {

--- a/src/main/java/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/repo/impl/PostgresFormSessionRepo.java
@@ -106,8 +106,8 @@ public class PostgresFormSessionRepo implements FormSessionRepo{
                 "username, initLang, sequenceId, " +
                 "domain, postUrl, sessionData, menu_session_id," +
                 "title, dateOpened, oneQuestionPerScreen, currentIndex, asUser, appid, functioncontext," +
-                "inPromptMode) " +
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                "inPromptMode, caseId) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
         this.jdbcTemplate.update(
                 query,
                 new Object[] {
@@ -128,7 +128,8 @@ public class PostgresFormSessionRepo implements FormSessionRepo{
                         session.getAsUser(),
                         session.getAppId(),
                         functionContextBytes,
-                        session.getInPromptMode()
+                        session.getInPromptMode(),
+                        session.getCaseId()
                 },
                 new int[] {
                         Types.VARCHAR,
@@ -148,7 +149,8 @@ public class PostgresFormSessionRepo implements FormSessionRepo{
                         Types.VARCHAR,
                         Types.VARCHAR,
                         Types.BINARY,
-                        Types.BINARY
+                        Types.BINARY,
+                        Types.VARCHAR
                 }
         );
         return session;
@@ -245,6 +247,7 @@ public class PostgresFormSessionRepo implements FormSessionRepo{
             session.setAsUser(rs.getString("asUser"));
             session.setAppId(rs.getString("appid"));
             session.setInPromptMode(rs.getBoolean("inPromptMode"));
+            session.setCaseId(rs.getString("caseId"));
 
             byte[] st = (byte[]) rs.getObject("sessionData");
             if (st != null) {

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -75,7 +75,7 @@ public class NewFormResponseFactory {
                 formSendCalloutHandler,
                 storageFactory,
                 Constants.NAV_MODE_PROMPT.equals(bean.getNavMode()),
-                bean.getCaseId()
+                bean.getRestoreAsCaseId()
         );
 
 

--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -74,8 +74,10 @@ public class NewFormResponseFactory {
                 bean.getSessionData().getFunctionContext(),
                 formSendCalloutHandler,
                 storageFactory,
-                Constants.NAV_MODE_PROMPT.equals(bean.getNavMode())
+                Constants.NAV_MODE_PROMPT.equals(bean.getNavMode()),
+                bean.getCaseId()
         );
+
 
         formSessionRepo.save(formSession.serialize());
         NewFormResponse response = new NewFormResponse(formSession);

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -89,6 +89,7 @@ public class FormSession {
     private Map<String, FunctionHandler[]> functionContext;
     private boolean isAtFirstIndex;
     private boolean inPromptMode;
+    private String caseId;
 
     private void setupJavaRosaObjects() {
         formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_NON_LINEAR);
@@ -123,6 +124,7 @@ public class FormSession {
         this.inPromptMode = session.getInPromptMode();
         formDef.setSendCalloutHandler(formSendCalloutHandler);
         this.functionContext = session.getFunctionContext();
+        this.caseId = session.getCaseId();
         setupJavaRosaObjects();
         if (this.oneQuestionPerScreen || this.inPromptMode) {
             FormIndex formIndex = JsonActionUtils.indexFromString(currentIndex, this.formDef);
@@ -150,7 +152,8 @@ public class FormSession {
                        Map<String, FunctionHandler[]> functionContext,
                        FormSendCalloutHandler formSendCalloutHandler,
                        FormplayerStorageFactory storageFactory,
-                       boolean inPromptMode) throws Exception {
+                       boolean inPromptMode,
+                       String caseId) throws Exception {
         this.username = TableBuilder.scrubName(username);
         this.formDef = formDef;
         formDef.setSendCalloutHandler(formSendCalloutHandler);
@@ -169,6 +172,7 @@ public class FormSession {
         this.currentIndex = "0";
         this.functionContext = functionContext;
         this.inPromptMode = inPromptMode;
+        this.caseId = caseId;
         setupJavaRosaObjects();
         setupFunctionContext();
         if(instanceContent != null){
@@ -347,6 +351,7 @@ public class FormSession {
         serializableFormSession.setAppId(appId);
         serializableFormSession.setFunctionContext(functionContext);
         serializableFormSession.setInPromptMode(inPromptMode);
+        serializableFormSession.setCaseId(caseId);
         return serializableFormSession;
     }
 

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -15,7 +15,6 @@ import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.core.services.storage.StorageManager;
 import org.javarosa.xpath.XPathException;
-import sandbox.SqlStorage;
 import sandbox.UserSqlSandbox;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.modern.database.TableBuilder;
@@ -27,8 +26,6 @@ import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.services.PrototypeManager;
-import org.javarosa.core.services.storage.IStorageIndexedFactory;
-import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.UnregisteredLocaleException;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.engine.FunctionExtensions;
@@ -89,7 +86,7 @@ public class FormSession {
     private Map<String, FunctionHandler[]> functionContext;
     private boolean isAtFirstIndex;
     private boolean inPromptMode;
-    private String caseId;
+    private String restoreAsCaseId;
 
     private void setupJavaRosaObjects() {
         formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_NON_LINEAR);
@@ -124,7 +121,7 @@ public class FormSession {
         this.inPromptMode = session.getInPromptMode();
         formDef.setSendCalloutHandler(formSendCalloutHandler);
         this.functionContext = session.getFunctionContext();
-        this.caseId = session.getCaseId();
+        this.restoreAsCaseId = session.getRestoreAsCaseId();
         setupJavaRosaObjects();
         if (this.oneQuestionPerScreen || this.inPromptMode) {
             FormIndex formIndex = JsonActionUtils.indexFromString(currentIndex, this.formDef);
@@ -172,7 +169,7 @@ public class FormSession {
         this.currentIndex = "0";
         this.functionContext = functionContext;
         this.inPromptMode = inPromptMode;
-        this.caseId = caseId;
+        this.restoreAsCaseId = caseId;
         setupJavaRosaObjects();
         setupFunctionContext();
         if(instanceContent != null){
@@ -351,7 +348,7 @@ public class FormSession {
         serializableFormSession.setAppId(appId);
         serializableFormSession.setFunctionContext(functionContext);
         serializableFormSession.setInPromptMode(inPromptMode);
-        serializableFormSession.setCaseId(caseId);
+        serializableFormSession.setRestoreAsCaseId(restoreAsCaseId);
         return serializableFormSession;
     }
 

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -270,7 +270,7 @@ public class MenuSession implements HereFunctionHandlerListener {
         return new FormSession(sandbox, formDef, username, domain,
                 sessionData, postUrl, locale, uuid,
                 null, oneQuestionPerScreen,
-                asUser, appId, null, formSendCalloutHandler, storageFactory, false);
+                asUser, appId, null, formSendCalloutHandler, storageFactory, false, null);
     }
 
     public void reloadSession(FormSession formSession) throws Exception {


### PR DESCRIPTION
And use this caseId to restore on subsequent requests.

The `FormSession` class has become overloaded, eventually I'd like to split the functionality into `SMSFormSession`, `OQPSFormSession`, and standard `FormSession` classes

cc @gcapalbo 