### PR TITLE
Allow for 412 recovery in aggressive/timed out syncs

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -206,7 +206,7 @@ public class RestoreFactory {
             return getSqlSandbox();
         } else {
             getSQLiteDB().createDatabaseFolder();
-            return restoreUser();
+            return performTimedSync(false);
         }
     }
 


### PR DESCRIPTION
Due to differences in the sync paths, if users needed an 'autosync' event because it had been to long since the previous sync a 412 response wouldn't be handled properly and would cycle for 5-10 requests when it retried.

![image](https://user-images.githubusercontent.com/155066/88955238-a4698800-d269-11ea-9e35-eb596b1f0378.png)

NOTE: this doesn't autopurge during the sync simply to be as consistent as possible with the current behavior to make sure to get this fixed asap.