### PR TITLE
Answer response isn't always positive, dummy

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -112,7 +112,6 @@ public class FormController extends AbstractBaseController{
         responseBean.setTitle(formEntrySession.getTitle());
         responseBean.setSequenceId(formEntrySession.getSequenceId());
         responseBean.setInstanceXml(new InstanceXmlBean(formEntrySession));
-        responseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
         return responseBean;
     }
 

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -513,6 +513,10 @@ public class FormSession {
         return responseBean;
     }
 
+    /**
+     *  Automatically advance to the next question after an answer when in "prompt" mode
+     *  (currently only used by SMS)
+     */
     public FormEntryNavigationResponseBean getNextFormNavigation() throws IOException {
         formEntryModel.setQuestionIndex(JsonActionUtils.indexFromString(this.currentIndex, formDef));
         int nextEvent = formEntryController.stepToNextEvent();

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -526,6 +526,7 @@ public class FormSession {
         responseBean.setCurrentIndex(currentIndex);
         responseBean.setInstanceXml(null);
         responseBean.setTree(null);
+        responseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
         if (nextEvent == formEntryController.EVENT_END_OF_FORM) {
             String output = submitGetXml();
             responseBean.getEvent().setOutput(output);


### PR DESCRIPTION
I think I messed this up in my SMS PR - when you get the *next* answer in prompt mode you know that the previous answer was `accepted`, but not for all requests (duh) 

addresses https://manage.dimagi.com/default.asp?270677