### PR TITLE
Fix HTTP Connection issues due to re-use of Rest Template

### DIFF
--- a/src/main/java/services/HqUserDetailsService.java
+++ b/src/main/java/services/HqUserDetailsService.java
@@ -20,6 +20,7 @@ import util.RequestUtils;
 public class HqUserDetailsService {
     private final Log log = LogFactory.getLog(HqUserDetailsService.class);
     private final RestTemplate restTemplate;
+    private final RestTemplateBuilder builder;
 
     @Value("${commcarehq.host}")
     private String host;
@@ -32,10 +33,12 @@ public class HqUserDetailsService {
 
     public HqUserDetailsService(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
+        this.builder = null;
     }
 
     public HqUserDetailsService(RestTemplateBuilder builder) {
-        restTemplate = builder.build();
+        this.builder = builder;
+        this.restTemplate = null;
     }
 
     public HqUserDetailsBean getUserDetails(String domain, String sessionKey) {
@@ -48,7 +51,8 @@ public class HqUserDetailsService {
             throw new UserDetailsException(e);
         }
         HttpEntity<String> request = new HttpEntity<>(data, headers);
-        HqUserDetailsBean userDetails = restTemplate.postForObject(getSessionDetailsUrl(), request, HqUserDetailsBean.class);
+        RestTemplate template = builder == null ? restTemplate : builder.build();
+        HqUserDetailsBean userDetails = template.postForObject(getSessionDetailsUrl(), request, HqUserDetailsBean.class);
         return userDetails;
     }
 


### PR DESCRIPTION
Locally, Formplayer had issues for me when I made requests too quickly back to back because the RestTemplate configured to make the auth request was being re-used, including the underlying connection object, resulting in

`localhost:8000 failed to respond; nested exception is org.apache.http.NoHttpResponseException: localhost:8000 failed to respond`

This ensures that a new RestTemplate is used for each auth attempt and fixes the issue for me. It looks like the only reason the old behavior was configured was to support a mock for testing, so this should be a safe change.