### PR TITLE
Remove aggression from in-form requests

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -74,6 +74,8 @@ public class RestoreFactory {
     private String domain;
     private HqAuth hqAuth;
 
+    private boolean permitAggressiveSyncs = true;
+
     public static final String FREQ_DAILY = "freq-daily";
     public static final String FREQ_WEEKLY = "freq-weekly";
     public static final String FREQ_NEVER = "freq-never";
@@ -317,7 +319,8 @@ public class RestoreFactory {
 
     public boolean useAggressiveSyncTiming() {
         try {
-            return storageFactory.getPropertyManager().isSyncAfterFormEnabled();
+            return storageFactory.getPropertyManager().isSyncAfterFormEnabled() &&
+                    permitAggressiveSyncs;
         } catch (RuntimeException e) {
             // In cases where we don't have access to the PropertyManager, such as sync-db, this call
             // throws a RuntimeException
@@ -611,6 +614,13 @@ public class RestoreFactory {
         }
         String fullUrl = host + restoreUrl;
         return new Pair<>(fullUrl, headers);
+    }
+
+    /**
+     * Configures whether restores through this factory should support 'aggressive' syncs.
+     */
+    public void setPermitAggressiveSyncs(boolean permitAggressiveSyncs) {
+        this.permitAggressiveSyncs = permitAggressiveSyncs;
     }
 
     @PreDestroy

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -107,10 +107,17 @@ public class FormSession {
         initLocale();
     }
 
+    // Session object for ongoing sessions
     public FormSession(SerializableFormSession session,
                        RestoreFactory restoreFactory,
                        FormSendCalloutHandler formSendCalloutHandler,
                        FormplayerStorageFactory storageFactory) throws Exception{
+
+        //We don't want ongoing form sessions to change their db state underneath in the middle,
+        //so suppress continuous syncs. Eventually this should likely go into the bean connector
+        // for FormController endpoints rather than this config.
+        restoreFactory.setPermitAggressiveSyncs(false);
+
         this.username = session.getUsername();
         this.asUser = session.getAsUser();
         this.appId = session.getAppId();


### PR DESCRIPTION
The new(ish) "aggressive" sync processing will force syncs before processing requests on some short-ish timeframe (IE: At least one sync every 5 mintues). 

This mechanism was previously applied to both Menu requests and in-form actions (like submitting an answer to a question, or adding a repeat), which was unintended. Syncing during a form can result in mismatches between the form start dataset and the current dataset, and introduces unnecessary churn.

This removes aggressive autosyncing from all form entry actions.