### PR TITLE
Add route for changing language of form session

### DIFF
--- a/src/main/java/api/json/JsonActionUtils.java
+++ b/src/main/java/api/json/JsonActionUtils.java
@@ -61,7 +61,7 @@ public class JsonActionUtils {
      * @param model      the FormEntryModel under consideration
      * @return The JSON representation of the question tree
      */
-    private static JSONObject getCurrentJson(FormEntryController controller,
+    public static JSONObject getCurrentJson(FormEntryController controller,
                                                  FormEntryModel model) {
         JSONObject ret = new JSONObject();
         ret.put(ApiConstants.QUESTION_TREE_KEY, getFullFormJSON(model, controller));

--- a/src/main/java/beans/ChangeLocaleRequestBean.java
+++ b/src/main/java/beans/ChangeLocaleRequestBean.java
@@ -1,0 +1,29 @@
+package beans;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request to change the locale of the form session
+ *
+ * Created by willpride on 1/20/16.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChangeLocaleRequestBean extends SessionRequestBean {
+    private String locale;
+    // our JSON-Object mapping lib (Jackson) requires a default constructor
+    public ChangeLocaleRequestBean(){}
+
+
+    @Override
+    public String toString(){
+        return "ChangeLocaleRequestBean [locale=" + locale + ", sessionId=" + sessionId + "]";
+    }
+
+    public String getLocale() {
+        return locale;
+    }
+
+    public void setLocale(String locale) {
+        this.locale = locale;
+    }
+}

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -290,7 +290,7 @@ public class FormSession {
         this.sequenceId = sequenceId;
     }
 
-    private String getLocale() {
+    public String getLocale() {
         return locale;
     }
 
@@ -482,6 +482,11 @@ public class FormSession {
         setCurrentIndex(formController.getFormIndex().toString());
     }
 
+    public FormEntryResponseBean getCurrentJSON() throws IOException {
+        JSONObject jsonObject = JsonActionUtils.getCurrentJson(formEntryController, formEntryModel);
+        return new ObjectMapper().readValue(jsonObject.toString(), FormEntryResponseBean.class);
+    }
+
     public FormEntryResponseBean answerQuestionToJSON(Object answer, String answerIndex) throws IOException {
         if (answerIndex == null) {
             answerIndex = getCurrentIndex();
@@ -579,5 +584,10 @@ public class FormSession {
 
     public void setIsAtFirstIndex(boolean isAtFirstIndex) {
         this.isAtFirstIndex = isAtFirstIndex;
+    }
+
+    public void changeLocale(String locale) {
+        this.locale = locale;
+        formEntryController.setLanguage(locale);
     }
 }

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -37,6 +37,7 @@ public class Constants {
     public static final String URL_PREV_INDEX = "prev_index";
     public static final String URL_VALIDATE_FORM = "validate_form";
     public static final String URL_GET_INSTANCE = "get-instance";
+    public static final String URL_CHANGE_LANGUAGE = "change_locale";
 
     // Alternative namings used by SMS
     public static final String URL_NEXT = "next";

--- a/src/test/java/tests/BaseTestClass.java
+++ b/src/test/java/tests/BaseTestClass.java
@@ -257,6 +257,18 @@ public class BaseTestClass {
                 FormEntryResponseBean.class);
     }
 
+    FormEntryResponseBean changeLanguage(String locale) throws Exception {
+        ChangeLocaleRequestBean changeLocaleBean = new ChangeLocaleRequestBean();
+        changeLocaleBean.setLocale(locale);
+        changeLocaleBean.setUsername(formSessionRepoMock.findOneWrapped("sessionid").getUsername());
+        changeLocaleBean.setDomain(formSessionRepoMock.findOneWrapped("sessionid").getDomain());
+        return generateMockQuery(ControllerType.FORM,
+                RequestType.POST,
+                Constants.URL_CHANGE_LANGUAGE,
+                changeLocaleBean,
+                FormEntryResponseBean.class);
+    }
+
     FormEntryResponseBean answerQuestionGetResult(String index, String answer, String sessionId) throws Exception {
         AnswerQuestionRequestBean answerQuestionBean = new AnswerQuestionRequestBean(index, answer, sessionId);
         answerQuestionBean.setUsername(formSessionRepoMock.findOneWrapped(sessionId).getUsername());

--- a/src/test/java/tests/LocalizationTests.java
+++ b/src/test/java/tests/LocalizationTests.java
@@ -1,6 +1,7 @@
 package tests;
 
 import auth.HqAuth;
+import beans.FormEntryResponseBean;
 import beans.NewFormResponse;
 import beans.menus.CommandListResponseBean;
 import org.json.JSONObject;
@@ -52,6 +53,31 @@ public class LocalizationTests extends BaseTestClass {
         assert commandListResponseSpanish.getCommands()[0].getDisplayText().equals("Spanish Form 1");
 
         assert commandListResponseSpanish.getCommands()[1].getDisplayText().equals("Spanish Form 2");
+
+    }
+
+    @Test
+    public void testInFormLocalization() throws Exception {
+        NewFormResponse newFormResponse =
+                this.sessionNavigate(new String[]{"0", "0"}, "langs", NewFormResponse.class);
+
+        assert newFormResponse.getTree().length == 2;
+
+        assert newFormResponse.getTree()[0].getCaption().equals("I'm English");
+
+        assert newFormResponse.getTree()[1].getCaption().equals("English rules");
+
+        FormEntryResponseBean formResponse = this.changeLanguage("es");
+
+        assert formResponse.getTree()[0].getCaption().equals("I'm Spanish");
+
+        assert formResponse.getTree()[1].getCaption().equals("No Spanish rules");
+
+        formResponse = this.answerQuestionGetResult(null, "0", "sessionid");
+
+        assert formResponse.getTree()[0].getCaption().equals("I'm Spanish");
+
+        assert formResponse.getTree()[1].getCaption().equals("No Spanish rules");
 
     }
 


### PR DESCRIPTION
For easier debugging in App Preview. Not wired into anything in the front end at the moment but safe to merge on its own.

@orangejenny 

The languages should be available at form start in the 'data' object [here](https://github.com/dimagi/commcare-hq/blob/b322c7ce0e00790b81e4937b6fef19b03737a9cb/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js#L144-L144)  under the `langs` key

