### PR TITLE
Ensure project root name is set explicitly

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':commcare'
 project(':commcare').projectDir = new File('libs/commcare')
+rootProject.name = 'formplayer'


### PR DESCRIPTION
Newer gradle versions deprecated the way we were setting the jar basename, which means the output jar for formplayer is now dependent on the name of the root project directory. This is breaking the production of the staging jar.

This change should provide a consistent output instead.

I tested manually on the buildserver after applying this change and it corrected the jar name output.