### PR TITLE
Don't purge caseDB for case claim sync

### DIFF
--- a/src/main/java/services/MenuSessionRunnerService.java
+++ b/src/main/java/services/MenuSessionRunnerService.java
@@ -243,7 +243,8 @@ public class MenuSessionRunnerService {
             return new NotificationMessage("Session error, expected sync block but didn't get one.", true);
         }
         if (responseEntity.getStatusCode().is2xxSuccessful()) {
-            restoreFactory.performTimedSync();
+            // Don't purge for case claim
+            restoreFactory.performTimedSync(false);
             return new NotificationMessage("Case claim successful.", false);
         } else {
             return new NotificationMessage(

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -137,16 +137,21 @@ public class RestoreFactory {
 
     // This function will only wipe user DBs when they have expired, otherwise will incremental sync
     public UserSqlSandbox performTimedSync() throws Exception {
+        return performTimedSync(true);
+    }
+    public UserSqlSandbox performTimedSync(boolean shouldPurge) throws Exception {
         // Create parent dirs if needed
         if(getSqlSandbox().getLoggedInUser() != null){
             getSQLiteDB().createDatabaseFolder();
         }
         UserSqlSandbox sandbox = restoreUser();
-        SimpleTimer purgeTimer = new SimpleTimer();
-        purgeTimer.start();
-        FormRecordProcessorHelper.purgeCases(sandbox);
-        purgeTimer.end();
-        categoryTimingHelper.recordCategoryTiming(purgeTimer, Constants.TimingCategories.PURGE_CASES);
+        if (shouldPurge) {
+            SimpleTimer purgeTimer = new SimpleTimer();
+            purgeTimer.start();
+            FormRecordProcessorHelper.purgeCases(sandbox);
+            purgeTimer.end();
+            categoryTimingHelper.recordCategoryTiming(purgeTimer, Constants.TimingCategories.PURGE_CASES);
+        }
         return sandbox;
     }
 


### PR DESCRIPTION
Noticed investigating https://manage.dimagi.com/default.asp?270264 that there were many case claim requests that took a while due to case purging. I don't think its correct to do a purge for a case claim sync and I don't believe the mobile does so. 