### PR TITLE
Fix Issues with Dangling DB Connections

### DIFF
--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -55,9 +55,8 @@ public class SqlSandboxUtils {
             Class.forName("org.sqlite.JDBC");
             SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
             dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=MEMORY");
-            dataSource.getConnection().setAutoCommit(false);
             return dataSource;
-        } catch (ClassNotFoundException|SQLException |IOException e) {
+        } catch (ClassNotFoundException |IOException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
The code which actually builds and establishes the SQLite connections was attempting to set the autoCommit behavior of the connection do a default state before returning it to the caller, and in doing so was unintentionally creating a hanging connection which was never closed.

This code doesn't push down the `autoCommit` portion of the change to the actually created connection, since the attempt to set the behavior of the connection to autoCommit was failing since it was only changing the behavior of the orphaned connection. It may be worth exploring whether actually setting the autoCommit value would work and/or have performance gains, but I think the system expects autoCommit to be active by default now and can't see how it would work otherwise.