### PR TITLE
Add handling for EvaluateXPathResponse to not fail hard on invalid re…

### DIFF
--- a/src/main/java/beans/EvaluateXPathResponseBean.java
+++ b/src/main/java/beans/EvaluateXPathResponseBean.java
@@ -66,7 +66,11 @@ public class EvaluateXPathResponseBean extends LocationRelevantResponseBean {
             serializer.setOutput(outputStream, "UTF-8");
             serializer.startTag(null, "result");
             serializer.flush();
-            XPathExpression.serializeResult(value, outputStream);
+            try {
+                XPathExpression.serializeResult(value, outputStream);
+            } catch (NullPointerException e) {
+                // We want to not fail on invalid refs here, just return an empty result
+            }
             serializer.endTag(null, "result");
             serializer.flush();
             output = XmlUtil.getPrettyXml(outputStream.toByteArray());


### PR DESCRIPTION
Because we decided [this change](https://github.com/dimagi/commcare-core/pull/800/commits/bd4c69b58f1c97cd34112da6b20f2ed02bc4caa7) in `commcare-core` needed to be reverted since we want to fail fast in `core`, handle the case of an invalid reference in the XPathEvaluator text box at the Formplayer level