### PR TITLE
UX cleanups for volatility warnings

### DIFF
--- a/src/main/java/beans/NotificationMessage.java
+++ b/src/main/java/beans/NotificationMessage.java
@@ -4,7 +4,15 @@ package beans;
  * Created by willpride on 1/12/16.
  */
 public class NotificationMessage {
+
+    public enum Type {
+        success,
+        warning,
+        error
+    }
+
     private boolean isError;
+    private String type;
     private String message;
 
     public NotificationMessage(){
@@ -14,6 +22,17 @@ public class NotificationMessage {
     public NotificationMessage(String message, boolean isError) {
         this.message = message;
         this.isError = isError;
+        if(this.isError){
+            this.type = Type.error.name();
+        } else {
+            this.type = Type.success.name();
+        }
+    }
+
+    public NotificationMessage(String message, Type type) {
+        this.message = message;
+        this.type = type.name();
+        this.isError = type == Type.error;
     }
 
     public String getMessage() {
@@ -32,8 +51,16 @@ public class NotificationMessage {
         isError = error;
     }
 
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
     @Override
     public String toString() {
-        return String.format("NotificationMessage message=%s, isError=%s", message, isError);
+        return String.format("NotificationMessage message=%s, isError=%s, type=%s", message, isError, type);
     }
 }

--- a/src/main/java/objects/FormVolatilityRecord.java
+++ b/src/main/java/objects/FormVolatilityRecord.java
@@ -8,6 +8,8 @@ import java.util.concurrent.TimeUnit;
 
 import beans.NotificationMessage;
 import session.FormSession;
+import util.StringUtils;
+import util.UserUtils;
 
 /**
  * Redis cache record object for managing records of actions (open, complete, etc) which
@@ -130,9 +132,10 @@ public class FormVolatilityRecord implements Serializable {
      */
     public void updateFormOpened(FormSession session) {
         this.username = session.getUsername();
-        this.currentMessage = formatOpenedMessage(session.getUsername());
+        this.currentMessage = formatOpenedMessage(UserUtils.getUsernameBeforeAtSymbol(session.getUsername()));
         this.openedOn = new Date().getTime();
     }
+
 
     /**
      * This record represents a finished form
@@ -141,12 +144,13 @@ public class FormVolatilityRecord implements Serializable {
      */
     public void updateFormSubmitted(FormSession session) {
         this.username = session.getUsername();
-        this.currentMessage = formatSubmittedMessage(session.getUsername());
+        this.currentMessage = formatSubmittedMessage(UserUtils.getUsernameBeforeAtSymbol(session.getUsername()));
         this.submittedOn = new Date().getTime();
     }
 
     public NotificationMessage getNotificationIfRelevant(long lastSyncTime) {
         String formatString;
+        NotificationMessage.Type type = NotificationMessage.Type.warning;
 
         long anchor = wasSubmitted() ? submittedOn : openedOn;
 
@@ -168,7 +172,7 @@ public class FormVolatilityRecord implements Serializable {
             return null;
         }
 
-        return new NotificationMessage(currentMessage + formatString, false);
+        return new NotificationMessage(currentMessage + formatString, type);
     }
 
     public boolean wasSubmitted() {


### PR DESCRIPTION
Minor cleanups for the user experience around volatility warnings. Strip domain info from warning text and use new warning coding when accepted by HQ (but works before the other PR is accepted)