### PR TITLE
Add HQ request timeouts

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -60,6 +61,7 @@ import services.RestoreFactory;
 import services.SubmitService;
 import services.SyncRequester;
 import services.XFormService;
+import util.Constants;
 import util.FormplayerSentry;
 
 import java.util.Arrays;
@@ -347,8 +349,13 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     public HqUserDetailsService userDetailsService(RestTemplateBuilder builder) { return new HqUserDetailsService(builder); }
 
     @Bean
+    public RestTemplate hqRest(RestTemplateBuilder builder) { return builder.build(); }
+
+    @Bean
     public RestTemplateBuilder restTemplateBuilder() {
-        return new RestTemplateBuilder();
+        return new RestTemplateBuilder()
+                .setConnectTimeout(Constants.CONNECT_TIMEOUT)
+                .setReadTimeout(Constants.READ_TIMEOUT);
     }
 
     @Bean

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -93,6 +93,9 @@ public class RestoreFactory {
     @Autowired
     private FormplayerStorageFactory storageFactory;
 
+    @Autowired
+    private RestTemplate hqRest;
+
     @Resource(name="redisTemplateLong")
     private ValueOperations<String, Long> valueOperations;
 
@@ -399,11 +402,10 @@ public class RestoreFactory {
     }
 
     private InputStream getRestoreXmlHelper(String restoreUrl, HttpHeaders headers) {
-        RestTemplate restTemplate = new RestTemplate();
         log.info("Restoring at domain: " + domain + " with url: " + restoreUrl);
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE);
         downloadRestoreTimer.start();
-        ResponseEntity<org.springframework.core.io.Resource> response = restTemplate.exchange(
+        ResponseEntity<org.springframework.core.io.Resource> response = hqRest.exchange(
                 restoreUrl,
                 HttpMethod.GET,
                 new HttpEntity<String>(headers),

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -108,6 +108,8 @@ public class Constants {
     public static final int USER_LOCK_TIMEOUT = 21;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;
+    public static final int CONNECT_TIMEOUT = 60 * 1000;
+    public static final int READ_TIMEOUT = LOCK_DURATION;
 
     //Misc
     public static String HMAC_HEADER = "X-MAC-DIGEST";

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -17,6 +17,7 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.support.locks.LockRegistry;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
@@ -149,6 +150,10 @@ public class TestContext {
     public FormplayerHttpRequest request() {
         return Mockito.mock(FormplayerHttpRequest.class);
     }
+
+    @Bean
+    public RestTemplate hqRest() { return new RestTemplate(); }
+
     @Bean
     public StatsDClient datadogStatsDClient() {
         return Mockito.mock(StatsDClient.class);


### PR DESCRIPTION
Read timeout of 15 minutes matches the expiration period of locks used around restore requests to hopefully prevent those requests from hanging indefinitely and subsequently locking a user out of formplayer (until the next restart). While it's good to have this in place as a fallback, 15 minute lock periods make for a bad user experience, and this does not fix the root cause of that issue.