### PR TITLE
Add Flag for Startup Cleanup of Form Sessions

### DIFF
--- a/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
@@ -64,6 +64,10 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
                 int deletedRows = this.jdbcTemplate.update(deleteQuery);
                 long elapsed = System.currentTimeMillis() - start;
                 log.info(String.format("Purged %d stale form sessions in %d ms", deletedRows, elapsed));
+            } else {
+                log.debug(String.format("Skipping stale session purge due to current trigger " +
+                        "config '%s'. To enable, set " +
+                        "commcare.formplayer.purge.trigger=startup", purgeConfig));
             }
         } catch (Exception e) {
             // Don't crash for this. Not fatal and prevents start-up

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ spring.datasource.driver-class-name=${datasource.formplayer.driverClassName}
 spring.datasource.url=${datasource.formplayer.url}
 spring.datasource.username=${datasource.formplayer.username}
 spring.datasource.password=${datasource.formplayer.password}
+
+commcare.formplayer.purge.trigger=never


### PR DESCRIPTION
The current behavior clears out all stale (more than 7 day old) form sessions on startup, which for large production environments has gotten untenable (Taking up to 45 minutes with a broad worker pool and hundreds of thousands of sessions). 

This sets that behavior to be dependent on the app config setting

```
commcare.formplayer.purge.trigger=startup
```

which can be used in smaller environments or on-demand without requiring new deployment to be halted until complete by default.