### PR TITLE
Signal 401 on Unavailable Session

### DIFF
--- a/src/main/java/application/FormplayerAuthFilter.java
+++ b/src/main/java/application/FormplayerAuthFilter.java
@@ -2,6 +2,7 @@ package application;
 
 import beans.auth.HqUserDetailsBean;
 import exceptions.FormNotFoundException;
+import exceptions.SessionAuthUnavailableException;
 import objects.SerializableFormSession;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
@@ -85,7 +86,12 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
                     return;
                 }
                 setDomain(request);
-                setUserDetails(request);
+                try {
+                    setUserDetails(request);
+                } catch(SessionAuthUnavailableException saue) {
+                    setResponseError(response, HttpServletResponse.SC_UNAUTHORIZED, "User session unavailable");
+                    return;
+                }
                 JSONObject data = RequestUtils.getPostData(request);
                 if (!authorizeRequest(request, data.getString("domain"), getUsername(data))) {
                     setResponseError(response, HttpServletResponse.SC_UNAUTHORIZED, "Invalid user");

--- a/src/main/java/exceptions/SessionAuthUnavailableException.java
+++ b/src/main/java/exceptions/SessionAuthUnavailableException.java
@@ -1,0 +1,8 @@
+package exceptions;
+
+/**
+ * Thrown when FormPlayer identifies that the user's authentication is
+ * unavailable and they will need a new session to continue
+ */
+public class SessionAuthUnavailableException extends RuntimeException {
+}

--- a/src/main/java/services/HqUserDetailsService.java
+++ b/src/main/java/services/HqUserDetailsService.java
@@ -65,6 +65,7 @@ public class HqUserDetailsService {
                 if(response.getRawStatusCode() == 404) {
                     throw new SessionAuthUnavailableException();
                 }
+                super.handleError(response);
             }
         });
         HqUserDetailsBean userDetails = template.postForObject(getSessionDetailsUrl(), request, HqUserDetailsBean.class);


### PR DESCRIPTION
Previously we were throwing a generic 500 if the lookup for the user's session failed (because the user was logged out). Changes that to return a 401.