### PR TITLE
Enable graceful upgrades for new settings

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,8 @@
 spring.flyway.locations=classpath:db/migration
 spring.flyway.table=schema_version
+
+#Legacy Property Setters - Allow continuity of configuration without manual changes
+spring.datasource.driver-class-name=${datasource.formplayer.driverClassName}
+spring.datasource.url=${datasource.formplayer.url}
+spring.datasource.username=${datasource.formplayer.username}
+spring.datasource.password=${datasource.formplayer.password}


### PR DESCRIPTION
Proposed change to https://github.com/dimagi/formplayer/pull/700 which would permit deployments with old settings to continue functioning without a config change. 

The jar-packaged settings are [reliably evaluated](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config) after the local settings, so this will never override user behavior, but will prevent users from needing to make a change before applying settings.