### PR TITLE
Form Volatility Indicators

### DIFF
--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -1,31 +1,7 @@
 package application;
 
-import annotations.ConfigureStorageFromSession;
-import annotations.UserLock;
-import annotations.UserRestore;
-import api.json.JsonActionUtils;
-import api.process.FormRecordProcessorHelper;
-import api.util.ApiConstants;
-import beans.AnswerQuestionRequestBean;
-import beans.ChangeLocaleRequestBean;
-import beans.FormEntryNavigationResponseBean;
-import beans.FormEntryResponseBean;
-import beans.InstanceXmlBean;
-import beans.NewFormResponse;
-import beans.NewSessionRequestBean;
-import beans.NotificationMessage;
-import beans.OpenRosaResponse;
-import beans.GetInstanceResponseBean;
-import beans.RepeatRequestBean;
-import beans.SessionRequestBean;
-import beans.SubmitRequestBean;
-import beans.SubmitResponseBean;
-import beans.menus.ErrorBean;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import engine.FormplayerTransactionParserFactory;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import objects.SerializableFormSession;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.javarosa.form.api.FormEntryController;
@@ -44,6 +20,36 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import annotations.ConfigureStorageFromSession;
+import annotations.UserLock;
+import annotations.UserRestore;
+import api.json.JsonActionUtils;
+import api.process.FormRecordProcessorHelper;
+import api.util.ApiConstants;
+import beans.AnswerQuestionRequestBean;
+import beans.ChangeLocaleRequestBean;
+import beans.FormEntryNavigationResponseBean;
+import beans.FormEntryResponseBean;
+import beans.GetInstanceResponseBean;
+import beans.InstanceXmlBean;
+import beans.NewFormResponse;
+import beans.NewSessionRequestBean;
+import beans.NotificationMessage;
+import beans.OpenRosaResponse;
+import beans.RepeatRequestBean;
+import beans.SessionRequestBean;
+import beans.SubmitRequestBean;
+import beans.SubmitResponseBean;
+import beans.menus.ErrorBean;
+import engine.FormplayerTransactionParserFactory;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import objects.SerializableFormSession;
 import repo.SerializableMenuSession;
 import services.CategoryTimingHelper;
 import services.FormplayerStorageFactory;
@@ -53,10 +59,6 @@ import session.FormSession;
 import session.MenuSession;
 import util.Constants;
 import util.SimpleTimer;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Controller class (API endpoint) containing all form entry logic. This includes

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -39,6 +39,7 @@ import util.FormplayerSentry;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 //have to exclude this to use two DataSources (HQ and Formplayer dbs)
@@ -155,6 +156,14 @@ public class WebAppContext implements WebMvcConfigurer {
     @Bean
     public RedisTemplate<String, Long> redisTemplateLong() {
         RedisTemplate template = new RedisTemplate<String, Long>();
+        template.setConnectionFactory(jedisConnFactory());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Map<String, String>> redisTemplateDict() {
+        RedisTemplate template = new RedisTemplate<String, Map<String, String>>();
         template.setConnectionFactory(jedisConnFactory());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return template;

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -28,6 +28,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.handler.SimpleMappingExceptionResolver;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.JstlView;
+
+import objects.FormVolatilityRecord;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
 import repo.impl.PostgresFormSessionRepo;
@@ -162,8 +164,8 @@ public class WebAppContext implements WebMvcConfigurer {
     }
 
     @Bean
-    public RedisTemplate<String, Map<String, String>> redisTemplateDict() {
-        RedisTemplate template = new RedisTemplate<String, Map<String, String>>();
+    public RedisTemplate<String, FormVolatilityRecord> redisVolatilityDict() {
+        RedisTemplate template = new RedisTemplate<String, FormVolatilityRecord>();
         template.setConnectionFactory(jedisConnFactory());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return template;

--- a/src/main/java/objects/FormVolatilityRecord.java
+++ b/src/main/java/objects/FormVolatilityRecord.java
@@ -1,0 +1,34 @@
+package objects;
+
+public class FormVolatilityRecord {
+    private String key;
+    private long timeout;
+    private String entityName;
+
+    public FormVolatilityRecord(String key, long timeout, String entityName) {
+        this.key = key;
+        this.timeout = timeout;
+        this.entityName = entityName;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public long getTimeout() {
+        return timeout;
+    }
+
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public String getDisplayMessage(String userTitle) {
+        String message = String.format(
+                "Warning: This form was started recently for %s by %s %s",
+                entityName == null? "the same record" : entityName,
+                userTitle,
+                "%s");
+        return message;
+    }
+}

--- a/src/main/java/objects/FormVolatilityRecord.java
+++ b/src/main/java/objects/FormVolatilityRecord.java
@@ -1,9 +1,35 @@
 package objects;
 
-public class FormVolatilityRecord {
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import session.FormSession;
+
+/**
+ * Redis cache record object for
+ *
+ * @author Clayton Sims (csims@dimagi.com)
+ */
+public class FormVolatilityRecord implements Serializable {
+    //If the data dict structure is changed, bump the version of the key
+    public final static String VOLATILITY_KEY_TEMPLATE = "FormInit-%s-%s-v2";
+
     private String key;
     private long timeout;
     private String entityName;
+
+    private String username;
+    private long openedOn;
+
+    private String currentMessage;
+
+    /**For serialization only **/
+    public FormVolatilityRecord() {
+
+    }
 
     public FormVolatilityRecord(String key, long timeout, String entityName) {
         this.key = key;
@@ -15,20 +41,94 @@ public class FormVolatilityRecord {
         return key;
     }
 
+    //Crud Methods
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
     public long getTimeout() {
         return timeout;
+    }
+
+    public void setTimeout(long timeout) {
+        this.timeout = timeout;
     }
 
     public String getEntityName() {
         return entityName;
     }
 
-    public String getDisplayMessage(String userTitle) {
+    public void setEntityName(String entityName) {
+        this.entityName = entityName;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public long getOpenedOn() {
+        return openedOn;
+    }
+
+    public void setOpenedOn(long openedOn) {
+        this.openedOn = openedOn;
+    }
+
+    public String getCurrentMessage() {
+        return currentMessage;
+    }
+
+    public void setCurrentMessage(String currentMessage) {
+        this.currentMessage = currentMessage;
+    }
+
+    private String formatOpenedMessage(String userTitle) {
         String message = String.format(
                 "Warning: This form was started recently for %s by %s %s",
                 entityName == null? "the same record" : entityName,
                 userTitle,
                 "%s");
         return message;
+    }
+
+    public boolean matchesUser(FormSession session) {
+        return this.username.equals(session.getUsername());
+    }
+
+    public void write(ValueOperations<String, FormVolatilityRecord> volatilityCache) {
+        volatilityCache.set(key, this, this.timeout, TimeUnit.SECONDS);
+    }
+
+    /**
+     * This record represents an Opened Form
+     *
+     * @param session
+     */
+    public void updateFormOpened(FormSession session) {
+        this.username = session.getUsername();
+        this.currentMessage = formatOpenedMessage(session.getUsername());
+        this.openedOn = new Date().getTime();
+
+    }
+
+    public String formatWarningString() {
+        String formatString;
+
+        long current = new Date().getTime();
+        long delta = (current - openedOn) / 1000;
+
+        if(delta < 60) {
+            formatString = String.format("%d Seconds ago", delta);
+        } else {
+            delta = delta / 60;
+            formatString = String.format("%d Minutes ago", delta);
+        }
+
+        return String.format(currentMessage, formatString);
     }
 }

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -265,13 +265,12 @@ public class FormSession {
 
     private void setVolatilityIndicators()
     {
-
         String volatilityKey = getPragma("Pragma-Volatility-Key");
         String entityTitle = getPragma("Pragma-Volatility-Entity-Title");
 
         if(volatilityKey != null) {
             this.sessionVolatilityRecord = new FormVolatilityRecord(
-                    String.format(MenuSessionRunnerService.VOLATILITY_KEY_TEMPLATE,
+                    String.format(FormVolatilityRecord.VOLATILITY_KEY_TEMPLATE,
                             this.getXmlns(),
                             volatilityKey),
                     this.getVolatilityKeyTimeout(),

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -249,9 +249,7 @@ public class FormSession {
         FormplayerSessionWrapper sessionWrapper = new FormplayerSessionWrapper(platform, this.sandbox, sessionData);
         formDef.initialize(newInstance, sessionWrapper.getIIF(), locale, false);
 
-        if(newInstance) {
-            setVolatilityIndicators();
-        }
+        setVolatilityIndicators();
     }
 
     private String getPragma(String key) {

--- a/src/main/java/session/FormSession.java
+++ b/src/main/java/session/FormSession.java
@@ -281,7 +281,7 @@ public class FormSession {
     }
 
     /**
-     * @return the Timeout (in ms) for volatility notices for this form
+     * @return the Timeout (in seconds) for volatility notices for this form
      */
     private long getVolatilityKeyTimeout() {
         String timeOut = getPragma("Pragma-Volatility-Window");

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -20,6 +20,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import objects.FormVolatilityRecord;
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
 import services.CategoryTimingHelper;
@@ -88,6 +90,11 @@ public class TestContext {
     @Bean
     public StringRedisTemplate redisTemplate() {
         return Mockito.mock(StringRedisTemplate.class);
+    }
+
+    @Bean
+    public ValueOperations<String, FormVolatilityRecord> redisVolatilityDict() {
+        return Mockito.mock(ValueOperations.class);
     }
 
     @Bean


### PR DESCRIPTION
Allows forms to declare a volatility key for their case entities. When volatile forms are begun of completed for a specific case a record is made, and users are warned if they open a form which was recently opened by another user, or submitted by another user (unless they have synced since after the form was submitted). 

![image](https://user-images.githubusercontent.com/155066/79620870-7196ec00-80df-11ea-881d-c586afbffed7.png)

This is hidden for now, and shouldn't affect most domains. I don't love the fact that the volatility indicators are stored inside the form record, I think it would be way better if this was generalized more heuristically against the session, but it will be easy to build on top of later.