### PR TITLE
Fix duplicate restore timings

### DIFF
--- a/config/application.example.properties
+++ b/config/application.example.properties
@@ -30,3 +30,6 @@ logging.level.org.hibernate=ERROR
 
 touchforms.username=touchforms_user
 touchforms.password=123
+
+# Recommended for developer configurations
+# logging.level.org.commcare=TRACE

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -1,6 +1,10 @@
 package org.commcare.formplayer.services;
 
 import com.timgroup.statsd.StatsDClient;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.commcare.formplayer.session.MenuSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.commcare.formplayer.util.*;
@@ -9,6 +13,8 @@ import javax.servlet.http.HttpServletRequest;
 
 @Component
 public class CategoryTimingHelper {
+    private final Log log = LogFactory.getLog(CategoryTimingHelper.class);
+
     @Autowired
     private HttpServletRequest request;
 
@@ -63,5 +69,10 @@ public class CategoryTimingHelper {
                 "category:" + category,
                 "request:" + RequestUtils.getRequestEndpoint(request)
         );
+
+        log.debug(String.format("Timing Event[%s][%s]: %dms",
+                RequestUtils.getRequestEndpoint(request),
+                category,
+                timing.durationInMs()));
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -218,15 +218,18 @@ public class RestoreFactory {
         while (true) {
             try {
                 UserSqlSandbox sandbox = getSqlSandbox();
-                SimpleTimer parseTimer = new SimpleTimer();
-                parseTimer.start();
                 FormplayerTransactionParserFactory factory = new FormplayerTransactionParserFactory(sandbox, true);
                 InputStream restoreStream = getRestoreXml();
+
+                SimpleTimer parseTimer = new SimpleTimer();
+                parseTimer.start();
+
                 setAutoCommit(false);
                 ParseUtils.parseIntoSandbox(restoreStream, factory, true, true);
                 hasRestored = true;
                 commit();
                 setAutoCommit(true);
+
                 parseTimer.end();
                 categoryTimingHelper.recordCategoryTiming(parseTimer, Constants.TimingCategories.PARSE_RESTORE);
                 sandbox.writeSyncToken();


### PR DESCRIPTION
Currently the timing code includes the amount of time spent waiting for a restore download in the amount of time it takes to parse this download, leading to confusing timing metrics

![image](https://user-images.githubusercontent.com/155066/88959798-93704500-d270-11ea-89b1-b1603c289aea.png)


This change splits out those timings int non-overlapping timers