### PR TITLE
Add log info for session purge timings

### DIFF
--- a/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
@@ -57,7 +57,7 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
             log.info("Beginning state form session purge");
             long start = System.currentTimeMillis();
             int deletedRows = this.jdbcTemplate.update(deleteQuery);
-            long elapsed = (System.currentTimeMillis() - start) / 1000;
+            long elapsed = System.currentTimeMillis() - start;
             log.info(String.format("Purged %d stale form sessions in %d ms", deletedRows, elapsed));
         } catch (Exception e) {
             // Don't crash for this. Not fatal and prevents start-up

--- a/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
@@ -54,7 +54,11 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
             String deleteQuery = replaceTableName(
                     "delete from %s where custom_safe_cast(dateopened, '2011-01-01'::timestamp) < NOW() - INTERVAL '7 days';"
             );
-            this.jdbcTemplate.execute(deleteQuery);
+            log.info("Beginning state form session purge");
+            long start = System.currentTimeMillis();
+            int deletedRows = this.jdbcTemplate.update(deleteQuery);
+            long elapsed = (System.currentTimeMillis() - start) / 1000;
+            log.info(String.format("Purged %d stale form sessions in %d ms", deletedRows, elapsed));
         } catch (Exception e) {
             // Don't crash for this. Not fatal and prevents start-up
             log.error("Exception purge form sessions", e);


### PR DESCRIPTION
This appears to be a very time consuming part of the restart process. Adding log events to confirm.