### PR TITLE
Use Thread Local Statics for Object Prototypes

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/Application.java
+++ b/src/main/java/org/commcare/formplayer/application/Application.java
@@ -40,7 +40,7 @@ public class Application {
     private final Log log = LogFactory.getLog(Application.class);
 
     public static void main(String[] args) {
-        PrototypeUtils.setupPrototypes();
+        PrototypeUtils.setupThreadLocalPrototypes();
         ConfigurableApplicationContext context = SpringApplication.run(Application.class, args);
         LocalizerManager.setUseThreadLocalStrategy(true);
         ReferenceHandler.setUseThreadLocalStrategy(true);

--- a/src/main/java/org/commcare/formplayer/util/PrototypeUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/PrototypeUtils.java
@@ -32,7 +32,7 @@ import org.javarosa.xpath.expr.*;
  * Created by willpride on 2/8/16.
  */
 public class PrototypeUtils {
-    public static void setupPrototypes(){
+    public static void setupThreadLocalPrototypes(){
         PrototypeFactory.setStaticHasher(new ClassNameHasher());
         String[] prototypes = new String[] {BasicInstaller.class.getName(),
                 LocaleFileInstaller.class.getName(),
@@ -103,5 +103,7 @@ public class PrototypeUtils {
             PrototypeManager.registerPrototype(clazz.getName());
         }
         PrototypeManager.registerPrototypes(prototypes);
+
+        PrototypeManager.useThreadLocalStrategy(true);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -165,7 +165,7 @@ public class BaseTestClass {
         mapper = new ObjectMapper();
         storageFactoryMock.getSQLiteDB().closeConnection();
         restoreFactoryMock.getSQLiteDB().closeConnection();
-        PrototypeUtils.setupPrototypes();
+        PrototypeUtils.setupThreadLocalPrototypes();
         LocalizerManager.setUseThreadLocalStrategy(true);
         new SQLiteProperties().setDataDir("testdbs/");
         MockTimezoneProvider tzProvider = new MockTimezoneProvider();


### PR DESCRIPTION
Ensures that after the Application spins up, each worker thread gets its own PrototypeFactory to prevent thread conflicts between the underlying vectors and other shared memory.

Depends on a cross-posted formplayer commit which should be pulled first:
https://github.com/dimagi/commcare-core/pull/923