### PR TITLE
Use ReferenceManager.instance() instead of ReferenceHandler

### DIFF
--- a/src/main/java/engine/ClasspathFileRoot.java
+++ b/src/main/java/engine/ClasspathFileRoot.java
@@ -3,7 +3,7 @@ package engine;
 import org.javarosa.core.reference.InvalidReferenceException;
 import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 
 /**
  * Created by willpride on 1/4/17.
@@ -20,7 +20,7 @@ public class ClasspathFileRoot implements ReferenceFactory {
         if (context.lastIndexOf('/') != -1) {
             context = context.substring(0, context.lastIndexOf('/') + 1);
         }
-        return ReferenceHandler.instance().DeriveReference(context + URI);
+        return ReferenceManager.instance().DeriveReference(context + URI);
     }
 
     @Override

--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -16,14 +16,18 @@ import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.io.BufferedInputStream;
 import org.javarosa.core.io.StreamsUtil;
 import org.javarosa.core.reference.InvalidReferenceException;
-import org.javarosa.core.reference.ReferenceHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.reference.ResourceReferenceFactory;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.json.JSONObject;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -42,7 +46,7 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
                                   ArchiveFileRoot formplayerArchiveFileRoot) {
         super(storageFactory, formplayerInstallerFactory, System.out);
         this.mArchiveRoot = formplayerArchiveFileRoot;
-        ReferenceHandler.instance().addReferenceFactory(formplayerArchiveFileRoot);
+        ReferenceManager.instance().addReferenceFactory(formplayerArchiveFileRoot);
     }
     
     private String parseAppId(String url) {
@@ -173,9 +177,9 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
 
     @Override
     protected void setRoots() {
-        ReferenceHandler.instance().addReferenceFactory(new JavaHttpRoot());
-        ReferenceHandler.instance().addReferenceFactory(new ResourceReferenceFactory());
-        ReferenceHandler.instance().addReferenceFactory(new ClasspathFileRoot());
+        ReferenceManager.instance().addReferenceFactory(new JavaHttpRoot());
+        ReferenceManager.instance().addReferenceFactory(new ResourceReferenceFactory());
+        ReferenceManager.instance().addReferenceFactory(new ClasspathFileRoot());
     }
 
     @Override


### PR DESCRIPTION
For consistency reasons, switch to using `ReferenceManager.instance()` (as in `commcare-android`) rather than `ReferenceHandler`

cross-request: https://github.com/dimagi/commcare-core/pull/766