### PR TITLE
Check assertions in Formplayer

### DIFF
--- a/src/main/java/services/MenuSessionRunnerService.java
+++ b/src/main/java/services/MenuSessionRunnerService.java
@@ -395,8 +395,6 @@ public class MenuSessionRunnerService {
         Text text = menuSession.getSessionWrapper().getCurrentEntry().getAssertions().getAssertionFailure(menuSession.getEvalContextWithHereFuncHandler());
         if (text != null) {
             return text.evaluate(menuSession.getEvalContextWithHereFuncHandler());
-        } else if (menuSession.getSessionWrapper().getForm() == null) {
-            return "No form found!";
         }
         return null;
     }


### PR DESCRIPTION
Addresses https://manage.dimagi.com/default.asp?277832

I hadn't realized we didn't evaluate `<assertion>` blocks in Formplayer - I thought we got them for free at the `commcare-core` level. This rectifies that. 

cc @orangejenny 