### PR TITLE
handle hmac exceptions separately from others

### DIFF
--- a/src/main/java/application/FormplayerAuthFilter.java
+++ b/src/main/java/application/FormplayerAuthFilter.java
@@ -60,21 +60,21 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
                 logger.info("Validating X-MAC-DIGEST");
                 String header = request.getHeader(Constants.HMAC_HEADER);
                 String body = RequestUtils.getBody(request);
+                String hash;
                 try {
-                    String hash = RequestUtils.getHmac(formplayerAuthKey, body);
-                    if (header.equals(hash)) {
-                        setSmsRequestDetails(request);
-                    } else {
-                        logger.error(String.format("Hash comparison between request %s and generated %s failed",
-                                header, hash));
-                        setResponseUnauthorized(response, "Invalid HMAC hash");
-                        return;
-                    }
+                    hash = RequestUtils.getHmac(formplayerAuthKey, body);
                 } catch (Exception e) {
                     logger.error(String.format("Error generating hash of body %s", body), e);
                     setResponseUnauthorized(response, "Invalid HMAC hash");
                     return;
                 }
+                if (!header.equals(hash)) {
+                    logger.error(String.format("Hash comparison between request %s and generated %s failed",
+                            header, hash));
+                    setResponseUnauthorized(response, "Invalid HMAC hash");
+                    return;
+                }
+                setSmsRequestDetails(request);
             }
             else {
                 if (getSessionId(request) == null) {


### PR DESCRIPTION
What was being reported as an HMAC error in [sentry](https://sentry.io/dimagi/commcarehq/issues/754700558/) is acatully a `FormNotFoundException`.

Formplayer will now 404 on `FormNotFoundException` and any other errors will cause a 500.