### PR TITLE
Don't purge CaseDB when restoring as a case

### DIFF
--- a/src/main/java/services/NewFormResponseFactory.java
+++ b/src/main/java/services/NewFormResponseFactory.java
@@ -54,7 +54,9 @@ public class NewFormResponseFactory {
         } else {
             throw new RuntimeException("No FormURL or FormContent");
         }
-        UserSqlSandbox sandbox = restoreFactory.performTimedSync();
+        // Don't purge when restoring as a case
+        boolean shouldPurge = bean.getRestoreAsCaseId() == null;
+        UserSqlSandbox sandbox = restoreFactory.performTimedSync(shouldPurge);
 
         storageFactory.configure(bean.getUsername(), bean.getDomain(), bean.getSessionData().getAppId(), bean.getRestoreAs());
 


### PR DESCRIPTION
Restoring as a case was running into issues when a case purge was triggered; because the logged in user (the case) is not the owner, the case would be purged. Set `shouldPurge` to false in this mode. 