### PR TITLE
Exposing Error Notifications to Sentry

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -138,6 +138,7 @@ public abstract class AbstractBaseController {
     public ExceptionResponseBean handleHttpRequestError(FormplayerHttpRequest req, HttpClientErrorException exception) {
         incrementDatadogCounter(Constants.DATADOG_ERRORS_EXTERNAL_REQUEST, req);
         log.error(String.format("Exception %s making external request %s.", exception, req));
+        raven.sendRavenException(exception, Event.Level.INFO);
         return new ExceptionResponseBean(exception.getResponseBodyAsString(), req.getRequestURL().toString());
     }
 
@@ -161,7 +162,7 @@ public abstract class AbstractBaseController {
     public HTMLExceptionResponseBean handleFormattedApplicationError(FormplayerHttpRequest req, Exception exception) {
         log.error("Request: " + req.getRequestURL() + " raised " + exception);
         incrementDatadogCounter(Constants.DATADOG_ERRORS_APP_CONFIG, req);
-
+        raven.sendRavenException(exception, Event.Level.INFO);
         return new HTMLExceptionResponseBean(exception.getMessage(), req.getRequestURL().toString());
     }
 
@@ -169,6 +170,7 @@ public abstract class AbstractBaseController {
     @ResponseBody
     @ResponseStatus(HttpStatus.LOCKED)
     public ExceptionResponseBean handleLockError(FormplayerHttpRequest req, Exception exception) {
+        raven.sendRavenException(exception, Event.Level.INFO);
         return new ExceptionResponseBean("User lock timed out", req.getRequestURL().toString());
     }
 

--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -40,6 +40,8 @@ import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.ArrayList;
 
+import javax.servlet.http.HttpServletRequest;
+
 import repo.FormSessionRepo;
 import repo.MenuSessionRepo;
 import services.FormplayerStorageFactory;
@@ -206,7 +208,7 @@ public abstract class AbstractBaseController {
         return new ExceptionResponseBean(exception.getMessage(), req.getRequestURL().toString());
     }
 
-    void logNotification(@Nullable NotificationMessage notification, FormplayerHttpRequest req) {
+    void logNotification(@Nullable NotificationMessage notification, HttpServletRequest req) {
         try {
             if (notification != null && notification.isError()) {
                 raven.sendRavenException(new RuntimeException(notification.getMessage()));
@@ -221,14 +223,17 @@ public abstract class AbstractBaseController {
         incrementDatadogCounter(metric, req, null);
     }
 
-    private void incrementDatadogCounter(String metric, FormplayerHttpRequest req, String tag) {
+    private void incrementDatadogCounter(String metric, HttpServletRequest req, String tag) {
         String user = "unknown";
         String domain = "unknown";
-        if (req.getUserDetails() != null) {
-            user = req.getUserDetails().getUsername();
-        }
-        if (req.getDomain() != null) {
-            domain = req.getDomain();
+        if(req instanceof FormplayerHttpRequest) {
+            FormplayerHttpRequest formplayerRequest = ((FormplayerHttpRequest)req);
+            if (formplayerRequest.getUserDetails() != null) {
+                user = formplayerRequest.getUserDetails().getUsername();
+            }
+            if (formplayerRequest.getDomain() != null) {
+                domain = formplayerRequest.getDomain();
+            }
         }
         ArrayList<String> tags = new ArrayList<>();
         tags.add("domain:" + domain);

--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -26,6 +26,8 @@ import util.Constants;
 import util.FormplayerHttpRequest;
 
 import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
+
 import java.util.List;
 
 /**
@@ -82,7 +84,7 @@ public class DebuggerController extends AbstractBaseController {
     public MenuDebuggerContentResponseBean menuDebuggerContent(
             @RequestBody SessionNavigationBean debuggerMenuRequest,
             @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-            FormplayerHttpRequest request) throws Exception {
+            HttpServletRequest request) throws Exception {
 
         MenuSession menuSession = getMenuSessionFromBean(debuggerMenuRequest);
         BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, debuggerMenuRequest.getSelections());
@@ -104,7 +106,7 @@ public class DebuggerController extends AbstractBaseController {
     @AppInstall
     public EvaluateXPathResponseBean menuEvaluateXpath(@RequestBody EvaluateXPathMenuRequestBean evaluateXPathRequestBean,
                                                        @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                                       FormplayerHttpRequest request) throws Exception {
+                                                       HttpServletRequest request) throws Exception {
         MenuSession menuSession = getMenuSessionFromBean(evaluateXPathRequestBean);
         BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
         logNotification(responseBean.getNotification(), request);

--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -8,6 +8,7 @@ import beans.*;
 import beans.debugger.DebuggerFormattedQuestionsResponseBean;
 import beans.debugger.MenuDebuggerContentResponseBean;
 import beans.debugger.XPathQueryItem;
+import beans.menus.BaseResponseBean;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import objects.SerializableFormSession;
@@ -22,6 +23,7 @@ import services.FormattedQuestionsService;
 import session.FormSession;
 import session.MenuSession;
 import util.Constants;
+import util.FormplayerHttpRequest;
 
 import javax.annotation.Resource;
 import java.util.List;
@@ -79,10 +81,12 @@ public class DebuggerController extends AbstractBaseController {
     @AppInstall
     public MenuDebuggerContentResponseBean menuDebuggerContent(
             @RequestBody SessionNavigationBean debuggerMenuRequest,
-            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+            FormplayerHttpRequest request) throws Exception {
 
         MenuSession menuSession = getMenuSessionFromBean(debuggerMenuRequest);
-        runnerService.advanceSessionWithSelections(menuSession, debuggerMenuRequest.getSelections());
+        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, debuggerMenuRequest.getSelections());
+        logNotification(responseBean.getNotification(), request);
 
         return new MenuDebuggerContentResponseBean(
                 menuSession.getAppId(),
@@ -99,9 +103,11 @@ public class DebuggerController extends AbstractBaseController {
     @UserRestore
     @AppInstall
     public EvaluateXPathResponseBean menuEvaluateXpath(@RequestBody EvaluateXPathMenuRequestBean evaluateXPathRequestBean,
-                                                       @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+                                                       @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+                                                       FormplayerHttpRequest request) throws Exception {
         MenuSession menuSession = getMenuSessionFromBean(evaluateXPathRequestBean);
-        runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
+        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
+        logNotification(responseBean.getNotification(), request);
 
 
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(

--- a/src/main/java/application/FormController.java
+++ b/src/main/java/application/FormController.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Resource;
+import javax.servlet.http.HttpServletRequest;
 
 import annotations.ConfigureStorageFromSession;
 import annotations.UserLock;
@@ -148,7 +149,7 @@ public class FormController extends AbstractBaseController{
     @UserRestore
     @ConfigureStorageFromSession
     public SubmitResponseBean submitForm(@RequestBody SubmitRequestBean submitRequestBean,
-                                         @CookieValue(name=Constants.POSTGRES_DJANGO_SESSION_ID, required=false) String authToken, FormplayerHttpRequest req) throws Exception {
+                                         @CookieValue(name=Constants.POSTGRES_DJANGO_SESSION_ID, required=false) String authToken, HttpServletRequest request) throws Exception {
         SerializableFormSession serializableFormSession = formSessionRepo.findOneWrapped(submitRequestBean.getSessionId());
         FormSession formEntrySession = new FormSession(serializableFormSession, restoreFactory, formSendCalloutHandler, storageFactory);
         SubmitResponseBean submitResponseBean;
@@ -189,7 +190,7 @@ public class FormController extends AbstractBaseController{
                             "Form submission failed with error response" + submitResponse,
                             true, NotificationMessage.Tag.submit);
                     submitResponseBean.setNotification(notification);
-                    logNotification(notification, req);
+                    logNotification(notification, request);
                     log.error("Submit response bean: " + submitResponseBean);
                     return submitResponseBean;
                 } else {
@@ -204,7 +205,7 @@ public class FormController extends AbstractBaseController{
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 NotificationMessage notification = new NotificationMessage(e.getMessage(), true, NotificationMessage.Tag.submit);
                 submitResponseBean.setNotification(notification);
-                logNotification(notification, req);
+                logNotification(notification, request);
                 log.error("Submission failed with structure exception " + e);
                 return submitResponseBean;
             }

--- a/src/main/java/application/IncompleteSessionController.java
+++ b/src/main/java/application/IncompleteSessionController.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiOperation;
 import objects.SerializableFormSession;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.aspectj.weaver.ast.Not;
 import org.commcare.modern.database.TableBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -67,7 +68,7 @@ public class IncompleteSessionController extends AbstractBaseController{
             @RequestBody IncompleteSessionRequestBean incompleteSessionRequestBean,
             @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
         deleteSession(incompleteSessionRequestBean.getSessionId());
-        return new NotificationMessage("Successfully deleted incomplete form.", false);
+        return new NotificationMessage("Successfully deleted incomplete form.", false, NotificationMessage.Tag.incomplete_form);
     }
 
     protected void deleteSession(String id) {

--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+
 import services.CategoryTimingHelper;
 import services.QueryRequester;
 import services.SyncRequester;
@@ -61,7 +63,7 @@ public class MenuController extends AbstractBaseController {
     @AppInstall
     public BaseResponseBean installRequest(@RequestBody InstallRequestBean installRequestBean,
                                            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                           FormplayerHttpRequest request) throws Exception {
+                                           HttpServletRequest request) throws Exception {
         BaseResponseBean baseResponseBean = runnerService.getNextMenu(performInstall(installRequestBean));
         logNotification(baseResponseBean.getNotification(), request);
         return baseResponseBean;
@@ -74,7 +76,7 @@ public class MenuController extends AbstractBaseController {
     //@AppInstall
     public NotificationMessage updateRequest(@RequestBody UpdateRequestBean updateRequestBean,
                                              @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                             FormplayerHttpRequest request) throws Exception {
+                                             HttpServletRequest request) throws Exception {
         NotificationMessage notificationMessage = performUpdate(updateRequestBean);
         logNotification(notificationMessage, request);
         return notificationMessage;
@@ -86,7 +88,7 @@ public class MenuController extends AbstractBaseController {
     @AppInstall
     public EntityDetailListResponse getDetails(@RequestBody SessionNavigationBean sessionNavigationBean,
                                                @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                               FormplayerHttpRequest request) throws Exception {
+                                               HttpServletRequest request) throws Exception {
         MenuSession menuSession = getMenuSessionFromBean(sessionNavigationBean);
         if (sessionNavigationBean.getIsPersistent()) {
             BaseResponseBean baseResponseBean = runnerService.advanceSessionWithSelections(menuSession,
@@ -158,7 +160,7 @@ public class MenuController extends AbstractBaseController {
     @AppInstall
     public BaseResponseBean navigateSessionWithAuth(@RequestBody SessionNavigationBean sessionNavigationBean,
                                                     @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                                    FormplayerHttpRequest request) throws Exception {
+                                                    HttpServletRequest request) throws Exception {
         String[] selections = sessionNavigationBean.getSelections();
         MenuSession menuSession;
         menuSession = getMenuSessionFromBean(sessionNavigationBean);

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -25,6 +25,8 @@ import util.Timing;
 
 import java.io.StringReader;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * Controller class (API endpoint) containing all all logic that isn't associated with
  * a particular form session or menu navigation. Includes:
@@ -58,7 +60,7 @@ public class UtilController extends AbstractBaseController {
     @UserLock
     public NotificationMessage deleteApplicationDbs(
             @RequestBody DeleteApplicationDbsRequestBean deleteRequest,
-            FormplayerHttpRequest request) {
+            HttpServletRequest request) {
 
         String message = "Successfully cleared application database for " + deleteRequest.getAppId();
         boolean success = true;
@@ -82,7 +84,7 @@ public class UtilController extends AbstractBaseController {
     @UserLock
     public NotificationMessage clearUserData(
             @RequestBody AuthenticatedRequestBean requestBean,
-            FormplayerHttpRequest request) {
+            HttpServletRequest request) {
 
         String message = "Successfully cleared the user data for  " + requestBean.getUsername();
         new UserDB(

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import services.CategoryTimingHelper;
 import sqlitedb.UserDB;
 import util.Constants;
+import util.FormplayerHttpRequest;
 import util.Timing;
 
 import java.io.StringReader;
@@ -56,7 +57,8 @@ public class UtilController extends AbstractBaseController {
     @RequestMapping(value = {Constants.URL_DELETE_APPLICATION_DBS, Constants.URL_UPDATE}, method = RequestMethod.POST)
     @UserLock
     public NotificationMessage deleteApplicationDbs(
-            @RequestBody DeleteApplicationDbsRequestBean deleteRequest) {
+            @RequestBody DeleteApplicationDbsRequestBean deleteRequest,
+            FormplayerHttpRequest request) {
 
         String message = "Successfully cleared application database for " + deleteRequest.getAppId();
         boolean success = true;
@@ -70,14 +72,17 @@ public class UtilController extends AbstractBaseController {
         if (!success) {
             message = "Failed to clear application database for " + deleteRequest.getAppId();
         }
-        return new NotificationMessage(message, !success);
+        NotificationMessage notificationMessage = new NotificationMessage(message, !success, NotificationMessage.Tag.wipedb);
+        logNotification(notificationMessage, request);
+        return notificationMessage;
     }
 
     @ApiOperation(value = "Clear the user's data")
     @RequestMapping(value = Constants.URL_CLEAR_USER_DATA, method = RequestMethod.POST)
     @UserLock
     public NotificationMessage clearUserData(
-            @RequestBody AuthenticatedRequestBean requestBean) {
+            @RequestBody AuthenticatedRequestBean requestBean,
+            FormplayerHttpRequest request) {
 
         String message = "Successfully cleared the user data for  " + requestBean.getUsername();
         new UserDB(
@@ -85,7 +90,9 @@ public class UtilController extends AbstractBaseController {
                 requestBean.getUsername(),
                 requestBean.getRestoreAs()
         ).deleteDatabaseFolder();
-        return new NotificationMessage(message, true);
+        NotificationMessage notificationMessage = new NotificationMessage(message, true, NotificationMessage.Tag.clear_data);
+        logNotification(notificationMessage, request);
+        return notificationMessage;
     }
 
     @ApiOperation(value = "Gets the status of the Formplayer service")

--- a/src/main/java/beans/NotificationMessage.java
+++ b/src/main/java/beans/NotificationMessage.java
@@ -1,8 +1,13 @@
 package beans;
 
+import org.springframework.beans.factory.annotation.Autowired;
+
+import util.FormplayerHttpRequest;
+
 /**
  * Created by willpride on 1/12/16.
  */
+
 public class NotificationMessage {
 
     public enum Type {
@@ -11,28 +16,40 @@ public class NotificationMessage {
         error
     }
 
+    public enum Tag {
+        submit,
+        selection,
+        query,
+        sync,
+        update,
+        incomplete_form,
+        wipedb,
+        clear_data,
+        volatility, menu
+    }
+
+
     private boolean isError;
     private String type;
     private String message;
+    private String tag;
 
-    public NotificationMessage(){
-        this(null, false);
-    }
-
-    public NotificationMessage(String message, boolean isError) {
+    public NotificationMessage(String message, boolean isError, Tag tag) {
         this.message = message;
         this.isError = isError;
-        if(this.isError){
+        if (this.isError) {
             this.type = Type.error.name();
         } else {
             this.type = Type.success.name();
         }
+        this.tag = tag.name();
     }
 
-    public NotificationMessage(String message, Type type) {
+    public NotificationMessage(String message, Type type, Tag tag) {
         this.message = message;
         this.type = type.name();
         this.isError = type == Type.error;
+        this.tag = tag.name();
     }
 
     public String getMessage() {
@@ -62,5 +79,9 @@ public class NotificationMessage {
     @Override
     public String toString() {
         return String.format("NotificationMessage message=%s, isError=%s, type=%s", message, isError, type);
+    }
+
+    public String getTag() {
+        return tag;
     }
 }

--- a/src/main/java/beans/NotificationMessage.java
+++ b/src/main/java/beans/NotificationMessage.java
@@ -25,7 +25,9 @@ public class NotificationMessage {
         incomplete_form,
         wipedb,
         clear_data,
-        volatility, menu
+        volatility,
+        menu,
+        unknown
     }
 
 
@@ -33,6 +35,10 @@ public class NotificationMessage {
     private String type;
     private String message;
     private String tag;
+
+    public NotificationMessage(){
+        // serialize
+    }
 
     public NotificationMessage(String message, boolean isError, Tag tag) {
         this.message = message;

--- a/src/main/java/beans/menus/BaseResponseBean.java
+++ b/src/main/java/beans/menus/BaseResponseBean.java
@@ -21,9 +21,9 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     public BaseResponseBean() {}
 
-    public BaseResponseBean(String title, String message, boolean isError, boolean clearSession){
+    public BaseResponseBean(String title, NotificationMessage notification, boolean clearSession){
         this.title = title;
-        this.notification = new NotificationMessage(message, isError);
+        this.notification = notification;
         this.clearSession = clearSession;
     }
 

--- a/src/main/java/objects/FormVolatilityRecord.java
+++ b/src/main/java/objects/FormVolatilityRecord.java
@@ -172,7 +172,7 @@ public class FormVolatilityRecord implements Serializable {
             return null;
         }
 
-        return new NotificationMessage(currentMessage + formatString, type);
+        return new NotificationMessage(currentMessage + formatString, type, NotificationMessage.Tag.volatility);
     }
 
     public boolean wasSubmitted() {

--- a/src/main/java/services/InstallService.java
+++ b/src/main/java/services/InstallService.java
@@ -56,8 +56,8 @@ public class InstallService {
                     engine.initEnvironment();
                     return new Pair<>(engine, false);
                 } catch (Exception e) {
-                    log.warn("Warning: An error occurred while trying to use the old DB file for app. CommCare will now try to install the new DB file for this app. Error details: Got exception "
-                            + e + " while reinitializing at path " + sqliteDB.getDatabaseFileForDebugPurposes());
+                    log.debug("An error occurred while trying to use the old DB file for app. Error details: Got exception "
+                            + e + " while reinitializing at path " + sqliteDB.getDatabaseFileForDebugPurposes() + " Reinitializing new DB ..");
                 }
             }
 

--- a/src/main/java/session/MenuSession.java
+++ b/src/main/java/session/MenuSession.java
@@ -142,26 +142,26 @@ public class MenuSession implements HereFunctionHandlerListener {
     public NotificationMessage updateApp(String updateMode) {
         try {
             if (this.engine.attemptAppUpdate(updateMode)) {
-                return new NotificationMessage("Application updated successfully.", false);
+                return new NotificationMessage("Application updated successfully.", false, NotificationMessage.Tag.update);
             } else {
-                return new NotificationMessage("Application up to date.", false);
+                return new NotificationMessage("Application up to date.", false, NotificationMessage.Tag.update);
             }
         } catch (UnresolvedResourceException e) {
             String message = "Update Failed! Couldn't find or install one of the remote resources";
             log.error(message, e);
-            return new NotificationMessage(message, true);
+            return new NotificationMessage(message, true, NotificationMessage.Tag.update);
         } catch (UnfullfilledRequirementsException e) {
             String message = "Update Failed! Formplayer is incompatible with the app";
             log.error(message, e);
-            return new NotificationMessage(message, true);
+            return new NotificationMessage(message, true, NotificationMessage.Tag.update);
         } catch (InstallCancelledException e) {
             String message = "Update Failed! Update was cancelled";
             log.error(message, e);
-            return new NotificationMessage(message, true);
+            return new NotificationMessage(message, true, NotificationMessage.Tag.update);
         } catch (ResourceInitializationException e) {
             String message = "Update Failed! Couldn't initialize one of the resources";
             log.error(message, e);
-            return new NotificationMessage(message, true);
+            return new NotificationMessage(message, true, NotificationMessage.Tag.update);
         }
     }
 

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -135,6 +135,7 @@ public class Constants {
     public static final String DATADOG_ERRORS_EXTERNAL_REQUEST = "errors.external_request";
     public static final String DATADOG_ERRORS_CRASH = "errors.crash";
     public static final String DATADOG_ERRORS_LOCK = "errors.lock";
+    public static final String DATADOG_ERRORS_NOTIFICATIONS = "errors.notifications";
 
     // End Datadog metrics
 


### PR DESCRIPTION
* Exposes error notifications to sentry and datadog counters
* Sends all kind of exceptions to Sentry

Notes: 
1. Would be great to get this deployed to staging to test first (As my HQ setup is still not great, I was not able to fully test it)

2. Is there a better Spring way to be able to avoid multiple `logNotification` calls here ? 