### PR TITLE
Include origin token in restore requests

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -156,6 +156,13 @@ public class WebAppContext implements WebMvcConfigurer {
     }
 
     @Bean
+    public RedisTemplate<String, String> redisTemplateString() {
+        StringRedisTemplate template = new StringRedisTemplate(jedisConnFactory());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
     public RedisTemplate<String, Long> redisTemplateLong() {
         RedisTemplate template = new RedisTemplate<String, Long>();
         template.setConnectionFactory(jedisConnFactory());

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -112,9 +112,9 @@ public class RestoreFactory {
     private ValueOperations<String, Long> valueOperations;
 
     @Autowired
-    private RedisTemplate redisTemplate;
+    private RedisTemplate redisTemplateString;
 
-    @Resource(name="redisTemplate")
+    @Resource(name="redisTemplateString")
     private ValueOperations<String, String> originTokens;
 
     @Value("${commcarehq.formplayerAuthKey}")

--- a/src/main/java/services/RestoreFactory.java
+++ b/src/main/java/services/RestoreFactory.java
@@ -536,7 +536,6 @@ public class RestoreFactory {
     private void addOriginTokenHeader(HttpHeaders headers) {
         String originToken = PropertyUtils.genUUID();
         String redisKey = String.format("%s%s", ORIGIN_TOKEN_SLUG, originToken);
-        System.out.println("Adding redis key: " + redisKey);
         originTokens.set(redisKey,
                 "valid",
                 Duration.ofSeconds(60));

--- a/src/test/java/utils/TestContext.java
+++ b/src/test/java/utils/TestContext.java
@@ -18,6 +18,7 @@ import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
@@ -91,6 +92,12 @@ public class TestContext {
     public StringRedisTemplate redisTemplate() {
         return Mockito.mock(StringRedisTemplate.class);
     }
+
+    @Bean
+    public ValueOperations<String, Long> redisTemplateString() {
+        return Mockito.mock(ValueOperations.class);
+    }
+
 
     @Bean
     public ValueOperations<String, FormVolatilityRecord> redisVolatilityDict() {


### PR DESCRIPTION
Support for Card: https://trello.com/c/gfl9nnI7/32-mobile-endpoint-access-permissions

Before submitting restore requests to HQ, set an origin token in redis that HQ can use to identify that the request is internal to the environment.