### PR TITLE
Impement FormplayerSuiteParser to override demo user restore

### DIFF
--- a/src/main/java/installers/FormplayerSuiteInstaller.java
+++ b/src/main/java/installers/FormplayerSuiteInstaller.java
@@ -1,17 +1,21 @@
 package installers;
 
+import org.commcare.resources.model.ResourceTable;
 import org.commcare.resources.model.installers.SuiteInstaller;
 import org.commcare.suite.model.Suite;
 import org.commcare.util.CommCarePlatform;
+import org.commcare.xml.SuiteParser;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
+import parsers.FormplayerSuiteParser;
 import services.FormplayerStorageFactory;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Created by willpride on 12/1/16.
@@ -24,6 +28,10 @@ public class FormplayerSuiteInstaller extends SuiteInstaller {
 
     public FormplayerSuiteInstaller(FormplayerStorageFactory storageFactory) {
         this.storageFactory = storageFactory;
+    }
+
+    protected SuiteParser getSuiteParser(InputStream incoming, ResourceTable table, String guid, IStorageUtilityIndexed formInstanceStorage) throws IOException {
+        return new FormplayerSuiteParser(incoming, table, guid, formInstanceStorage);
     }
 
     @Override

--- a/src/main/java/parsers/FormplayerSuiteParser.java
+++ b/src/main/java/parsers/FormplayerSuiteParser.java
@@ -1,0 +1,43 @@
+package parsers;
+
+import org.commcare.resources.model.ResourceTable;
+import org.commcare.suite.model.Detail;
+import org.commcare.suite.model.Entry;
+import org.commcare.suite.model.Menu;
+import org.commcare.xml.SuiteParser;
+import org.javarosa.core.model.instance.FormInstance;
+import org.javarosa.core.services.storage.IStorageUtilityIndexed;
+import org.javarosa.xml.util.InvalidStructureException;
+import org.javarosa.xml.util.UnfullfilledRequirementsException;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Hashtable;
+import java.util.Vector;
+
+/**
+ * Currently, we have to skip offline (demo) restores for Formplayer because these restore
+ * payloads are usually too large to store in SQLite and we don't have a file system
+ * storage abstraction setup.
+ */
+public class FormplayerSuiteParser extends SuiteParser {
+
+    public FormplayerSuiteParser(InputStream suiteStream, ResourceTable table, String resourceGuid, IStorageUtilityIndexed<FormInstance> fixtureStorage) throws IOException {
+        super(suiteStream, table, resourceGuid, fixtureStorage);
+    }
+
+    @Override
+    protected void handleTag(String tagName,
+                             Hashtable<String, Entry> entries,
+                             Vector<Menu> menus,
+                             Hashtable<String, Detail> details) throws IOException, XmlPullParserException, InvalidStructureException, UnfullfilledRequirementsException {
+        switch(tagName) {
+            case "user-restore":
+                parser.nextTag();
+                break;
+            default:
+                super.handleTag(tagName, entries, menus, details);
+        }
+    }
+}


### PR DESCRIPTION
Enable Formplayer to skip user-restore parsing during app install

- override `getSuiteParser` to return `FormplayerSuiteParser`
- override `handleTag` in `FormplayerSuiteParser` to skip `user-restore`

cross-request: https://github.com/dimagi/commcare-core/pull/762