### PR TITLE
StorageManager refactor

### DIFF
--- a/src/main/java/installers/FormplayerInstallerFactory.java
+++ b/src/main/java/installers/FormplayerInstallerFactory.java
@@ -20,20 +20,20 @@ public class FormplayerInstallerFactory extends InstallerFactory {
     FormplayerStorageFactory storageFactory;
 
     public ResourceInstaller getProfileInstaller(boolean forceInstall) {
-        return new FormplayerProfileInstaller(forceInstall, storageFactory);
+        return new FormplayerProfileInstaller(forceInstall);
     }
 
     @Override
     public ResourceInstaller getXFormInstaller() {
-        return new FormplayerXFormInstaller(storageFactory);
+        return new FormplayerXFormInstaller();
     }
 
     public ResourceInstaller getUserRestoreInstaller() {
-        return new FormplayerOfflineUserRestoreInstaller(storageFactory);
+        return new FormplayerOfflineUserRestoreInstaller();
     }
 
     public ResourceInstaller getSuiteInstaller() {
-        return new FormplayerSuiteInstaller(storageFactory);
+        return new FormplayerSuiteInstaller();
     }
 
     public ResourceInstaller getLocaleFileInstaller(String locale) {

--- a/src/main/java/installers/FormplayerOfflineUserRestoreInstaller.java
+++ b/src/main/java/installers/FormplayerOfflineUserRestoreInstaller.java
@@ -26,13 +26,7 @@ import java.io.IOException;
  */
 public class FormplayerOfflineUserRestoreInstaller extends OfflineUserRestoreInstaller {
 
-    FormplayerStorageFactory storageFactory;
-
     public FormplayerOfflineUserRestoreInstaller(){}
-
-    public FormplayerOfflineUserRestoreInstaller(FormplayerStorageFactory storageFactory) {
-        this.storageFactory = storageFactory;
-    }
 
     @Override
     public boolean initialize(CommCarePlatform platform, boolean isUpgrade) {
@@ -42,21 +36,9 @@ public class FormplayerOfflineUserRestoreInstaller extends OfflineUserRestoreIns
     @Override
     protected IStorageUtilityIndexed<OfflineUserRestore> storage(CommCarePlatform platform) {
         if (cacheStorage == null) {
-            cacheStorage = storageFactory.newStorage(OfflineUserRestore.STORAGE_KEY, OfflineUserRestore.class);
+            cacheStorage = platform.getStorageManager().getStorage(OfflineUserRestore.STORAGE_KEY);
         }
         return cacheStorage;
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        super.readExternal(in, pf);
-        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String restoreAs = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(username, domain, appId, restoreAs);
-
     }
 
     @Override
@@ -70,14 +52,5 @@ public class FormplayerOfflineUserRestoreInstaller extends OfflineUserRestoreIns
             table.commit(r, Resource.RESOURCE_STATUS_UPGRADE);
         }
         return true;
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAsUsername()));
     }
 }

--- a/src/main/java/installers/FormplayerProfileInstaller.java
+++ b/src/main/java/installers/FormplayerProfileInstaller.java
@@ -18,41 +18,17 @@ import java.io.IOException;
  */
 public class FormplayerProfileInstaller extends ProfileInstaller {
 
-    FormplayerStorageFactory storageFactory;
-
     public FormplayerProfileInstaller(){}
 
-    public FormplayerProfileInstaller(boolean forceInstall, FormplayerStorageFactory storageFactory) {
+    public FormplayerProfileInstaller(boolean forceInstall) {
         super(forceInstall);
-        this.storageFactory = storageFactory;
     }
 
     @Override
     protected IStorageUtilityIndexed<Profile> storage(CommCarePlatform platform) {
         if (cacheStorage == null) {
-            cacheStorage = storageFactory.newStorage(Profile.STORAGE_KEY, Profile.class);
+            cacheStorage = platform.getStorageManager().getStorage(Profile.STORAGE_KEY);
         }
         return cacheStorage;
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        super.readExternal(in, pf);
-        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String asUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(username, domain, appId, asUsername);
-
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAsUsername()));
     }
 }

--- a/src/main/java/installers/FormplayerSuiteInstaller.java
+++ b/src/main/java/installers/FormplayerSuiteInstaller.java
@@ -18,40 +18,13 @@ import java.io.IOException;
  */
 public class FormplayerSuiteInstaller extends SuiteInstaller {
 
-    FormplayerStorageFactory storageFactory;
-
     public FormplayerSuiteInstaller(){}
-
-    public FormplayerSuiteInstaller(FormplayerStorageFactory storageFactory) {
-        this.storageFactory = storageFactory;
-    }
 
     @Override
     protected IStorageUtilityIndexed<Suite> storage(CommCarePlatform platform) {
         if (cacheStorage == null) {
-            cacheStorage = storageFactory.newStorage(Suite.STORAGE_KEY, Suite.class);
+            cacheStorage = platform.getStorageManager().getStorage(Suite.STORAGE_KEY);
         }
         return cacheStorage;
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        super.readExternal(in, pf);
-        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String asUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(username, domain, appId, asUsername);
-
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAsUsername()));
     }
 }

--- a/src/main/java/installers/FormplayerXFormInstaller.java
+++ b/src/main/java/installers/FormplayerXFormInstaller.java
@@ -18,39 +18,13 @@ import java.io.IOException;
  */
 public class FormplayerXFormInstaller extends XFormInstaller {
 
-    FormplayerStorageFactory storageFactory;
-
     public FormplayerXFormInstaller(){}
-
-    public FormplayerXFormInstaller(FormplayerStorageFactory storageFactory) {
-        this.storageFactory = storageFactory;
-    }
 
     @Override
     protected IStorageUtilityIndexed<FormDef> storage(CommCarePlatform platform) {
         if (cacheStorage == null) {
-            cacheStorage = storageFactory.newStorage(FormDef.STORAGE_KEY, FormDef.class);
+            cacheStorage = platform.getStorageManager().getStorage(FormDef.STORAGE_KEY);
         }
         return cacheStorage;
-    }
-
-    @Override
-    public void readExternal(DataInputStream in, PrototypeFactory pf) throws IOException, DeserializationException {
-        super.readExternal(in, pf);
-        String username = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String domain = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String appId = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        String asUsername = ExtUtil.nullIfEmpty(ExtUtil.readString(in));
-        storageFactory = new FormplayerStorageFactory();
-        storageFactory.configure(username, domain, appId, asUsername);
-    }
-
-    @Override
-    public void writeExternal(DataOutputStream out) throws IOException {
-        super.writeExternal(out);
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getUsername()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getDomain()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAppId()));
-        ExtUtil.writeString(out, ExtUtil.emptyIfNull(storageFactory.getAsUsername()));
     }
 }


### PR DESCRIPTION
An earlier refactor for parity with `commcare-core/master` added the `StorageManager` to the `CommCarePlatform` class so we no longer need to configure it separately inside these installers. 

~~Contains commits from https://github.com/dimagi/formplayer/pull/641 so don't look into until that is merged~~