### PR TITLE
Kev/scheduled tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,8 @@ dependencies {
     compile group: 'org.springframework.data', name: 'spring-data-redis', version: '2.2.0.RELEASE'
     compile group: 'org.springframework.data', name: 'spring-data-commons', version: '2.2.0.RELEASE'
     compile group: 'org.springframework.integration', name: 'spring-integration-redis', version: '5.2.0.RELEASE'
+    compile group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '4.14.0'
+    compile group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '4.14.0'
 
     compile fileTree(dir: 'libs', include: '*.jar')
     compile project(path: ':commcare', configuration: 'api')

--- a/src/main/java/org/commcare/formplayer/db/migration/V18__init_shedlock.java
+++ b/src/main/java/org/commcare/formplayer/db/migration/V18__init_shedlock.java
@@ -1,0 +1,18 @@
+package org.commcare.formplayer.db.migration;
+
+import java.util.Arrays;
+
+public class V18__init_shedlock extends BaseFormplayerMigration {
+
+    @Override
+    public Iterable<String> getSqlStatements() {
+        return Arrays.asList("CREATE TABLE shedlock (\n" +
+                "    name VARCHAR(64) NOT NULL,\n" +
+                "    lock_until TIMESTAMP NOT NULL,\n" +
+                "    locked_at TIMESTAMP NOT NULL,\n" +
+                "    locked_by VARCHAR(255) NOT NULL,\n" +
+                "    PRIMARY KEY (name)\n" +
+                ")"
+        );
+    }
+}

--- a/src/main/java/org/commcare/formplayer/db/migration/V18__init_shedlock.java
+++ b/src/main/java/org/commcare/formplayer/db/migration/V18__init_shedlock.java
@@ -2,6 +2,10 @@ package org.commcare.formplayer.db.migration;
 
 import java.util.Arrays;
 
+/**
+ * Creates a table to use with shedlock for JdbcTemplate
+ * https://github.com/lukas-krecan/ShedLock/blob/shedlock-parent-4.14.0/README.md#jdbctemplate
+ */
 public class V18__init_shedlock extends BaseFormplayerMigration {
 
     @Override

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -10,6 +10,7 @@ import java.util.List;
  * Repository for storing and accessing form entry sessions
  */
 public interface FormSessionRepo extends CrudRepository<SerializableFormSession, String> {
+    int purgeFormSessions();
     List<SerializableFormSession> findUserSessions(String username);
     SerializableFormSession findOneWrapped(String id) throws FormNotFoundException;
 }

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Repository for storing and accessing form entry sessions
  */
 public interface FormSessionRepo extends CrudRepository<SerializableFormSession, String> {
-    int purgeFormSessions();
+    int purge();
     List<SerializableFormSession> findUserSessions(String username);
     SerializableFormSession findOneWrapped(String id) throws FormNotFoundException;
 }

--- a/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
+++ b/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
@@ -38,11 +38,11 @@ public class ScheduledTasks {
         log.info("Starting purge scheduled task.");
         int deletedRows = formSessionRepo.purge();
         datadogStatsDClient.count(
-                "%s.%s".format(Constants.SCHEDULED_TASKS_PURGE, "deletedRows"),
+                String.format("%s.%s", Constants.SCHEDULED_TASKS_PURGE, "deletedRows"),
                 deletedRows
         );
         datadogStatsDClient.increment(
-                "%s.%s".format(Constants.SCHEDULED_TASKS_PURGE, "timesRun")
+                String.format("%s.%s", Constants.SCHEDULED_TASKS_PURGE, "timesRun")
         );
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
+++ b/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
@@ -1,0 +1,26 @@
+package org.commcare.formplayer.services;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.commcare.formplayer.Application;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import net.javacrumbs.shedlock.core.SchedulerLock;
+
+@Component
+public class ScheduledTasks {
+
+    private final Log log = LogFactory.getLog(ScheduledTasks.class);
+
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+
+    @Scheduled(fixedRate = 5000)
+    @SchedulerLock(name = "reportCurrentTime", lockAtMostFor = 14000, lockAtLeastFor = 14000)
+    public void reportCurrentTime() {
+        log.info("The time is now {}".format(dateFormat.format(new Date())));
+    }
+}

--- a/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
+++ b/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
@@ -1,15 +1,20 @@
 package org.commcare.formplayer.services;
 
+import com.timgroup.statsd.StatsDClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.formplayer.Application;
+import org.commcare.formplayer.repo.FormSessionRepo;
+import org.commcare.formplayer.util.Constants;
+import org.commcare.formplayer.util.RequestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import net.javacrumbs.shedlock.core.SchedulerLock;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 
 @Component
 public class ScheduledTasks {
@@ -18,9 +23,26 @@ public class ScheduledTasks {
 
     private static final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
 
-    @Scheduled(fixedRate = 5000)
-    @SchedulerLock(name = "reportCurrentTime", lockAtMostFor = 14000, lockAtLeastFor = 14000)
-    public void reportCurrentTime() {
-        log.info("The time is now {}".format(dateFormat.format(new Date())));
+    @Autowired
+    protected FormSessionRepo formSessionRepo;
+
+    @Autowired
+    private StatsDClient datadogStatsDClient;
+
+    // the default "-" corresponds to Scheduled.CRON_DISABLED
+    @Scheduled(cron= "${commcare.formplayer.scheduledTasks.purge.cron:-}")
+    @SchedulerLock(name = "purge",
+            lockAtMostFor = "${commcare.formplayer.scheduledTasks.purge.lockAtMostFor:5h}",
+            lockAtLeastFor = "${commcare.formplayer.scheduledTasks.purge.lockAtLeastFor:20m}")
+    public void purge() {
+        log.info("Starting purge scheduled task.");
+        int deletedRows = formSessionRepo.purgeFormSessions();
+        datadogStatsDClient.count(
+                "%s.%s".format(Constants.SCHEDULED_TASKS_PURGE, "deletedRows"),
+                deletedRows
+        );
+        datadogStatsDClient.increment(
+                "%s.%s".format(Constants.SCHEDULED_TASKS_PURGE, "timesRun")
+        );
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
+++ b/src/main/java/org/commcare/formplayer/services/ScheduledTasks.java
@@ -33,10 +33,10 @@ public class ScheduledTasks {
     @Scheduled(cron= "${commcare.formplayer.scheduledTasks.purge.cron:-}")
     @SchedulerLock(name = "purge",
             lockAtMostFor = "${commcare.formplayer.scheduledTasks.purge.lockAtMostFor:5h}",
-            lockAtLeastFor = "${commcare.formplayer.scheduledTasks.purge.lockAtLeastFor:20m}")
+            lockAtLeastFor = "${commcare.formplayer.scheduledTasks.purge.lockAtLeastFor:1h}")
     public void purge() {
         log.info("Starting purge scheduled task.");
-        int deletedRows = formSessionRepo.purgeFormSessions();
+        int deletedRows = formSessionRepo.purge();
         datadogStatsDClient.count(
                 "%s.%s".format(Constants.SCHEDULED_TASKS_PURGE, "deletedRows"),
                 deletedRows

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -142,5 +142,5 @@ public class Constants {
 
     // End Datadog metrics
 
-
+    public static final String SCHEDULED_TASKS_PURGE = "scheduled_tasks.purge";
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.datasource.username=${datasource.formplayer.username}
 spring.datasource.password=${datasource.formplayer.password}
 
 commcare.formplayer.purge.trigger=never
+commcare.formplayer.scheduledTasks.purge.cron=0 0 0 * * *
+commcare.formplayer.scheduledTasks.purge.lockAtMostFor=5h
+commcare.formplayer.scheduledTasks.purge.lockAtLeastFor=1h

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,8 +6,3 @@ spring.datasource.driver-class-name=${datasource.formplayer.driverClassName}
 spring.datasource.url=${datasource.formplayer.url}
 spring.datasource.username=${datasource.formplayer.username}
 spring.datasource.password=${datasource.formplayer.password}
-
-commcare.formplayer.purge.trigger=never
-commcare.formplayer.scheduledTasks.purge.cron=0 0 0 * * *
-commcare.formplayer.scheduledTasks.purge.lockAtMostFor=5h
-commcare.formplayer.scheduledTasks.purge.lockAtLeastFor=1h


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11257

## Summary
Allows purge db query to be run on a schedule in isolation on one node in a cluster. 
Uses the `@Scheduled` annotation and uses shedlock to handle distributed locking to ensure only one runs at a time.

## Changes
- adds shedlock dependency
- refactors the `PostgresFormSessionRepo` to make purge callable 
- adds a scheduled task class to call purge and report metrics to statsd
- Follows [jdbctemplate](FormSessionRepo) instructiions
    - adds a db migration to create a shedlock table 
    - creates a jdbctemplate lockprovider and calls `usingDbTime()` to use the postgres server db time instead of the formplayer server time to ensure synchronization 
- Adds configurations for a [cron expression](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/support/CronSequenceGenerator.html), lockAtMostFor and lockAtLeastFor to control the task schedule
    - `0 0 0 * * *` runs on midnight every day


## Testing
Tested locally
With configuration:
```
commcare.formplayer.scheduledTasks.purge.cron=0/1 * * * * *  # Runs every second
commcare.formplayer.scheduledTasks.purge.lockAtMostFor=6s 
commcare.formplayer.scheduledTasks.purge.lockAtLeastFor=6s
```
Which means it is scheduled for every second but there is a lock for exactly 6 seconds. 
output:
```
2020-09-10 11:32:22.16 [scheduling-1] INFO  o.c.f.services.ScheduledTasks - Starting purge scheduled task.
2020-09-10 11:32:22.22 [scheduling-1] INFO  o.c.f.r.impl.PostgresFormSessionRepo - Beginning state form session purge
2020-09-10 11:32:22.31 [scheduling-1] INFO  o.c.f.r.impl.PostgresFormSessionRepo - Purged 0 stale form sessions in 9 ms
2020-09-10 11:32:28.12 [scheduling-1] INFO  o.c.f.services.ScheduledTasks - Starting purge scheduled task.
2020-09-10 11:32:28.14 [scheduling-1] INFO  o.c.f.r.impl.PostgresFormSessionRepo - Beginning state form session purge
2020-09-10 11:32:28.18 [scheduling-1] INFO  o.c.f.r.impl.PostgresFormSessionRepo - Purged 0 stale form sessions in 4 ms
```
Although it is scheduled for every second, it only runs every 6s because of the lock. 

DB entry:
<img width="1174" alt="Screen Shot 2020-09-10 at 11 34 51 AM" src="https://user-images.githubusercontent.com/615126/92755276-a9862080-f359-11ea-96c9-a00c595ed01e.png">


TODO: Run on staging to verify statsd.
