### PR TITLE
unnecessary message

### DIFF
--- a/src/main/java/services/MenuSessionRunnerService.java
+++ b/src/main/java/services/MenuSessionRunnerService.java
@@ -205,7 +205,7 @@ public class MenuSessionRunnerService {
         } else {
             BaseResponseBean responseBean = resolveFormGetNext(menuSession);
             if (responseBean == null) {
-                responseBean = new BaseResponseBean(null, "Got null menu, redirecting to home screen.", false, true);
+                responseBean = new BaseResponseBean(null, null, false, true);
             }
             return responseBean;
         }


### PR DESCRIPTION
https://manage.dimagi.com/default.asp?280046#1513916

This response does seem unnecessarily confusing. It seems reasonable to just get rid of it. I'm not sure what other situations besides the `case list menu item` would trigger it, but I think I'm ok with a silent error anyway.

I didn't find anything existent that distinguishes `clmi` items that's currently available, but maybe I can spend a bit more time at some point and figure out how to do that.

buddy: @snopoke 
not sure who else to tag --> @dannyroberts?