### PR TITLE
Fix Spring Boot Wiring for Testing and Consistency 

### DIFF
--- a/src/main/java/org/commcare/formplayer/Application.java
+++ b/src/main/java/org/commcare/formplayer/Application.java
@@ -1,4 +1,4 @@
-package org.commcare.formplayer.application;
+package org.commcare.formplayer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -6,6 +6,7 @@ import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.services.locale.LocalizerManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -23,11 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
-@Configuration
-@ComponentScan
-@EnableAutoConfiguration
-@EnableWebMvc
-@Component
+@SpringBootApplication
 @EnableJpaRepositories(basePackages = {"repo.*", "objects.*"})
 @EntityScan("objects.*")
 public class Application {

--- a/src/main/java/org/commcare/formplayer/application/DebuggerController.java
+++ b/src/main/java/org/commcare/formplayer/application/DebuggerController.java
@@ -35,7 +35,6 @@ import java.util.List;
  */
 @Api(value = "Debugger Controller", description = "Operations involving the CloudCare Debugger")
 @RestController
-@EnableAutoConfiguration
 public class DebuggerController extends AbstractBaseController {
 
     private int MAX_RECENT = 5;

--- a/src/main/java/org/commcare/formplayer/installers/FormplayerInstallerFactory.java
+++ b/src/main/java/org/commcare/formplayer/installers/FormplayerInstallerFactory.java
@@ -6,6 +6,8 @@ import org.commcare.resources.model.installers.LocaleFileInstaller;
 import org.commcare.resources.model.installers.LoginImageInstaller;
 import org.commcare.resources.model.installers.MediaInstaller;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
 
@@ -14,6 +16,7 @@ import org.commcare.formplayer.services.FormplayerStorageFactory;
  * The primary difference is that Formplayer overrides the storage() call to point to its own storage factory class
  */
 @Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class FormplayerInstallerFactory extends InstallerFactory {
 
     @Autowired

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -2,13 +2,17 @@ package org.commcare.formplayer.services;
 
 import com.timgroup.statsd.StatsDClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 import org.commcare.formplayer.util.*;
 
 import javax.servlet.http.HttpServletRequest;
 
 @Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class CategoryTimingHelper {
+
     @Autowired
     private HttpServletRequest request;
 

--- a/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
@@ -8,6 +8,8 @@ import org.javarosa.core.services.storage.IStorageIndexedFactory;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.services.storage.StorageManager;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PreDestroy;
@@ -23,6 +25,7 @@ import org.commcare.formplayer.util.UserUtils;
  * FormPlayer's storage factory that negotiates between parsers/installers and the storage layer
  */
 @Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class FormplayerStorageFactory implements IStorageIndexedFactory {
 
     private String username;

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -10,6 +10,8 @@ import org.commcare.modern.reference.ArchiveFileRoot;
 import org.commcare.modern.util.Pair;
 import org.commcare.resources.model.UnresolvedResourceException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Service;
 
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
@@ -22,6 +24,7 @@ import org.commcare.formplayer.util.SimpleTimer;
  * This can involve app download, install, and initialization of resources.
  */
 @Service
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class InstallService {
 
     @Autowired

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -22,6 +22,8 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpEntity;
@@ -30,6 +32,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -65,6 +68,7 @@ import java.util.concurrent.TimeUnit;
  * then retrieves and returns the restore XML.
  */
 @Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class RestoreFactory {
     @Value("${commcarehq.host}")
     private String host;
@@ -102,7 +106,7 @@ public class RestoreFactory {
     private FormplayerStorageFactory storageFactory;
 
     @Autowired
-    private RestTemplateBuilder restTemplateBuilder;
+    private RestTemplate restTemplate;
 
     @Autowired
     private RedisTemplate redisTemplateLong;
@@ -458,7 +462,7 @@ public class RestoreFactory {
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE);
         downloadRestoreTimer.start();
         try {
-            response = restTemplateBuilder.build().exchange(
+            response = restTemplate.exchange(
                     restoreUrl,
                     HttpMethod.GET,
                     new HttpEntity<String>(headers),

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -65,7 +65,6 @@ import org.commcare.formplayer.util.Constants;
  *
  * @author willpride
  */
-@Component
 public class FormSession {
 
     Log log = LogFactory.getLog(FormSession.class);

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -58,8 +58,6 @@ import java.util.*;
  *
  * A lot of this is copied from the CLI. We need to merge that. Big TODO
  */
-@EnableAutoConfiguration
-@Component
 public class MenuSession implements HereFunctionHandlerListener {
     private FormplayerConfigEngine engine;
     private UserSqlSandbox sandbox;

--- a/src/test/java/org/commcare/formplayer/tests/AsyncRestoreTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/AsyncRestoreTest.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.services.RestoreFactory;

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sandbox.SqlStorage;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestContext.class)
+@ActiveProfiles("UnitTesting")
 public class CaseClaimTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestContext.class)
-@ActiveProfiles("UnitTesting")
 public class CaseClaimTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
@@ -1,6 +1,6 @@
 package org.commcare.formplayer.tests;
 
-import org.commcare.formplayer.application.Application;
+import org.commcare.formplayer.Application;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -1,25 +1,12 @@
 package org.commcare.formplayer.utils;
 
 import com.timgroup.statsd.StatsDClient;
+
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
 import org.commcare.formplayer.mocks.MockFormSessionRepo;
 import org.commcare.formplayer.mocks.MockLockRegistry;
 import org.commcare.formplayer.mocks.MockMenuSessionRepo;
 import org.commcare.formplayer.mocks.TestInstallService;
-import org.commcare.modern.reference.ArchiveFileRoot;
-import org.javarosa.core.model.actions.FormSendCalloutHandler;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.MessageSource;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.support.ResourceBundleMessageSource;
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.integration.support.locks.LockRegistry;
-import org.springframework.web.servlet.view.InternalResourceViewResolver;
-
 import org.commcare.formplayer.objects.FormVolatilityRecord;
 import org.commcare.formplayer.repo.FormSessionRepo;
 import org.commcare.formplayer.repo.MenuSessionRepo;
@@ -38,10 +25,22 @@ import org.commcare.formplayer.services.XFormService;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerHttpRequest;
 import org.commcare.formplayer.util.FormplayerSentry;
+import org.commcare.modern.reference.ArchiveFileRoot;
+import org.javarosa.core.model.actions.FormSendCalloutHandler;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.MessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.integration.support.locks.LockRegistry;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
 import java.time.Duration;
 
-@Configuration
 public class TestContext {
 
     public TestContext() {
@@ -168,10 +167,10 @@ public class TestContext {
     }
 
     @Bean
-    public RestTemplateBuilder restTemplateBuilder() {
+    public RestTemplate restTemplate() {
         return new RestTemplateBuilder()
                 .setConnectTimeout(Duration.ofMillis(Constants.CONNECT_TIMEOUT))
-                .setReadTimeout(Duration.ofMillis(Constants.READ_TIMEOUT));
+                .setReadTimeout(Duration.ofMillis(Constants.READ_TIMEOUT)).build();
     }
 
     @Bean


### PR DESCRIPTION
Apologies for another big PR, but making structural changes has required fixing a lot of latent mistakes in the code that need joint cleanup for things to work after the changes.

Outline (Changes go in order)

1. Moves `Application` from the Nested Package to the Package root

This is a huge change because it makes Spring Boot's AutoConfiguration **actually work.** Previously all of the classes that were tagged as `@Component` and `@Service` etc, weren't actually being wired that way at all.

2. Cleans up Spring object configurations

Now that AutoConfig actually does something, there were a ton of errors in how beans were declared. I've tried hard to not change the semantics of anything - Everything that was a per-request Bean before stayed that way, although a lot of them are now self-declared rather than being defined by the `WebAppContext`

I also removed a lot of Annotations that didn't seem to be in the right place (like declaring @EnableWebMvc on the root Application), but was a bit conservative, so there are probably more annotations that can be cleared.

3. Shift away from a declared RestTemplateBuilder bean 

Now that the app is a properly configured `@SpringBootApplicaiton,` there is a latent autowired `RestTemplateBuilder` bean that conflicts, so the normal pattern is to declare your downstream `RestTemplate` as the bean. 

This change required shuffling how we use the RestTemplate to make sure that it is stateless, such as changing `HqUserDetailsService` to handle 404's in exception rather than a custom catch. 

4. Transition to OkHttp for internal rest requests

Apache has historically had issues with keeping connections open and letting them go stale, especially with CORS requests that have an extra OPTIONS request upfront. We fixed this previously by forcing request to use new restTemplates, but this is deeply discouraged. We've transitioned to OkHTTP on mobile and have been liking it, so this moves Formplayer over to the same core libs.

5. Update the User Detail Service test to use Spring Autowiring

Finally, updates a test that was previously causing us to break the auto-wiring pattern globally in order to work around Spring not setting the test up correctly.