### PR TITLE
Clear the userDB and retry when we get a 412 on restore

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -294,10 +294,6 @@ public class WebAppContext implements WebMvcConfigurer {
     public HqUserDetailsService userDetailsService(RestTemplateBuilder builder) { return new HqUserDetailsService(builder); }
 
     @Bean
-    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
-    public RestTemplate hqRest(RestTemplateBuilder builder) { return builder.build(); }
-
-    @Bean
     public RestTemplateBuilder restTemplateBuilder() {
         return new RestTemplateBuilder()
                 .setConnectTimeout(Duration.ofMillis(Constants.CONNECT_TIMEOUT))

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -19,6 +19,7 @@ import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpEntity;
@@ -94,7 +95,7 @@ public class RestoreFactory {
     private FormplayerStorageFactory storageFactory;
 
     @Autowired
-    private RestTemplate hqRest;
+    private RestTemplateBuilder restTemplateBuilder;
 
     @Resource(name="redisTemplateLong")
     private ValueOperations<String, Long> valueOperations;
@@ -405,7 +406,7 @@ public class RestoreFactory {
         log.info("Restoring at domain: " + domain + " with url: " + restoreUrl);
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE);
         downloadRestoreTimer.start();
-        ResponseEntity<org.springframework.core.io.Resource> response = hqRest.exchange(
+        ResponseEntity<org.springframework.core.io.Resource> response = restTemplateBuilder.build().exchange(
                 restoreUrl,
                 HttpMethod.GET,
                 new HttpEntity<String>(headers),

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -18,7 +18,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.integration.support.locks.LockRegistry;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
@@ -151,9 +150,6 @@ public class TestContext {
     public FormplayerHttpRequest request() {
         return Mockito.mock(FormplayerHttpRequest.class);
     }
-
-    @Bean
-    public RestTemplate hqRest() { return new RestTemplate(); }
 
     @Bean
     public StatsDClient datadogStatsDClient() {

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -10,6 +10,7 @@ import org.commcare.modern.reference.ArchiveFileRoot;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,8 +34,11 @@ import services.RestoreFactory;
 import services.SubmitService;
 import services.SyncRequester;
 import services.XFormService;
+import util.Constants;
 import util.FormplayerHttpRequest;
 import util.FormplayerSentry;
+
+import java.time.Duration;
 
 @Configuration
 public class TestContext {
@@ -149,6 +153,13 @@ public class TestContext {
     @Bean
     public FormplayerHttpRequest request() {
         return Mockito.mock(FormplayerHttpRequest.class);
+    }
+
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder() {
+        return new RestTemplateBuilder()
+                .setConnectTimeout(Duration.ofMillis(Constants.CONNECT_TIMEOUT))
+                .setReadTimeout(Duration.ofMillis(Constants.READ_TIMEOUT));
     }
 
     @Bean


### PR DESCRIPTION
I ran into similar issues to what @millerdev fixed in https://github.com/dimagi/formplayer/pull/697, so I reworked the code to use a fresh `RestTemplate` object each time which fixed the issues.

This PR makes Web Apps support a 412 restore response from the server. Previously the behavior was that formplayer threw an error and Web Apps showed a generic error message, and all subsequent clicks showed the same error message, making it impossible to move past it until the db file got deleted.

Now the behavior is that when formplayer gets a 412, it deletes the userDB and syncs again without a sync token (i.e. without `since=...` in the URL). Other than incomplete forms getting silently deleted, and the restore possibly taking longer than normal, there's no sign that anything special happened to the user. I think this is the same as what happens on a 412 on the phone.