### PR TITLE
Allow POST requests to get-instance as well

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -350,7 +350,7 @@ public class FormController extends AbstractBaseController{
     }
 
     @ApiOperation(value = "Get the raw instance for a form session")
-    @RequestMapping(value = Constants.URL_GET_INSTANCE, method = RequestMethod.GET)
+    @RequestMapping(value = Constants.URL_GET_INSTANCE, method = {RequestMethod.GET, RequestMethod.POST})
     @ResponseBody
     @UserLock
     @UserRestore


### PR DESCRIPTION
Fixes https://sentry.io/dimagi/commcarehq/issues/492026734/?referrer=slack

Seems like technically this should be a `GET` request but for the sake of the SMS migration accept `POST` too