### PR TITLE
Catch Errors in Auth Filter

### DIFF
--- a/src/main/java/application/FormplayerAuthFilter.java
+++ b/src/main/java/application/FormplayerAuthFilter.java
@@ -106,7 +106,7 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
                 throw AuthorizationFailureException.AuthFailedWithLog (
                         "Invalid HMAC hash",
                         String.format("Hash comparison between request %s and generated %s failed", header, hash),
-                        HttpServletResponse.SC_UNAUTHORIZED).forceReport();
+                        HttpServletResponse.SC_BAD_REQUEST).forceReport();
 
             }
             try {
@@ -151,7 +151,7 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
             throw AuthorizationFailureException.AuthFailedWithError(
                     "Error validating session",
                     String.format("Error generating HMAC hash for validation of body: %s", body == null ? "Error reading body" : body),
-                    HttpServletResponse.SC_UNAUTHORIZED,
+                    HttpServletResponse.SC_BAD_REQUEST,
                     e);
         }
     }
@@ -167,7 +167,7 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
                 throw AuthorizationFailureException.AuthFailedWithError(
                         "No username for authentication",
                         "Request doesn't contain a username in POST data or session data for authentication",
-                        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                        HttpServletResponse.SC_BAD_REQUEST,
                         etwo);
 
             }

--- a/src/main/java/application/WebAppContext.java
+++ b/src/main/java/application/WebAppContext.java
@@ -209,6 +209,9 @@ public class WebAppContext implements WebMvcConfigurer {
     }
 
     @Bean
+    public FallbackSentryReporter sentryReporter() { return new FallbackSentryReporter(); }
+
+    @Bean
     @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public CategoryTimingHelper categoryTimingHelper() {
         return new CategoryTimingHelper();

--- a/src/main/java/services/FallbackSentryReporter.java
+++ b/src/main/java/services/FallbackSentryReporter.java
@@ -1,0 +1,54 @@
+package services;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import io.sentry.SentryClient;
+import io.sentry.SentryClientFactory;
+import io.sentry.dsn.InvalidDsnException;
+import io.sentry.event.Event;
+import io.sentry.event.EventBuilder;
+import io.sentry.event.interfaces.ExceptionInterface;
+import util.FormplayerSentry;
+
+/**
+ * Provides stateless reporting to Sentry for individual events that fall outside of the clean
+ * request cycle.
+ *
+ * @author Clayton Sims <csims@dimagi.com>
+ *
+ */
+@Service
+public class FallbackSentryReporter {
+    @Value("${sentry.dsn:}")
+    private String ravenDsn;
+
+    @Value("${commcarehq.environment}")
+    private String environment;
+
+    public EventBuilder getEventForException(Exception e) {
+        return new EventBuilder()
+            .withEnvironment(environment)
+            .withMessage(e.getMessage())
+            .withLevel(Event.Level.ERROR)
+            .withSentryInterface(new ExceptionInterface(e));
+    }
+
+
+    public void sendEvent(EventBuilder event) {
+        //TODO: In theory this could stay a singleton and not need to be re-inititalied
+        SentryClient client;
+        try {
+            client = SentryClientFactory.sentryClient(ravenDsn);
+            if (client == null) {
+                return;
+            }
+        } catch (InvalidDsnException e) {
+            return;
+        }
+
+        client.sendEvent(event);
+        client.closeConnection();
+    }
+
+}


### PR DESCRIPTION
Initial Authorization in Formplayer is performed through a Request Filter before the internal Spring Request lifecycle. This means that all of the core control mechanisms available in a normal scope (Default Exception Handling, Sentry breadcrumbs,  Request Logging aspects) are unavailable and errors in the Auth process were not logged in Sentry, did not return a clear response, and were logged as

```
2020-06-03 19:24:12.307 ERROR 9294 --- [o-8181-exec-128] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
org.json.JSONException: JSONObject["session-id"] not found.
        at org.json.JSONObject.get(JSONObject.java:473) ~[json-20131018.jar!/:na]
        at org.json.JSONObject.getString(JSONObject.java:654) ~[json-20131018.jar!/:na]
```

This provides clearer information about failures, makes sure they are logged to the server logs, and that some lightweight info can get up to sentry, and also provides a clearer logging message for the specific error that was causing issues.

New log error:
```
2020-06-03 19:32:34.898 ERROR 16576 --- [nio-8080-exec-2] application.FormplayerAuthFilter         : Request to /break_locks - Authorization Failed[500] Unexpectedly - Request doesn't contain a username in POST data or session data for authentication

application.FormplayerAuthFilter$AuthorizationFailureException: No username for authentication
	at application.FormplayerAuthFilter$AuthorizationFailureException.AuthFailedWithError(FormplayerAuthFilter.java:319) ~[classes!/:na]
```