### PR TITLE
Skip user restores in OfflineUserRestoreInstaller

### DIFF
--- a/src/main/java/installers/FormplayerOfflineUserRestoreInstaller.java
+++ b/src/main/java/installers/FormplayerOfflineUserRestoreInstaller.java
@@ -64,14 +64,11 @@ public class FormplayerOfflineUserRestoreInstaller extends OfflineUserRestoreIns
                            Reference ref, ResourceTable table,
                            CommCarePlatform platform, boolean upgrade)
             throws UnresolvedResourceException, UnfullfilledRequirementsException {
-        OfflineUserRestore offlineUserRestore = new OfflineUserRestore();
-        storage(platform).write(offlineUserRestore);
         if (upgrade) {
             table.commit(r, Resource.RESOURCE_STATUS_INSTALLED);
         } else {
             table.commit(r, Resource.RESOURCE_STATUS_UPGRADE);
         }
-        cacheLocation = offlineUserRestore.getID();
         return true;
     }
 


### PR DESCRIPTION
cross-request: https://github.com/dimagi/commcare-core/pull/763

Skip demo user restore parsing in `FormplayerOfflineUserRestoreInstaller`

@ctsims only returning `true` from install resulted in an infinite loop [here](https://github.com/dimagi/commcare-core/blob/a1a5d09e87985a85f0c208007e49b9dc47c2c35a/src/main/java/org/commcare/resources/model/ResourceTable.java#L366-L366) - parsing in a dummy `OfflineUserRestore` and then skipping initialization gives the desired result. Please let me know if I'm missing something

