### PR TITLE
Update File Path References

### DIFF
--- a/src/main/java/sqlitedb/ApplicationDBPath.java
+++ b/src/main/java/sqlitedb/ApplicationDBPath.java
@@ -1,5 +1,7 @@
 package sqlitedb;
 
+import java.io.File;
+
 import util.Constants;
 
 class ApplicationDBPath extends DBPath {
@@ -18,7 +20,7 @@ class ApplicationDBPath extends DBPath {
 
     @Override
     public String getDatabasePath() {
-        return UserDBPath.getUserDBPath(domain, username, asUsername) + "/" + appId;
+        return UserDBPath.getUserDBPath(domain, username, asUsername) + File.separator + appId;
     }
 
     @Override

--- a/src/main/java/sqlitedb/DBPath.java
+++ b/src/main/java/sqlitedb/DBPath.java
@@ -1,10 +1,12 @@
 package sqlitedb;
 
+import java.io.File;
+
 abstract class DBPath {
     abstract String getDatabasePath();
     abstract String getDatabaseName();
 
     String getDatabaseFile() {
-        return getDatabasePath() + "/" + getDatabaseName() + ".db";
+        return getDatabasePath() + File.separator + getDatabaseName() + ".db";
     }
 }

--- a/src/main/java/sqlitedb/UserDBPath.java
+++ b/src/main/java/sqlitedb/UserDBPath.java
@@ -2,6 +2,9 @@ package sqlitedb;
 
 import application.SQLiteProperties;
 import org.commcare.modern.database.TableBuilder;
+
+import java.io.File;
+
 import util.Constants;
 
 class UserDBPath extends DBPath {
@@ -18,7 +21,7 @@ class UserDBPath extends DBPath {
     }
 
     static String getUserDBPath(String domain, String username, String asUsername) {
-        return SQLiteProperties.getDataDir() + domain + "/" + TableBuilder.scrubName(getUsernameDetail(username, asUsername));
+        return SQLiteProperties.getDataDir() + domain + File.separator + TableBuilder.scrubName(getUsernameDetail(username, asUsername));
     }
 
     private static String getUsernameDetail(String username, String asUsername) {


### PR DESCRIPTION
Fixes filepath references to use explicit file separators, rather than implicit ones

Fixes bugs that occur downstream if the paths don't match (Specifically failures to update the autoCommit behavior on the connection) 