### PR TITLE
Lock in Gradle dependency versions for modernized Spring libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,46 +39,46 @@ idea {
 }
 
 dependencies {
-    compile group: 'org.springframework.boot', name: 'spring-boot'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
-    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
-    compile group: 'org.springframework.data', name: 'spring-data-jpa'
-    compile("org.springframework:spring-web")
-    compile group: 'org.springframework.data', name: 'spring-data-redis'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
+    compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework', name: 'spring-web', version: '5.2.0.RELEASE'
+    compile group: 'org.springframework.data', name: 'spring-data-redis', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.0.RELEASE'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.0'
     compile group: 'io.sentry', name: 'sentry', version: '1.5.6'
-    compile("org.apache.directory.studio:org.apache.commons.io:2.0.1")
-    compile 'org.json:json:20131018'
-    compile 'redis.clients:jedis'
-    compile 'org.apache.commons:commons-pool2:2.4.2'
-    compile 'commons-codec:commons-codec:1.5'
-    compile("javax.servlet:jstl:1.2")
-    compile('org.lightcouch:lightcouch:0.1.6')
-    compile("io.springfox:springfox-swagger2:2.4.0")
-    compile("io.springfox:springfox-swagger-ui:2.4.0")
+    compile group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.0.1'
+    compile group: 'org.json', name: 'json', version: '20131018'
+    compile group: 'redis.clients', name: 'jedis', version: '3.1.0'
+    compile group: 'org.apache.commons', name: 'commons-pool2', version: '2.4.2'
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.5'
+    compile group: 'javax.servlet', name: 'jstl', version: '1.2'
+    compile group: 'org.lightcouch', name: 'lightcouch', version: '0.1.6'
+    compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.4.0'
+    compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.4.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'org.apache.commons', name: 'commons-email', version: '1.2'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
-    compile group: 'org.springframework', name: 'spring-jdbc'
+    compile group: 'org.springframework', name: 'spring-jdbc', version: '5.2.0.RELEASE'
     compile group: 'org.postgresql', name: 'postgresql', version: '42.2.8'
-    compile group: 'org.flywaydb', name: 'flyway-core'
-    compile group: 'org.springframework', name: 'spring-orm'
+    compile group: 'org.flywaydb', name: 'flyway-core', version: '6.0.6'
+    compile group: 'org.springframework', name: 'spring-orm', version: '5.2.0.RELEASE'
     compile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.4.7.Final'
     compile group: 'org.hibernate', name: 'hibernate-core', version: '5.4.7.Final'
-    compile group: 'org.springframework.data', name: 'spring-data-commons'
+    compile group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.0.RELEASE'
     compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
     compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
-    compile group: 'org.springframework.integration', name: 'spring-integration-redis'
-    compile 'org.xerial:sqlite-jdbc:3.16.1'
+    compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '5.2.0.RELEASE'
+    compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.16.1'
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
     compile project(path: ':commcare', configuration: 'translate')
-    compile 'org.simpleframework:simple-xml:2.7.1'
+    compile group: 'org.simpleframework', name: 'simple-xml', version: '2.7.1'
     testCompile project(path: ':commcare', configuration: 'api')
     testCompile("org.springframework.boot:spring-boot-starter-test")
     testCompile("com.jayway.jsonpath:json-path:2.2.0")

--- a/build.gradle
+++ b/build.gradle
@@ -39,16 +39,23 @@ idea {
 }
 
 dependencies {
-    compile group: 'org.springframework.boot', name: 'spring-boot', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework', name: 'spring-web', version: '5.2.0.RELEASE'
-    compile group: 'org.springframework.data', name: 'spring-data-redis', version: '2.2.0.RELEASE'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.0.RELEASE'
+
+    //Versions managed by Spring Dependency Management
+    compile group: 'org.springframework.boot', name: 'spring-boot'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
+    compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
+    compile group: 'org.springframework.data', name: 'spring-data-jpa'
+    compile group: 'org.springframework', name: 'spring-web'
+    compile group: 'org.springframework.data', name: 'spring-data-redis'
+    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
+    compile group: 'org.springframework', name: 'spring-orm'
+    compile group: 'org.springframework.integration', name: 'spring-integration-redis'
+    compile group: 'org.springframework', name: 'spring-jdbc'
+    compile group: 'org.springframework.data', name: 'spring-data-commons'
+
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.0'
     compile group: 'io.sentry', name: 'sentry', version: '1.5.6'
@@ -64,26 +71,29 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile group: 'org.apache.commons', name: 'commons-email', version: '1.2'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
-    compile group: 'org.springframework', name: 'spring-jdbc', version: '5.2.0.RELEASE'
     compile group: 'org.postgresql', name: 'postgresql', version: '42.2.8'
     compile group: 'org.flywaydb', name: 'flyway-core', version: '6.0.6'
-    compile group: 'org.springframework', name: 'spring-orm', version: '5.2.0.RELEASE'
     compile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.4.7.Final'
     compile group: 'org.hibernate', name: 'hibernate-core', version: '5.4.7.Final'
-    compile group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.0.RELEASE'
     compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
     compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
-    compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '5.2.0.RELEASE'
     compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.16.1'
+    compile group: 'org.simpleframework', name: 'simple-xml', version: '2.7.1'
+
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
     compile project(path: ':commcare', configuration: 'translate')
-    compile group: 'org.simpleframework', name: 'simple-xml', version: '2.7.1'
+
     testCompile project(path: ':commcare', configuration: 'api')
-    testCompile("org.springframework.boot:spring-boot-starter-test")
-    testCompile("com.jayway.jsonpath:json-path:2.2.0")
-    testCompile("com.jayway.jsonpath:json-path-assert:2.2.0")
-    testRuntime("org.skyscreamer:jsonassert:1.4.0")
+
+    //Versions managed by Spring Dependency Management
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+
+    testCompile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'
+    testCompile group: 'com.jayway.jsonpath', name: 'json-path-assert', version: '2.2.0'
+
+    testRuntime group: 'org.skyscreamer', name: 'jsonassert', version: '1.4.0'
+
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -38,24 +38,30 @@ idea {
     }
 }
 
+dependencyManagement {
+    dependencies {
+
+    }
+}
+
 dependencies {
 
-    //Versions managed by Spring Dependency Management
+    //Versions managed by Spring Boot Dependency Management
     compile group: 'org.springframework.boot', name: 'spring-boot'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
-    compile group: 'org.springframework.data', name: 'spring-data-jpa'
-    compile group: 'org.springframework', name: 'spring-web'
-    compile group: 'org.springframework.data', name: 'spring-data-redis'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
-    compile group: 'org.springframework', name: 'spring-orm'
-    compile group: 'org.springframework.integration', name: 'spring-integration-redis'
-    compile group: 'org.springframework', name: 'spring-jdbc'
-    compile group: 'org.springframework.data', name: 'spring-data-commons'
 
+    compile group: 'org.springframework', name: 'spring-web', version: '5.2.0.RELEASE'
+    compile group: 'org.springframework', name: 'spring-orm', version: '5.2.0.RELEASE'
+    compile group: 'org.springframework', name: 'spring-jdbc', version: '5.2.0.RELEASE'
+    compile group: 'org.springframework.data', name: 'spring-data-jpa', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.data', name: 'spring-data-redis', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.0.RELEASE'
+    compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '5.2.0.RELEASE'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.0'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.0'
     compile group: 'io.sentry', name: 'sentry', version: '1.5.6'

--- a/build.gradle
+++ b/build.gradle
@@ -38,12 +38,6 @@ idea {
     }
 }
 
-dependencyManagement {
-    dependencies {
-
-    }
-}
-
 dependencies {
 
     //Versions managed by Spring Boot Dependency Management

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,17 @@ idea {
 dependencies {
 
     //Versions managed by Spring Boot Dependency Management
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core'
+    compile group: 'commons-codec', name: 'commons-codec'
+    compile group: 'org.hibernate', name: 'hibernate-entitymanager'
+    compile group: 'org.hibernate', name: 'hibernate-core'
+    compile group: 'javax.servlet', name: 'jstl'
+    compile group: 'org.apache.commons', name: 'commons-lang3'
+    compile group: 'org.apache.commons', name: 'commons-pool2'
+    compile group: 'org.apache.httpcomponents', name: 'httpclient'
+    compile group: 'org.flywaydb', name: 'flyway-core'
+    compile group: 'org.postgresql', name: 'postgresql'
     compile group: 'org.springframework.boot', name: 'spring-boot'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
@@ -48,7 +59,20 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
     compile group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
+    compile group: 'org.xerial', name: 'sqlite-jdbc'
+    compile group: 'redis.clients', name: 'jedis'
 
+    //Unmanaged Dependencies
+    compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
+    compile group: 'io.sentry', name: 'sentry', version: '1.5.6'
+    compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.4.0'
+    compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.4.0'
+    compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
+    compile group: 'org.apache.commons', name: 'commons-email', version: '1.2'
+    compile group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.0.1'
+    compile group: 'org.json', name: 'json', version: '20131018'
+    compile group: 'org.lightcouch', name: 'lightcouch', version: '0.1.6'
+    compile group: 'org.simpleframework', name: 'simple-xml', version: '2.7.1'
     compile group: 'org.springframework', name: 'spring-web', version: '5.2.0.RELEASE'
     compile group: 'org.springframework', name: 'spring-orm', version: '5.2.0.RELEASE'
     compile group: 'org.springframework', name: 'spring-jdbc', version: '5.2.0.RELEASE'
@@ -56,29 +80,6 @@ dependencies {
     compile group: 'org.springframework.data', name: 'spring-data-redis', version: '2.2.0.RELEASE'
     compile group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.0.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '5.2.0.RELEASE'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.0'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.0'
-    compile group: 'io.sentry', name: 'sentry', version: '1.5.6'
-    compile group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.0.1'
-    compile group: 'org.json', name: 'json', version: '20131018'
-    compile group: 'redis.clients', name: 'jedis', version: '3.1.0'
-    compile group: 'org.apache.commons', name: 'commons-pool2', version: '2.4.2'
-    compile group: 'commons-codec', name: 'commons-codec', version: '1.5'
-    compile group: 'javax.servlet', name: 'jstl', version: '1.2'
-    compile group: 'org.lightcouch', name: 'lightcouch', version: '0.1.6'
-    compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.4.0'
-    compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.4.0'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
-    compile group: 'org.apache.commons', name: 'commons-email', version: '1.2'
-    compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.2'
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.2.8'
-    compile group: 'org.flywaydb', name: 'flyway-core', version: '6.0.6'
-    compile group: 'org.hibernate', name: 'hibernate-entitymanager', version: '5.4.7.Final'
-    compile group: 'org.hibernate', name: 'hibernate-core', version: '5.4.7.Final'
-    compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'
-    compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
-    compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.16.1'
-    compile group: 'org.simpleframework', name: 'simple-xml', version: '2.7.1'
 
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')
@@ -89,6 +90,7 @@ dependencies {
     //Versions managed by Spring Dependency Management
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
+    //Unmanaged Dependencies
     testCompile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'
     testCompile group: 'com.jayway.jsonpath', name: 'json-path-assert', version: '2.2.0'
 

--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -390,7 +390,7 @@ public class SqlHelper {
         } else if (arg instanceof byte[]) {
             preparedStatement.setBinaryStream(index, new ByteArrayInputStream((byte[])arg), ((byte[])arg).length);
         } else if(arg == null) {
-            //ToFix
+            preparedStatement.setNull(index, 0);
         }
     }
 

--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -389,6 +389,8 @@ public class SqlHelper {
             preparedStatement.setLong(index, (Long)arg);
         } else if (arg instanceof byte[]) {
             preparedStatement.setBinaryStream(index, new ByteArrayInputStream((byte[])arg), ((byte[])arg).length);
+        } else if(arg == null) {
+            //ToFix
         }
     }
 

--- a/src/main/java/sqlitedb/SQLiteDB.java
+++ b/src/main/java/sqlitedb/SQLiteDB.java
@@ -41,7 +41,7 @@ public class SQLiteDB implements ConnectionHandler {
     }
 
     private Boolean matchesConnection(SQLiteConnection sqLiteConnection) {
-        return sqLiteConnection.url().contains(dbPath.getDatabasePath());
+        return sqLiteConnection.getUrl().contains(dbPath.getDatabasePath());
     }
 
     @Override
@@ -53,7 +53,7 @@ public class SQLiteDB implements ConnectionHandler {
                 if (connection instanceof SQLiteConnection) {
                     SQLiteConnection sqLiteConnection = (SQLiteConnection) connection;
                     if (!matchesConnection(sqLiteConnection)) {
-                        log.error(String.format("Connection for path %s already exists",  sqLiteConnection.url()));
+                        log.error(String.format("Connection for path %s already exists",  sqLiteConnection.getUrl()));
                         connection = getNewConnection();
                     }
                 }


### PR DESCRIPTION
It's best practice for production Gradle builds to have explicit version dependencies, to ensure that build products are consistent.

This locks in the most up to date versions of the release libs, using spring-boot's new dependency manager for the libraries covered under its POM, and setting explicit dependencies for any other libraries without one.

To accept spring-boot's new versions, I also had to update a couple of JDBC connector details. They are tested locally, but have not been tested in a staging environment.