### PR TITLE
Improved Locking Pattern for Archivable Files

### DIFF
--- a/src/main/java/exceptions/SqlArchiveLockException.java
+++ b/src/main/java/exceptions/SqlArchiveLockException.java
@@ -1,0 +1,13 @@
+package exceptions;
+
+import java.io.IOException;
+
+/**
+ * Signals that there was a fault attempting to safely acquire or manage
+ * the a lock around a db archive file, which prevented the success of an I/O operation
+ */
+public class SqlArchiveLockException extends IOException {
+    public SqlArchiveLockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sandbox/SqlSandboxUtils.java
+++ b/src/main/java/sandbox/SqlSandboxUtils.java
@@ -47,16 +47,12 @@ public class SqlSandboxUtils {
     }
 
     public static SQLiteConnectionPoolDataSource getDataSource(File databasePath) {
-        File databaseFolder = new File(databasePath.getParent());
         try {
-            if (!databaseFolder.exists()) {
-                Files.createDirectories(databaseFolder.toPath());
-            }
             Class.forName("org.sqlite.JDBC");
             SQLiteConnectionPoolDataSource dataSource = new SQLiteConnectionPoolDataSource();
             dataSource.setUrl("jdbc:sqlite:" + databasePath.getPath() + "?journal_mode=MEMORY");
             return dataSource;
-        } catch (ClassNotFoundException |IOException e) {
+        } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Core PR: https://dimagi-dev.atlassian.net/browse/COV-8

A few things in here:

1) Previously neither the Formplayer process nor the db archive script actually had the ability to clean up stale archive file locks. Archive file locks are now expunged after 5 minutes (this is a long time given the expected lifetime of such a lock)
2) When locks didn't go away on their own, formplayer threads would just hang in an endless loop. It looks like someone didn't understand how thread interrupts work and may have been assuming that calling thread interrupt did something to exit the loop it was in, but it didn't.
3) Fixed the lock ordering to always create a lock before performing the rest of the operations, to prevent race conditions where locks were created after checks
4) [Most Relevant to the Ticket] Ensures that the db file is `touch`ed each time it is loaded (and before a lock can be applied from the archive). This effectively prevents the situation where a db record is loaded at the start of a request but then the DB is archived before the request is ended (which was previously possible to replicate), causing the db file to be written incorrectly unless the request itself is longer than the archiver check window