### PR TITLE
Add Source ID to Request Logs

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/RequestResponseLoggingFilter.java
+++ b/src/main/java/org/commcare/formplayer/application/RequestResponseLoggingFilter.java
@@ -100,6 +100,8 @@ public class RequestResponseLoggingFilter extends GenericFilterBean {
             // Swallow, restoreAs not always provided in request.
         }
 
+        logLineJson.put("sourceIpAddr", request.getRemoteAddr());
+
         FormplayerHttpRequest formplayerHttpRequest = (FormplayerHttpRequest) request;
         logLineJson.put("projectSpace", formplayerHttpRequest.getDomain());
         logLineJson.put("requestUrl", new String(formplayerHttpRequest.getRequestURL()));


### PR DESCRIPTION
Adds the source IP address redundantly to this log channel for more convenient in-place aggregation.

Note: For production (or any environments behind a load balance or IP carrying proxy), a new directive will need to be added to deploy scripts before this address is processed correctly.
