### PR TITLE
Do not crash when using OQPS on a form with no questions

### DIFF
--- a/src/main/java/api/json/JsonActionUtils.java
+++ b/src/main/java/api/json/JsonActionUtils.java
@@ -287,8 +287,11 @@ public class JsonActionUtils {
     }
 
     public static JSONArray getOneQuestionPerScreenJSON(FormEntryModel fem, FormEntryController fec, FormIndex formIndex) {
-        FormEntryPrompt[] prompts = fec.getQuestionPrompts(formIndex);
         JSONArray ret = new JSONArray();
+        if (formIndex.isEndOfFormIndex()) {
+            return ret;
+        }
+        FormEntryPrompt[] prompts = fec.getQuestionPrompts(formIndex);
         for (FormEntryPrompt prompt: prompts) {
             fem.setQuestionIndex(prompt.getIndex());
             JSONObject obj = new JSONObject();

--- a/src/test/java/tests/FormEntryTest.java
+++ b/src/test/java/tests/FormEntryTest.java
@@ -174,4 +174,11 @@ public class FormEntryTest extends BaseTestClass{
         assert response3.getTree().length == 1;
 
     }
+
+    // Test form with no questions
+    @Test
+    public void testNoQuestions() throws Exception {
+        NewFormResponse newSessionResponse = startNewForm("requests/new_form/new_form_oqps.json", "xforms/no_questions.xml");
+        assert newSessionResponse.getTree().length == 0;
+    }
 }

--- a/src/test/resources/xforms/no_questions.xml
+++ b/src/test/resources/xforms/no_questions.xml
@@ -1,0 +1,30 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Survey</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/179475ED-0A85-4360-852B-4D8AD373076E" uiVersion="1" version="5" name="Survey">
+                    <hidden_in_root/>
+                    <a_group>
+                        <hidden_in_group/>
+                    </a_group>
+                    <orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+            </instance><instance id="commcaresession" src="jr://instance/session"/>
+            <bind nodeset="/data/hidden_in_root" calculate="&quot;hidden_in_root&quot;"/>
+            <bind nodeset="/data/a_group"/>
+            <bind nodeset="/data/a_group/hidden_in_group" calculate="&quot;hidden_in_group&quot;"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="a_group-label">
+                        <value>A GROUP</value>
+                    </text>
+                </translation>
+            </itext>
+            <setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
+    </h:head>
+    <h:body>
+        <group ref="/data/a_group" appearance="field-list">
+            <label ref="jr:itext('a_group-label')"/>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
When using OQPS on a form with no questions (for example, only hidden values) we would crash. Fix that by returning an empty tree instead. 

Sentry: https://sentry.io/dimagi/formplayer/issues/438147580/?query=is:unresolved%20level:error

Shoutout to @pr33thi for helping me get to the bottom of this one!