### PR TITLE
Ensure Sentry async connections are closed on cleanup

### DIFF
--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -193,7 +193,7 @@ public class WebAppContext implements WebMvcConfigurer {
         return new XFormService();
     }
 
-    @Bean
+    @Bean(destroyMethod="cleanup")
     @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public FormplayerSentry raven() {
         FormplayerSentry raven;

--- a/src/main/java/util/FormplayerSentry.java
+++ b/src/main/java/util/FormplayerSentry.java
@@ -231,4 +231,10 @@ public class FormplayerSentry {
     public void setAppId(String appId) {
         this.appId = appId;
     }
+
+    public void cleanup() {
+        if (sentryClient != null) {
+            sentryClient.closeConnection();
+        }
+    }
 }


### PR DESCRIPTION
Initial Ticket: https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/53/SUPPORT-1640

A barrage of unrelated surfaced the problem that once Sentry issues were reported, the reporting thread never closed out. This makes sure that connections are closed according to the bean lifecycle.