### PR TITLE
Revert "Add HQ request timeouts"

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -32,7 +32,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -61,7 +60,6 @@ import services.RestoreFactory;
 import services.SubmitService;
 import services.SyncRequester;
 import services.XFormService;
-import util.Constants;
 import util.FormplayerSentry;
 
 import java.util.Arrays;
@@ -349,13 +347,8 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     public HqUserDetailsService userDetailsService(RestTemplateBuilder builder) { return new HqUserDetailsService(builder); }
 
     @Bean
-    public RestTemplate hqRest(RestTemplateBuilder builder) { return builder.build(); }
-
-    @Bean
     public RestTemplateBuilder restTemplateBuilder() {
-        return new RestTemplateBuilder()
-                .setConnectTimeout(Constants.CONNECT_TIMEOUT)
-                .setReadTimeout(Constants.READ_TIMEOUT);
+        return new RestTemplateBuilder();
     }
 
     @Bean

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -93,9 +93,6 @@ public class RestoreFactory {
     @Autowired
     private FormplayerStorageFactory storageFactory;
 
-    @Autowired
-    private RestTemplate hqRest;
-
     @Resource(name="redisTemplateLong")
     private ValueOperations<String, Long> valueOperations;
 
@@ -402,10 +399,11 @@ public class RestoreFactory {
     }
 
     private InputStream getRestoreXmlHelper(String restoreUrl, HttpHeaders headers) {
+        RestTemplate restTemplate = new RestTemplate();
         log.info("Restoring at domain: " + domain + " with url: " + restoreUrl);
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE);
         downloadRestoreTimer.start();
-        ResponseEntity<org.springframework.core.io.Resource> response = hqRest.exchange(
+        ResponseEntity<org.springframework.core.io.Resource> response = restTemplate.exchange(
                 restoreUrl,
                 HttpMethod.GET,
                 new HttpEntity<String>(headers),

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -108,8 +108,6 @@ public class Constants {
     public static final int USER_LOCK_TIMEOUT = 21;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;
-    public static final int CONNECT_TIMEOUT = 60 * 1000;
-    public static final int READ_TIMEOUT = LOCK_DURATION;
 
     //Misc
     public static String HMAC_HEADER = "X-MAC-DIGEST";

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -17,7 +17,6 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.support.locks.LockRegistry;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
@@ -150,10 +149,6 @@ public class TestContext {
     public FormplayerHttpRequest request() {
         return Mockito.mock(FormplayerHttpRequest.class);
     }
-
-    @Bean
-    public RestTemplate hqRest() { return new RestTemplate(); }
-
     @Bean
     public StatsDClient datadogStatsDClient() {
         return Mockito.mock(StatsDClient.class);


### PR DESCRIPTION
The deploy of this code coincides with formplayer 401 errors from HQ on restore URLs. 

Notice the time of the first occurrance of the current formplayer errors
```
(production) cchq@formplayer2-production:~/www/production/log$ grep "HttpClientErrorException: 401" formplayer-spring.log | head
2019-10-17 19:30:16.851 ERROR 4660 --- [nio-8181-exec-3] application.AbstractBaseController       : Exception org.springframework.web.client.HttpClientErrorException: 401 Unauthorized making external request util.FormplayerHttpRequest@5864d204.
2019-10-17 19:39:22.577 ERROR 4660 --- [nio-8181-exec-2] application.AbstractBaseController       : Exception org.springframework.web.client.HttpClientErrorException: 401 Unauthorized making external request util.FormplayerHttpRequest@7efa5cf0.
```
Notice the deploy time of formplayer, matches with those exceptions
```
lrwxrwxrwx 1 root root   68 Oct 17 19:23 current -> /home/cchq/www/production/formplayer_build/releases/2019-10-17_19.23/
```

Notice the nginx 401s for webapps requests
```
35.175.35.59 - - - - - [18/Oct/2019:09:04:32 +0000] "GET /a/sravan-test/phone/restore/?version=2.0&device_id=WebAppsLogin HTTP/1.1" 401 639 0 "-" "Apache-HttpClient/4.5.2 (Java/1.8.0_222)"
```

I am not sure how [this PR](https://github.com/dimagi/formplayer/pull/688) would cause these issues, so I am attempting a revert of this PR since entire webapps is down due to this issue. The context also available on https://dimagi.slack.com/archives/C0B44C0Q2/p1571391889050300


@calellowitz 