### PR TITLE
Update Sentry dependence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     //Unmanaged Dependencies
     compile group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
-    compile group: 'io.sentry', name: 'sentry', version: '1.5.6'
+    compile group: 'io.sentry', name: 'sentry', version: '1.7.28'
     compile group: 'io.springfox', name: 'springfox-swagger2', version: '2.4.0'
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.4.0'
     compile group: 'javax.mail', name: 'mail', version: '1.5.0-b01'


### PR DESCRIPTION
A heap dump indicates that we are seeing big thread process leak from

https://github.com/getsentry/sentry-java/issues/548

which is fixed on newer versions. Impact is unclear, but can't rule out significant issues.