### PR TITLE
skip fixtures

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -237,7 +237,9 @@ public class FormController extends AbstractBaseController{
                 //If configured to do so, do a sync with server now to ensure dats is up to date.
                 //Need to do before end of form nav triggers, since the new data might change the
                 //validity of the form
-                restoreFactory.performTimedSync(true, true);
+
+                boolean skipFixtures = storageFactory.getPropertyManager().skipFixturesAfterSubmit();
+                restoreFactory.performTimedSync(true, skipFixtures);
             }
 
             if (formEntrySession.getMenuSessionId() != null &&

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -237,7 +237,7 @@ public class FormController extends AbstractBaseController{
                 //If configured to do so, do a sync with server now to ensure dats is up to date.
                 //Need to do before end of form nav triggers, since the new data might change the
                 //validity of the form
-                restoreFactory.performTimedSync();
+                restoreFactory.performTimedSync(true, true);
             }
 
             if (formEntrySession.getMenuSessionId() != null &&

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -269,7 +269,7 @@ public class MenuSessionRunnerService {
         }
         if (responseEntity.getStatusCode().is2xxSuccessful()) {
             // Don't purge for case claim
-            restoreFactory.performTimedSync(false);
+            restoreFactory.performTimedSync(false, false);
             return new NotificationMessage("Case claim successful.", false, NotificationMessage.Tag.sync);
         } else {
             return new NotificationMessage(

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -56,7 +56,7 @@ public class NewFormResponseFactory {
         }
         // Don't purge when restoring as a case
         boolean shouldPurge = bean.getRestoreAsCaseId() == null;
-        UserSqlSandbox sandbox = restoreFactory.performTimedSync(shouldPurge);
+        UserSqlSandbox sandbox = restoreFactory.performTimedSync(shouldPurge, false);
 
         storageFactory.configure(bean.getUsername(),
                 bean.getDomain(),

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -327,16 +327,6 @@ public class RestoreFactory {
         }
     }
 
-    public boolean skipFixturesAfterSubmit() {
-        try {
-            return storageFactory.getPropertyManager().skipFixturesAfterSubmit();
-        } catch (RuntimeException e) {
-            // In cases where we don't have access to the PropertyManager, such sync-db, this call
-            // throws a RuntimeException
-            return false;
-        }
-    }
-
     public boolean useAggressiveSyncTiming() {
         try {
             return storageFactory.getPropertyManager().isSyncAfterFormEnabled() &&
@@ -632,7 +622,7 @@ public class RestoreFactory {
         if( asUsername != null) {
             builder.append("&as=").append(asUsername).append("@").append(domain).append(".commcarehq.org");
         }
-        if (skipFixtures && skipFixturesAfterSubmit()) {
+        if (skipFixtures) {
             builder.append("&skip_fixtures=true");
         }
         String restoreUrl = builder.toString();

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -327,6 +327,16 @@ public class RestoreFactory {
         }
     }
 
+    public boolean skipFixturesAfterSubmit() {
+        try {
+            return storageFactory.getPropertyManager().skipFixturesAfterSubmit();
+        } catch (RuntimeException e) {
+            // In cases where we don't have access to the PropertyManager, such sync-db, this call
+            // throws a RuntimeException
+            return false;
+        }
+    }
+
     public boolean useAggressiveSyncTiming() {
         try {
             return storageFactory.getPropertyManager().isSyncAfterFormEnabled() &&
@@ -622,8 +632,8 @@ public class RestoreFactory {
         if( asUsername != null) {
             builder.append("&as=").append(asUsername).append("@").append(domain).append(".commcarehq.org");
         }
-        if (skipFixtures) {
-            builder.append("&skip_fixtures=True");
+        if (skipFixtures && skipFixturesAfterSubmit()) {
+            builder.append("&skip_fixtures=true");
         }
         String restoreUrl = builder.toString();
         HttpHeaders headers;

--- a/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
@@ -18,6 +18,8 @@ public class FormplayerPropertyManager extends PropertyManager {
     public static final String POST_FORM_SYNC = "cc-sync-after-form";
     public static final String FUZZY_SEARCH_ENABLED = "cc-fuzzy-search-enabled";
 
+    public static final String SKIP_FIXTURES_AFTER_SUBMIT = "cc-skip-fixtures-after-submit";
+
     /**
      * Constructor for this PropertyManager
      *
@@ -50,5 +52,9 @@ public class FormplayerPropertyManager extends PropertyManager {
 
     public boolean isFuzzySearchEnabled() {
         return doesPropertyMatch(FUZZY_SEARCH_ENABLED, NO, YES);
+    }
+
+    public boolean skipFixturesAfterSubmit() {
+        return doesPropertyMatch(SKIP_FIXTURES_AFTER_SUBMIT, NO, YES);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -158,7 +159,7 @@ public class BaseTestClass {
         mockMenuController = MockMvcBuilders.standaloneSetup(menuController).build();
         mockDebuggerController = MockMvcBuilders.standaloneSetup(debuggerController).build();
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer(this.getMockRestoreFileName());
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
         setupSubmitServiceMock();
         Mockito.doReturn(false)
                 .when(restoreFactoryMock).isRestoreXmlExpired();

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import java.util.Hashtable;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +62,7 @@ public class CaseClaimTests extends BaseTestClass {
 
         // When we sync afterwards, include new case and case-claim 
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim2.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
 
         CommandListResponseBean commandResponse = sessionNavigateWithQuery(new String[]{"1", "action 1", "0156fa3e-093e-4136-b95c-01b13dae66c6"},
                 "caseclaim",
@@ -84,7 +85,7 @@ public class CaseClaimTests extends BaseTestClass {
         configureQueryMockOwned();
         configureSyncMock();
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
 
         CommandListResponseBean response = sessionNavigateWithQuery(new String[]{"1", "action 1", "3512eb7c-7a58-4a95-beda-205eb0d7f163"},
                 "caseclaim",


### PR DESCRIPTION
This adds a flag to restore requests sent on form completion to ask HQ to avoid sending down fixtures. There will be linked HQ PR that implements that for domains that enable a feature flag.