### PR TITLE
Modernize Database Connection Management

### DIFF
--- a/src/main/java/database/models/EntityStorageCache.java
+++ b/src/main/java/database/models/EntityStorageCache.java
@@ -108,30 +108,21 @@ public class EntityStorageCache {
 
     // Currently unused
     public String retrieveCacheValue(String entityKey, String cacheKey) {
-        Connection connection = null;
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = SqlHelper.prepareTableSelectStatement(connection,
+        Connection connection = handler.getConnection();
+        try (PreparedStatement preparedStatement = SqlHelper.prepareTableSelectStatement(connection,
                     TABLE_NAME,
                     new String[]{COL_CACHE_NAME, COL_ENTITY_KEY, COL_CACHE_KEY},
-                    new String[]{mCacheName, entityKey, cacheKey});
-            ResultSet resultSet = preparedStatement.executeQuery();
+                    new String[]{mCacheName, entityKey, cacheKey})) {
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
 
-            if (resultSet.next()) {
-                return resultSet.getString(resultSet.findColumn(COL_VALUE));
-            } else {
-                return null;
+                if (resultSet.next()) {
+                    return resultSet.getString(resultSet.findColumn(COL_VALUE));
+                } else {
+                    return null;
+                }
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    log.debug("Exception closing prepared statement ", e);
-                }
-            }
         }
     }
 

--- a/src/main/java/sandbox/ArchivableFile.java
+++ b/src/main/java/sandbox/ArchivableFile.java
@@ -37,18 +37,17 @@ public class ArchivableFile extends File {
 
     private static void decompressGzipFile(File gzipFile, File newFile) throws IOException {
         // copied and modified from http://www.journaldev.com/966/java-gzip-example-compress-decompress-file
+        try (
         FileInputStream fis = new FileInputStream(gzipFile);
         GZIPInputStream gis = new GZIPInputStream(fis);
         FileOutputStream fos = new FileOutputStream(newFile);
-        byte[] buffer = new byte[1024];
-        int len;
-        while((len = gis.read(buffer)) != -1){
-            fos.write(buffer, 0, len);
+        ) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gis.read(buffer)) != -1) {
+                fos.write(buffer, 0, len);
+            }
         }
-        //close resources
-        fis.close();
-        fos.close();
-        gis.close();
     }
 
     private void waitOnLock() {

--- a/src/main/java/sandbox/JdbcSqlStorageIterator.java
+++ b/src/main/java/sandbox/JdbcSqlStorageIterator.java
@@ -146,8 +146,8 @@ public class JdbcSqlStorageIterator<T extends Persistable> implements IStorageIt
 
     public void close() {
         try {
-            preparedStatement.close();
             resultSet.close();
+            preparedStatement.close();
         } catch (SQLException e) {
             log.error("Unable to close JdbcSqlStorageIterator resources", e);
         }

--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -81,7 +81,6 @@ public class SqlHelper {
     public static void dropTable(Connection c, String storageKey) {
         String sqlStatement = "DROP TABLE IF EXISTS " + storageKey;
         try (PreparedStatement preparedStatement = c.prepareStatement(sqlStatement)) {
-            ;
             preparedStatement.execute();
         } catch (SQLException e) {
             Logger.log("E", "Could not drop table: " + e.getMessage());

--- a/src/main/java/sandbox/SqlHelper.java
+++ b/src/main/java/sandbox/SqlHelper.java
@@ -29,25 +29,16 @@ public class SqlHelper {
     public static final boolean SQL_DEBUG = false;
 
     public static void explainSql(Connection c, String sql, String[] args) {
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = c.prepareStatement("EXPLAIN QUERY PLAN " + sql);
+        try (PreparedStatement preparedStatement = c.prepareStatement("EXPLAIN QUERY PLAN " + sql)){
             for (int i = 1; i <= args.length; i++) {
                 preparedStatement.setString(i, args[i - 1]);
             }
-            ResultSet resultSet = preparedStatement.executeQuery();
-            dumpResultSet(resultSet);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                dumpResultSet(resultSet);
+            }
 
         } catch (SQLException e) {
             e.printStackTrace();
-        } finally {
-            try {
-                if (preparedStatement != null) {
-                    preparedStatement.close();
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
         }
     }
 
@@ -89,20 +80,11 @@ public class SqlHelper {
 
     public static void dropTable(Connection c, String storageKey) {
         String sqlStatement = "DROP TABLE IF EXISTS " + storageKey;
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = c.prepareStatement(sqlStatement);
+        try (PreparedStatement preparedStatement = c.prepareStatement(sqlStatement)) {
+            ;
             preparedStatement.execute();
         } catch (SQLException e) {
             Logger.log("E", "Could not drop table: " + e.getMessage());
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            }
         }
     }
 
@@ -112,15 +94,25 @@ public class SqlHelper {
         try {
             preparedStatement = c.prepareStatement(sqlStatement);
             preparedStatement.execute();
+            preparedStatement.close();
+
             if (storageKey.equals(UserSqlSandbox.FORMPLAYER_CASE)) {
                 preparedStatement = c.prepareStatement(DatabaseIndexingUtils.indexOnTableCommand("case_id_index", UserSqlSandbox.FORMPLAYER_CASE, "case_id"));
                 preparedStatement.execute();
+                preparedStatement.close();
+
                 preparedStatement = c.prepareStatement(DatabaseIndexingUtils.indexOnTableCommand("case_type_index", UserSqlSandbox.FORMPLAYER_CASE, "case_type"));
                 preparedStatement.execute();
+                preparedStatement.close();
+
                 preparedStatement = c.prepareStatement(DatabaseIndexingUtils.indexOnTableCommand("case_status_index", UserSqlSandbox.FORMPLAYER_CASE, "case_status"));
                 preparedStatement.execute();
+                preparedStatement.close();
+
                 preparedStatement = c.prepareStatement(DatabaseIndexingUtils.indexOnTableCommand("case_status_open_index", UserSqlSandbox.FORMPLAYER_CASE, "case_type,case_status"));
                 preparedStatement.execute();
+                preparedStatement.close();
+
             }
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
@@ -135,6 +127,12 @@ public class SqlHelper {
         }
     }
 
+    /**
+     * Get a prepared statement to select matching rows by the internal ID column
+     *
+     * Note: Caller is responsible for ensuring the prepared statement is closed
+     *
+     */
     public static PreparedStatement prepareIdSelectStatement(Connection c, String storageKey, int id) {
         try {
             PreparedStatement preparedStatement =
@@ -147,6 +145,12 @@ public class SqlHelper {
         }
     }
 
+    /**
+     * Get a prepared statement to select matching rows by multiple storage keys
+     *
+     * Note: Caller is responsible for ensuring the prepared statement is closed
+     *
+     */
     public static PreparedStatement prepareTableSelectProjectionStatement(Connection c,
                                                                           String storageKey,
                                                                           String[] projections) {
@@ -165,6 +169,13 @@ public class SqlHelper {
         }
     }
 
+    /**
+     * Get a prepared statement to select matching appropriate metadata fields from
+     * an individual record
+     *
+     * Note: Caller is responsible for ensuring the prepared statement is closed
+     *
+     */
     public static PreparedStatement prepareTableSelectProjectionStatement(Connection c,
                                                                           String storageKey,
                                                                           String recordId,
@@ -262,9 +273,7 @@ public class SqlHelper {
 
     private static void performInsert(Connection c,
                                       Pair<List<Object>, String> valsAndInsertStatement) {
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = c.prepareStatement(valsAndInsertStatement.second);
+        try (PreparedStatement preparedStatement = c.prepareStatement(valsAndInsertStatement.second)) {
             int i = 1;
 
             for (Object val : valsAndInsertStatement.first) {
@@ -273,14 +282,6 @@ public class SqlHelper {
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 
@@ -336,10 +337,8 @@ public class SqlHelper {
 
     public static int insertToTable(Connection c, String storageKey, Persistable p) {
         Pair<String, List<Object>> mPair = DatabaseHelper.getTableInsertData(storageKey, p);
-        PreparedStatement preparedStatement = null;
 
-        try {
-            preparedStatement = c.prepareStatement(mPair.first);
+        try (PreparedStatement preparedStatement = c.prepareStatement(mPair.first)) {
             for (int i = 0; i < mPair.second.size(); i++) {
                 Object obj = mPair.second.get(i);
                 setArgumentToSqlStatement(preparedStatement, obj, i+1);
@@ -367,14 +366,6 @@ public class SqlHelper {
             }
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 
@@ -411,21 +402,11 @@ public class SqlHelper {
 
         String query = "UPDATE " + storageKey + " SET " + DatabaseHelper.DATA_COL + " = ? WHERE " + where.first + ";";
 
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = c.prepareStatement(query);
+        try (PreparedStatement preparedStatement = c.prepareStatement(query)){
             setPreparedStatementArgs(preparedStatement, p, where.second);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 
@@ -452,22 +433,12 @@ public class SqlHelper {
 
         String query = stringBuilder.append(queryEnd).toString();
 
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = connection.prepareStatement(query);
+        try (PreparedStatement preparedStatement = connection.prepareStatement(query)){
             int lastArgIndex = setPreparedStatementArgs(preparedStatement, persistable, values);
             preparedStatement.setInt(lastArgIndex, id);
             preparedStatement.executeUpdate();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 
@@ -507,44 +478,24 @@ public class SqlHelper {
     public static void deleteFromTableWhere(Connection connection, String tableName, String whereClause, String arg) {
         String query = "DELETE FROM " + tableName + " WHERE " + whereClause + ";";
 
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = connection.prepareStatement(query);
+        try (PreparedStatement preparedStatement = connection.prepareStatement(query)){
             preparedStatement.setString(1, arg);
             preparedStatement.execute();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    throw new SQLiteRuntimeException(e);
-                }
-            }
         }
     }
 
     public static void deleteFromTableWhere(Connection connection, String tableName, String whereClause, String[] args) {
         String query = "DELETE FROM " + tableName + " WHERE " + whereClause + ";";
 
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = connection.prepareStatement(query);
+        try (PreparedStatement preparedStatement = connection.prepareStatement(query)){
             for (int i = 1; i <= args.length; i++) {
                 preparedStatement.setString(i, args[i - 1]);
             }
             preparedStatement.execute();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    // ignore
-                }
-            }
         }
     }
 
@@ -558,21 +509,11 @@ public class SqlHelper {
     public static void deleteIdFromTable(Connection connection, String tableName, int id) {
         String query = "DELETE FROM " + tableName + " WHERE " + DatabaseHelper.ID_COL + " = ?;";
 
-        PreparedStatement preparedStatement = null;
-        try {
-            preparedStatement = connection.prepareStatement(query);
+        try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
             preparedStatement.setInt(1, id);
             preparedStatement.execute();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            }
         }
     }
 
@@ -583,23 +524,16 @@ public class SqlHelper {
      * @param tableName  name of table
      */
     public static void deleteAllFromTable(Connection connection, String tableName) {
-        PreparedStatement preparedStatement = null;
-        try {
-            if (isTableExist(connection, tableName)) {
-                String query = "DELETE FROM " + tableName;
-                preparedStatement = connection.prepareStatement(query);
-                preparedStatement.execute();
-            }
+
+        if (!isTableExist(connection, tableName)) {
+            return;
+        }
+
+        String query = "DELETE FROM " + tableName;
+        try (PreparedStatement preparedStatement = connection.prepareStatement(query)) {
+            preparedStatement.execute();
         } catch (SQLException e) {
             throw new SQLiteRuntimeException(e);
-        } finally {
-            if (preparedStatement != null) {
-                try {
-                    preparedStatement.close();
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            }
         }
     }
 

--- a/src/main/java/sandbox/UserSqlSandbox.java
+++ b/src/main/java/sandbox/UserSqlSandbox.java
@@ -94,38 +94,20 @@ public class UserSqlSandbox extends UserSandbox implements ConnectionHandler {
 
     @Override
     public IndexedFixtureIdentifier getIndexedFixtureIdentifier(String fixtureName) {
-        Connection connection;
-        PreparedStatement preparedStatement = null;
-        ResultSet resultSet = null;
-        try {
-            connection = sqlUtil.getConnection();
-            preparedStatement =
-                    connection.prepareStatement(IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE_SELECT_STMT);
+        Connection connection = sqlUtil.getConnection();
+        try (PreparedStatement preparedStatement = connection.prepareStatement(
+                IndexedFixturePathsConstants.INDEXED_FIXTURE_PATHS_TABLE_SELECT_STMT) ){
             preparedStatement.setString(1, fixtureName);
-            resultSet = preparedStatement.executeQuery();
-            if (resultSet.next()) {
-                return new IndexedFixtureIdentifier(
-                        resultSet.getString(1),
-                        resultSet.getString(2),
-                        resultSet.getBytes(3));
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                if (resultSet.next()) {
+                    return new IndexedFixtureIdentifier(
+                            resultSet.getString(1),
+                            resultSet.getString(2),
+                            resultSet.getBytes(3));
+                }
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
-        } finally {
-            try {
-                if (preparedStatement != null) {
-                    preparedStatement.close();
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
-            try {
-                if (resultSet != null) {
-                    resultSet.close();
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
         }
 
         return null;

--- a/src/main/java/services/FormplayerStorageFactory.java
+++ b/src/main/java/services/FormplayerStorageFactory.java
@@ -9,6 +9,9 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.StorageManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PreDestroy;
+
 import repo.FormSessionRepo;
 import sandbox.SqlStorage;
 import sqlitedb.ApplicationDB;
@@ -87,6 +90,14 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory {
         this.propertyManager = new FormplayerPropertyManager(newStorage(PropertyManager.STORAGE_KEY, Property.class));
         storageManager = new StorageManager(this);
     }
+
+    @PreDestroy
+    public void preDestroy() {
+        if(sqLiteDB != null) {
+            sqLiteDB.closeConnection();
+        }
+    }
+
 
     public FormplayerPropertyManager getPropertyManager() {
         return propertyManager;

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -47,6 +47,7 @@ import util.RequestUtils;
 import util.SimpleTimer;
 import util.UserUtils;
 
+import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -569,6 +570,12 @@ public class RestoreFactory {
         return new Pair<>(fullUrl, headers);
     }
 
+    @PreDestroy
+    public void preDestroy() {
+        if(sqLiteDB != null) {
+            sqLiteDB.closeConnection();
+        }
+    }
 
     public String getUsername() {
         return username;

--- a/src/main/java/sqlitedb/SQLiteDB.java
+++ b/src/main/java/sqlitedb/SQLiteDB.java
@@ -54,6 +54,7 @@ public class SQLiteDB implements ConnectionHandler {
                     SQLiteConnection sqLiteConnection = (SQLiteConnection) connection;
                     if (!matchesConnection(sqLiteConnection)) {
                         log.error(String.format("Connection for path %s already exists",  sqLiteConnection.getUrl()));
+                        connection.close();
                         connection = getNewConnection();
                     }
                 }
@@ -76,6 +77,7 @@ public class SQLiteDB implements ConnectionHandler {
     }
 
     public void deleteDatabaseFile() {
+        closeConnection();
         SqlSandboxUtils.deleteDatabaseFolder(dbArchivableFile);
     }
 


### PR DESCRIPTION
Updates to the way that we are managing jdbc connections and objects. 

Ensures that all connection objects are closed out to try and fix the issue with the system leaking paged sqlite journal files.

Replaces (where cleanly possible) meaningless try{} finally{} blocks with cleaner [try with resource](https://www.baeldung.com/java-try-with-resources) patterns, now that we are on a compatible version.