### PR TITLE
Fix submit error reporting and single out too-many-requests

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -181,19 +181,18 @@ public class FormController extends AbstractBaseController{
                         purgeCasesTimer.durationInMs() > 2 ?
                                 "Puring cases took some time" : "Probably didn't have to purge cases");
 
-                ResponseEntity<String> submitResponse;
-                try {
-                    submitResponse = submitService.submitForm(
-                            formEntrySession.getInstanceXml(),
-                            formEntrySession.getPostUrl()
-                    );
-                } catch (HttpClientErrorException e) {
-                    if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                ResponseEntity<String> submitResponse = submitService.submitForm(
+                        formEntrySession.getInstanceXml(),
+                        formEntrySession.getPostUrl()
+                );
+
+                if (!submitResponse.getStatusCode().is2xxSuccessful()) {
+                    if (submitResponse.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
                         submitResponseBean.setStatus(Constants.SUBMIT_RESPONSE_TOO_MANY_REQUESTS);
                     } else {
                         submitResponseBean.setStatus("error");
                         NotificationMessage notification = new NotificationMessage(
-                                "Form submission failed with error response: " + e.getStatusText(),
+                                "Form submission failed with error response" + submitResponse,
                                 true, NotificationMessage.Tag.submit);
                         submitResponseBean.setNotification(notification);
                         logNotification(notification, request);

--- a/src/main/java/org/commcare/formplayer/services/SubmitService.java
+++ b/src/main/java/org/commcare/formplayer/services/SubmitService.java
@@ -5,6 +5,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.DefaultResponseErrorHandler;
@@ -34,6 +35,12 @@ public class SubmitService extends DefaultResponseErrorHandler {
         submitTimer.start();
         try {
             RestTemplate restTemplate = new RestTemplate();
+            restTemplate.setErrorHandler(new DefaultResponseErrorHandler() {
+                @Override
+                protected boolean hasError(HttpStatus statusCode) {
+                    return false;
+                }
+            });
             HttpEntity<?> entity = new HttpEntity<Object>(formXml, restoreFactory.getUserHeaders());
             return restTemplate.exchange(submitUrl,
                     HttpMethod.POST,

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -60,6 +60,7 @@ public class Constants {
     public static final String ANSWER_RESPONSE_STATUS_POSITIVE = "accepted";
     public static final String ANSWER_RESPONSE_STATUS_NEGATIVE = "validation-error";
     public static final String SYNC_RESPONSE_STATUS_POSITIVE = "success";
+    public static final String SUBMIT_RESPONSE_TOO_MANY_REQUESTS = "too-many-requests";
 
     //Debug output request types
     public static final String BASIC_NO_TRACE = "basic";


### PR DESCRIPTION
Easiest to review with w=1

As far as I can tell the `submitResponse.getStatusCode().is2xxSuccessful` clause was never getting run because `submitService.submitForm` with the default error handler will throw an error instead of returning if it's a 4xx or 5xx response; I guess if we got a 3xx response it would have hit that clause.

Now we make it never raise and always return, letting us handle the status code manually.