### PR TITLE
Update Error Reporting Paths

### DIFF
--- a/src/main/java/application/AbstractBaseController.java
+++ b/src/main/java/application/AbstractBaseController.java
@@ -210,9 +210,12 @@ public abstract class AbstractBaseController {
 
     void logNotification(@Nullable NotificationMessage notification, HttpServletRequest req) {
         try {
-            if (notification != null && notification.isError()) {
+            if (notification != null && notification.getType() == NotificationMessage.Type.error.name()) {
                 raven.sendRavenException(new RuntimeException(notification.getMessage()));
                 incrementDatadogCounter(Constants.DATADOG_ERRORS_NOTIFICATIONS, req, notification.getTag());
+            } else if (notification != null && notification.getType() == NotificationMessage.Type.app_error.name()) {
+                raven.sendRavenException(new ApplicationConfigException(notification.getMessage()),Event.Level.INFO);
+                incrementDatadogCounter(Constants.DATADOG_ERRORS_APP_CONFIG, req, notification.getTag());
             }
         } catch (Exception e) {
             // we don't wanna crash while logging the error

--- a/src/main/java/application/DebuggerController.java
+++ b/src/main/java/application/DebuggerController.java
@@ -9,6 +9,7 @@ import beans.debugger.DebuggerFormattedQuestionsResponseBean;
 import beans.debugger.MenuDebuggerContentResponseBean;
 import beans.debugger.XPathQueryItem;
 import beans.menus.BaseResponseBean;
+import exceptions.ApplicationConfigException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import objects.SerializableFormSession;
@@ -114,7 +115,8 @@ public class DebuggerController extends AbstractBaseController {
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(
                 menuSession.getSessionWrapper().getEvaluationContext(),
                 evaluateXPathRequestBean.getXpath(),
-                evaluateXPathRequestBean.getDebugOutputLevel()
+                evaluateXPathRequestBean.getDebugOutputLevel(),
+                raven
         );
 
         cacheMenuXPathQuery(
@@ -141,7 +143,8 @@ public class DebuggerController extends AbstractBaseController {
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(
                 formEntrySession.getFormEntryModel().getForm().getEvaluationContext(),
                 evaluateXPathRequestBean.getXpath(),
-                evaluateXPathRequestBean.getDebugOutputLevel()
+                evaluateXPathRequestBean.getDebugOutputLevel(),
+                raven
         );
 
         cacheFormXPathQuery(

--- a/src/main/java/application/MenuController.java
+++ b/src/main/java/application/MenuController.java
@@ -176,7 +176,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex()
         );
-        logNotification(response.getNotification(),request);
+        logNotification(response.getNotification(), request);
         return setLocationNeeds(response, menuSession);
     }
 

--- a/src/main/java/application/UtilController.java
+++ b/src/main/java/application/UtilController.java
@@ -103,7 +103,7 @@ public class UtilController extends AbstractBaseController {
                 requestBean.getUsername(),
                 requestBean.getRestoreAs()
         ).deleteDatabaseFolder();
-        NotificationMessage notificationMessage = new NotificationMessage(message, true, NotificationMessage.Tag.clear_data);
+        NotificationMessage notificationMessage = new NotificationMessage(message, false, NotificationMessage.Tag.clear_data);
         logNotification(notificationMessage, request);
         return notificationMessage;
     }

--- a/src/main/java/beans/NotificationMessage.java
+++ b/src/main/java/beans/NotificationMessage.java
@@ -13,6 +13,7 @@ public class NotificationMessage {
     public enum Type {
         success,
         warning,
+        app_error,
         error
     }
 
@@ -55,7 +56,7 @@ public class NotificationMessage {
     public NotificationMessage(String message, Type type, Tag tag) {
         this.message = message;
         this.type = type.name();
-        this.isError = type == Type.error;
+        this.isError = type == Type.error || type == Type.app_error;
         this.tag = tag.name();
     }
 

--- a/src/main/java/exceptions/ApplicationConfigException.java
+++ b/src/main/java/exceptions/ApplicationConfigException.java
@@ -6,7 +6,12 @@ package exceptions;
  * is thrown, no error emails are sent.
  */
 public class ApplicationConfigException extends RuntimeException {
-        public ApplicationConfigException(String message) {
-            super(message);
-        }
+
+    public ApplicationConfigException(String message) {
+        super(message);
+    }
+
+    public ApplicationConfigException(String message, Exception wrapped) {
+        super(message, wrapped);
+    }
 }

--- a/src/main/java/services/MenuSessionRunnerService.java
+++ b/src/main/java/services/MenuSessionRunnerService.java
@@ -107,7 +107,7 @@ public class MenuSessionRunnerService {
             String assertionFailure = getAssertionFailure(menuSession);
             if (assertionFailure != null) {
                 BaseResponseBean responseBean = new BaseResponseBean("App Configuration Error",
-                        new NotificationMessage(assertionFailure, true, NotificationMessage.Tag.menu),
+                        new NotificationMessage(assertionFailure, NotificationMessage.Type.app_error, NotificationMessage.Tag.menu),
                         true);
                 return responseBean;
             }


### PR DESCRIPTION
Currently when formplayer catches `assert` errors we re-throw through the top level "error" notification path, which isn't differentiated from real code errors in sentry, datadog, other monitoring.

This switches the report path to present like a proper app issue (example below, old behavior on bottom, new behavior on top)
![image](https://user-images.githubusercontent.com/155066/84820661-fc18a080-afe7-11ea-93f8-2df2f3870966.png)

This also eliminates the Sentry Logging for DB Clear events which were reported as errors, but if that change isn't desirable it is easy to revert, and updates other noisy notifications being thrown as errors currently.
