### PR TITLE
Centralize restoreAsCaseId username placeholder

### DIFF
--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -20,6 +20,7 @@ import services.FormplayerLockRegistry.FormplayerReentrantLock;
 import util.Constants;
 import util.FormplayerSentry;
 import util.RequestUtils;
+import util.UserUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +79,10 @@ public class LockAspect {
             SerializableFormSession formSession = formSessionRepo.findOne(bean.getSessionId());
             String tempUser = formSession.getUsername();
             String restoreAs = formSession.getAsUser();
-            if (restoreAs != null) {
+            String restoreAsCaseId = formSession.getRestoreAsCaseId();
+            if (restoreAsCaseId != null) {
+                username = UserUtils.getRestoreAsCaseIdUsername(restoreAsCaseId);
+            } else if (restoreAs != null) {
                 username = tempUser + "_" + restoreAs;
             } else {
                 username = tempUser;

--- a/src/main/java/beans/AuthenticatedRequestBean.java
+++ b/src/main/java/beans/AuthenticatedRequestBean.java
@@ -2,6 +2,7 @@ package beans;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import util.UserUtils;
 
 /**
  * The AuthenticatedRequestBean should be used for requests that
@@ -46,6 +47,9 @@ public class AuthenticatedRequestBean {
     }
 
     public String getUsernameDetail() {
+        if (restoreAsCaseId != null) {
+            return UserUtils.getRestoreAsCaseIdUsername(restoreAsCaseId);
+        }
         if (restoreAs != null) {
             return username + "_" + restoreAs;
         }

--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -14,6 +14,7 @@ import sandbox.SqlStorage;
 import sqlitedb.ApplicationDB;
 import sqlitedb.SQLiteDB;
 import util.FormplayerPropertyManager;
+import util.UserUtils;
 
 /**
  * FormPlayer's storage factory that negotiates between parsers/installers and the storage layer
@@ -47,7 +48,7 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory {
         SerializableFormSession formSession = formSessionRepo.findOneWrapped(formSessionId);
         if (formSession.getRestoreAsCaseId() != null) {
             configure(
-                    "CASE" + formSession.getRestoreAsCaseId(),
+                    UserUtils.getRestoreAsCaseIdUsername(formSession.getRestoreAsCaseId()),
                     formSession.getDomain(),
                     formSession.getAppId(),
                     null

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -102,7 +102,7 @@ public class RestoreFactory {
     private String caseId;
 
     public void configure(String domain, String caseId, HqAuth auth) {
-        this.setUsername("CASE" + caseId);
+        this.setUsername(UserUtils.getRestoreAsCaseIdUsername(caseId));
         this.setDomain(domain);
         this.setCaseId(caseId);
         this.setHqAuth(auth);

--- a/src/main/java/util/UserUtils.java
+++ b/src/main/java/util/UserUtils.java
@@ -4,6 +4,11 @@ package util;
  * Utility methods for dealing with users
  */
 public class UserUtils {
+
+    public static String getRestoreAsCaseIdUsername(String caseId) {
+        return "CASE" + caseId;
+    }
+
     public static boolean isAnonymous(String domain, String username) {
         if (domain == null || username == null) {
             return false;


### PR DESCRIPTION
Restoring as case was using the `Touchforms` default username `unknown` which I believe was causing issues with locking. This PR adds a function to create a placeholder username for requests restoring as a case and uses that for locking and in some other places. 