### PR TITLE
Lock Eviction Endpoint

### DIFF
--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -103,7 +103,6 @@ public class DebuggerController extends AbstractBaseController {
         MenuSession menuSession = getMenuSessionFromBean(evaluateXPathRequestBean);
         runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
 
-
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(
                 menuSession.getSessionWrapper().getEvaluationContext(),
                 evaluateXPathRequestBean.getXpath(),

--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -107,25 +107,6 @@ public class DebuggerController extends AbstractBaseController {
     public EvaluateXPathResponseBean menuEvaluateXpath(@RequestBody EvaluateXPathMenuRequestBean evaluateXPathRequestBean,
                                                        @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
                                                        HttpServletRequest request) throws Exception {
-
-        String path = evaluateXPathRequestBean.getXpath();
-
-
-        if(path.equals("lockup")) {
-            System.out.println("Locking up for 30 seconds");
-            long start = System.currentTimeMillis();
-            try {
-                while (System.currentTimeMillis() - start < 1000 * 30) {
-                    Thread.sleep(100);
-                }
-            } catch(InterruptedException e) {
-                System.out.println("Lock Broken");
-            }
-            System.out.println("Lockup Complete");
-            return null;
-        }
-
-
         MenuSession menuSession = getMenuSessionFromBean(evaluateXPathRequestBean);
         BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
         logNotification(responseBean.getNotification(), request);

--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -107,6 +107,25 @@ public class DebuggerController extends AbstractBaseController {
     public EvaluateXPathResponseBean menuEvaluateXpath(@RequestBody EvaluateXPathMenuRequestBean evaluateXPathRequestBean,
                                                        @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
                                                        HttpServletRequest request) throws Exception {
+
+        String path = evaluateXPathRequestBean.getXpath();
+
+
+        if(path.equals("lockup")) {
+            System.out.println("Locking up for 30 seconds");
+            long start = System.currentTimeMillis();
+            try {
+                while (System.currentTimeMillis() - start < 1000 * 30) {
+                    Thread.sleep(100);
+                }
+            } catch(InterruptedException e) {
+                System.out.println("Lock Broken");
+            }
+            System.out.println("Lockup Complete");
+            return null;
+        }
+
+
         MenuSession menuSession = getMenuSessionFromBean(evaluateXPathRequestBean);
         BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
         logNotification(responseBean.getNotification(), request);

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -121,7 +121,7 @@ public class UtilController extends AbstractBaseController {
             message = "No locks for the current user";
         }
 
-        return new NotificationMessage(message, false NotificationMessage.Type.success);
+        return new NotificationMessage(message, false, NotificationMessage.Tag.break_locks);
     }
 
     @ApiOperation(value = "Gets the status of the Formplayer service")

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -121,7 +121,7 @@ public class UtilController extends AbstractBaseController {
             message = "No locks for the current user";
         }
 
-        return new NotificationMessage(message, true);
+        return new NotificationMessage(message, false NotificationMessage.Type.success);
     }
 
     @ApiOperation(value = "Gets the status of the Formplayer service")

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -108,6 +108,20 @@ public class UtilController extends AbstractBaseController {
         return notificationMessage;
     }
 
+    @ApiOperation(value = "Reports back on any locks in place for the current user")
+    @RequestMapping(value = Constants.URL_CHECK_LOCKS, method = RequestMethod.POST)
+    public LockReportBean checkLocks(@RequestBody AuthenticatedRequestBean requestBean) throws Exception {
+        String key = LockAspect.getLockKeyForAuthenticatedBean(requestBean, formSessionRepo);
+
+
+        Integer secondsLocked = userLockRegistry.getTimeLocked(key);
+        if(secondsLocked == null) {
+            return new LockReportBean(false, 0);
+        } else{
+            return new LockReportBean(true, secondsLocked);
+        }
+    }
+
     @ApiOperation(value = "Breaks any currently locked requests for the current user")
     @RequestMapping(value = Constants.URL_BREAK_LOCKS, method = RequestMethod.POST)
     public NotificationMessage breakLocks(@RequestBody AuthenticatedRequestBean requestBean) throws Exception {

--- a/src/main/java/aspects/LockAspect.java
+++ b/src/main/java/aspects/LockAspect.java
@@ -72,22 +72,8 @@ public class LockAspect {
         String username;
         AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
 
-        if (bean.getUsernameDetail() != null) {
-            username = TableBuilder.scrubName(bean.getUsernameDetail());
-        }
-        else {
-            SerializableFormSession formSession = formSessionRepo.findOneWrapped(bean.getSessionId());
-            String tempUser = formSession.getUsername();
-            String restoreAs = formSession.getAsUser();
-            String restoreAsCaseId = formSession.getRestoreAsCaseId();
-            if (restoreAsCaseId != null) {
-                username = UserUtils.getRestoreAsCaseIdUsername(restoreAsCaseId);
-            } else if (restoreAs != null) {
-                username = tempUser + "_" + restoreAs;
-            } else {
-                username = tempUser;
-            }
-        }
+
+        username = getLockKeyForAuthenticatedBean(bean, formSessionRepo);
 
         Lock lock;
 
@@ -113,6 +99,27 @@ public class LockAspect {
                 }
             }
         }
+    }
+
+    public static String getLockKeyForAuthenticatedBean(AuthenticatedRequestBean bean, FormSessionRepo formSessionRepo) {
+        String username;
+        if (bean.getUsernameDetail() != null) {
+            username = TableBuilder.scrubName(bean.getUsernameDetail());
+        }
+        else {
+            SerializableFormSession formSession = formSessionRepo.findOneWrapped(bean.getSessionId());
+            String tempUser = formSession.getUsername();
+            String restoreAs = formSession.getAsUser();
+            String restoreAsCaseId = formSession.getRestoreAsCaseId();
+            if (restoreAsCaseId != null) {
+                username = UserUtils.getRestoreAsCaseIdUsername(restoreAsCaseId);
+            } else if (restoreAs != null) {
+                username = tempUser + "_" + restoreAs;
+            } else {
+                username = tempUser;
+            }
+        }
+        return username;
     }
 
     private void logLockError(AuthenticatedRequestBean bean, ProceedingJoinPoint joinPoint, String lockIssue) {

--- a/src/main/java/beans/LockReportBean.java
+++ b/src/main/java/beans/LockReportBean.java
@@ -1,0 +1,38 @@
+package beans;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Returns true if the server is up and healthy
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LockReportBean {
+
+    boolean locked;
+    int secondsLocked;
+
+    // our JSON-Object mapping lib (Jackson) requires a default constructor
+    public LockReportBean(){}
+
+    public LockReportBean(boolean locked, int secondsLocked) {
+        this.locked = locked;
+        this.secondsLocked = secondsLocked;
+    }
+
+    public boolean getLocked() {
+        return locked;
+    }
+
+    public void setLocked(boolean locked) {
+        this.locked = locked;
+    }
+
+    public void setSecondsLocked(int secondsLocked) {
+        this.secondsLocked = secondsLocked;
+    }
+
+    public long getSeckondsLocked() {
+        return secondsLocked;
+    }
+}

--- a/src/main/java/beans/NotificationMessage.java
+++ b/src/main/java/beans/NotificationMessage.java
@@ -25,6 +25,7 @@ public class NotificationMessage {
         incomplete_form,
         wipedb,
         clear_data,
+        break_locks,
         volatility,
         menu,
         unknown

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -39,6 +39,7 @@ public class Constants {
     public static final String URL_GET_INSTANCE = "get-instance";
     public static final String URL_CHANGE_LANGUAGE = "change_locale";
     public static final String URL_BREAK_LOCKS = "break_locks";
+    public static final String URL_CHECK_LOCKS = "check_locks";
 
     // Alternative namings used by SMS
     public static final String URL_NEXT = "next";

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -38,6 +38,7 @@ public class Constants {
     public static final String URL_VALIDATE_FORM = "validate_form";
     public static final String URL_GET_INSTANCE = "get-instance";
     public static final String URL_CHANGE_LANGUAGE = "change_locale";
+    public static final String URL_BREAK_LOCKS = "break_locks";
 
     // Alternative namings used by SMS
     public static final String URL_NEXT = "next";


### PR DESCRIPTION
Many long running request operations in formplayer can leave user sandboxes locked for very long amounts of time with no recourse. This makes operations like load testing especially painful.

This introduces an endpoint which forces the same 'lock eviction' process as would naturally occur if a request had come after the long timeout. 

Includes: https://github.com/dimagi/commcare-core/pull/893 to increase coverage of interruptable requests