### PR TITLE
Add HQ request timeouts (second try)

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -32,6 +32,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -60,6 +61,7 @@ import services.RestoreFactory;
 import services.SubmitService;
 import services.SyncRequester;
 import services.XFormService;
+import util.Constants;
 import util.FormplayerSentry;
 
 import java.util.Arrays;
@@ -347,8 +349,13 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     public HqUserDetailsService userDetailsService(RestTemplateBuilder builder) { return new HqUserDetailsService(builder); }
 
     @Bean
+    public RestTemplate hqRest(RestTemplateBuilder builder) { return builder.build(); }
+
+    @Bean
     public RestTemplateBuilder restTemplateBuilder() {
-        return new RestTemplateBuilder();
+        return new RestTemplateBuilder()
+                .setConnectTimeout(Constants.CONNECT_TIMEOUT)
+                .setReadTimeout(Constants.READ_TIMEOUT);
     }
 
     @Bean

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -349,6 +349,7 @@ public class WebAppContext extends WebMvcConfigurerAdapter {
     public HqUserDetailsService userDetailsService(RestTemplateBuilder builder) { return new HqUserDetailsService(builder); }
 
     @Bean
+    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public RestTemplate hqRest(RestTemplateBuilder builder) { return builder.build(); }
 
     @Bean

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -93,6 +93,9 @@ public class RestoreFactory {
     @Autowired
     private FormplayerStorageFactory storageFactory;
 
+    @Autowired
+    private RestTemplate hqRest;
+
     @Resource(name="redisTemplateLong")
     private ValueOperations<String, Long> valueOperations;
 
@@ -399,11 +402,10 @@ public class RestoreFactory {
     }
 
     private InputStream getRestoreXmlHelper(String restoreUrl, HttpHeaders headers) {
-        RestTemplate restTemplate = new RestTemplate();
         log.info("Restoring at domain: " + domain + " with url: " + restoreUrl);
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE);
         downloadRestoreTimer.start();
-        ResponseEntity<org.springframework.core.io.Resource> response = restTemplate.exchange(
+        ResponseEntity<org.springframework.core.io.Resource> response = hqRest.exchange(
                 restoreUrl,
                 HttpMethod.GET,
                 new HttpEntity<String>(headers),

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -108,6 +108,8 @@ public class Constants {
     public static final int USER_LOCK_TIMEOUT = 21;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;
+    public static final int CONNECT_TIMEOUT = 60 * 1000;
+    public static final int READ_TIMEOUT = LOCK_DURATION;
 
     //Misc
     public static String HMAC_HEADER = "X-MAC-DIGEST";

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -17,6 +17,7 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.integration.support.locks.LockRegistry;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
@@ -149,6 +150,10 @@ public class TestContext {
     public FormplayerHttpRequest request() {
         return Mockito.mock(FormplayerHttpRequest.class);
     }
+
+    @Bean
+    public RestTemplate hqRest() { return new RestTemplate(); }
+
     @Bean
     public StatsDClient datadogStatsDClient() {
         return Mockito.mock(StatsDClient.class);


### PR DESCRIPTION
Reverts https://github.com/dimagi/formplayer/pull/690

Changes since https://github.com/dimagi/formplayer/pull/688: https://github.com/dimagi/formplayer/commit/8501145de6fb84e7bcd767311ac69e105cd153c0

The default scope is singleton, so the previous version (#688) created a single `RestTemplate` instance that was used for all restore requests.

This has been deployed to and tested on staging. Testing actions taken:
- Navigate to [app](https://staging.commcarehq.org/a/dmiller-staging/apps/view/a6ee6bcff4f11ba66e7a6b0af966daf0/)
- Sync (success)
- Navigate to form
- Submit [form](https://staging.commcarehq.org/a/dmiller-staging/reports/form_data/833abd19-3ec5-4fef-9a32-6da470fea448/)
- Sync (success)

According to @dannyroberts a similar test workflow had failed on staging when he deployed and tested #688 there.