### PR TITLE
Adds timeouts on download requests

### DIFF
--- a/src/main/java/engine/FormplayerConfigEngine.java
+++ b/src/main/java/engine/FormplayerConfigEngine.java
@@ -3,11 +3,13 @@ package engine;
 import exceptions.ApplicationConfigException;
 import exceptions.FormattedApplicationConfigException;
 import installers.FormplayerInstallerFactory;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
+import org.commcare.core.network.CommCareNetworkServiceGenerator;
 import org.commcare.modern.reference.ArchiveFileRoot;
 import org.commcare.modern.reference.JavaHttpRoot;
 import org.commcare.resources.model.InstallCancelledException;
@@ -49,12 +51,12 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         this.mArchiveRoot = formplayerArchiveFileRoot;
         ReferenceManager.instance().addReferenceFactory(formplayerArchiveFileRoot);
     }
-    
+
     private String parseAppId(String url) {
         String appId = null;
         try {
             List<NameValuePair> params = new URIBuilder(url).getQueryParams();
-            for (NameValuePair param: params) {
+            for (NameValuePair param : params) {
                 if (param.getName().equals("app_id")) {
                     appId = param.getValue();
                 }
@@ -108,9 +110,11 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         BufferedInputStream bis = null;
         try {
             URL url = new URL(resource);
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            HttpURLConnection conn = (HttpURLConnection)url.openConnection();
             conn.setInstanceFollowRedirects(true);  //you still need to handle redirect manully.
             HttpURLConnection.setFollowRedirects(true);
+            conn.setReadTimeout(CommCareNetworkServiceGenerator.CONNECTION_SO_TIMEOUT);
+            conn.setConnectTimeout(CommCareNetworkServiceGenerator.CONNECTION_TIMEOUT);
 
             if (conn.getResponseCode() == 400) {
                 handleInstallError(conn.getErrorStream());


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/HI-776
Sentry: https://sentry.io/organizations/dimagi/issues/1037055401/?project=142105&query=is%3Aunresolved

In the sentry trace error above, the app profile download always seems stuck while reading the network response from stream. Since we were not setting any explicit timeouts on these request, it can cause the thread to get stuck and hold the lock infinitely. 

cross-request: https://github.com/dimagi/commcare-core/pull/863