### PR TITLE
Kev/point core to kev timezone

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/AuthenticatedRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/AuthenticatedRequestBean.java
@@ -21,6 +21,7 @@ public class AuthenticatedRequestBean {
     private String restoreAsCaseId;
 
     private int timezoneOffsetMillis = -1;
+    private String timezoneFromBrowser = null;
 
     public String getUsername() {
         return username;
@@ -87,6 +88,16 @@ public class AuthenticatedRequestBean {
     @JsonSetter(value = "tz_offset_millis")
     public void setTzOffset(int offset) {
         this.timezoneOffsetMillis = offset;
+    }
+
+    @JsonGetter(value = "tz_from_browser")
+    public String getTzFromBrowser() {
+        return this.timezoneFromBrowser;
+    }
+
+    @JsonSetter(value = "tz_from_browser")
+    public void setTzFromBrowser(String offset) {
+        this.timezoneFromBrowser = offset;
     }
 
     @JsonGetter(value = "session-id")

--- a/src/main/java/org/commcare/formplayer/services/BrowserValuesProvider.java
+++ b/src/main/java/org/commcare/formplayer/services/BrowserValuesProvider.java
@@ -1,26 +1,57 @@
 package org.commcare.formplayer.services;
 
+import io.sentry.event.Event;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
+import org.commcare.formplayer.util.FormplayerSentry;
 import org.javarosa.core.model.utils.TimezoneProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.Date;
 import java.util.TimeZone;
-import java.util.Calendar;
 
 /**
  * Created by amstone326 on 1/8/18.
  */
 public class BrowserValuesProvider extends TimezoneProvider {
 
+    @Autowired
+    protected FormplayerSentry raven;
+
     private int timezoneOffsetMillis = -1;
     private TimeZone timezoneFromBrowser = null;
 
     public void setTimezoneOffset(AuthenticatedRequestBean bean) {
-        try {
-            timezoneFromBrowser = TimeZone.getTimeZone(bean.getTzFromBrowser());
-        } catch (Exception e) {
-            // TODO: handle and make more specific.
+        timezoneOffsetMillis = bean.getTzOffset();
+        String tzFromBrowserString = bean.getTzFromBrowser();
+
+        if (tzFromBrowserString != null &&
+                Arrays.asList(TimeZone.getAvailableIDs()).contains(tzFromBrowserString)) {
+            timezoneFromBrowser = TimeZone.getTimeZone(tzFromBrowserString);
         }
 
-        timezoneOffsetMillis = bean.getTzOffset();
+        try {
+            checkTzDiscrepancy(timezoneFromBrowser, timezoneOffsetMillis);
+        } catch (TzDiscrepancyException e) {
+            raven.sendRavenException(e, Event.Level.WARNING);
+        }
+    }
+
+    public void checkTzDiscrepancy(TimeZone tz, int reportedTzOffsetMillis) throws TzDiscrepancyException {
+        if (tz == null && reportedTzOffsetMillis == -1) {
+            return;
+        }
+        int tzOffsetFromTz = 0;
+        if (tz != null) {
+            tzOffsetFromTz = tz.getOffset(new Date().getTime());
+            if (tzOffsetFromTz == reportedTzOffsetMillis) {
+                return;
+            }
+        }
+        String tzName = (tz == null) ? null : tz.getDisplayName();
+        String errorMsg = String.format("Reported timezone %s has offset %d which is different than reported" +
+                "offset %d", tzName, tzOffsetFromTz, reportedTzOffsetMillis);
+        throw new TzDiscrepancyException("");
     }
 
     @Override
@@ -31,6 +62,12 @@ public class BrowserValuesProvider extends TimezoneProvider {
     @Override
     public TimeZone getTimezone() {
         return timezoneFromBrowser;
+    }
+
+    public class TzDiscrepancyException extends Exception {
+        public TzDiscrepancyException(String message) {
+            super(message);
+        }
     }
 
 }

--- a/src/main/java/org/commcare/formplayer/services/BrowserValuesProvider.java
+++ b/src/main/java/org/commcare/formplayer/services/BrowserValuesProvider.java
@@ -2,6 +2,8 @@ package org.commcare.formplayer.services;
 
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.javarosa.core.model.utils.TimezoneProvider;
+import java.util.TimeZone;
+import java.util.Calendar;
 
 /**
  * Created by amstone326 on 1/8/18.
@@ -9,14 +11,26 @@ import org.javarosa.core.model.utils.TimezoneProvider;
 public class BrowserValuesProvider extends TimezoneProvider {
 
     private int timezoneOffsetMillis = -1;
+    private TimeZone timezoneFromBrowser = null;
 
     public void setTimezoneOffset(AuthenticatedRequestBean bean) {
+        try {
+            timezoneFromBrowser = TimeZone.getTimeZone(bean.getTzFromBrowser());
+        } catch (Exception e) {
+            // TODO: handle and make more specific.
+        }
+
         timezoneOffsetMillis = bean.getTzOffset();
     }
 
     @Override
     public int getTimezoneOffsetMillis() {
         return timezoneOffsetMillis;
+    }
+
+    @Override
+    public TimeZone getTimezone() {
+        return timezoneFromBrowser;
     }
 
 }

--- a/src/test/java/org/commcare/formplayer/tests/BrowserValuesProviderTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/BrowserValuesProviderTest.java
@@ -1,0 +1,54 @@
+package org.commcare.formplayer.tests;
+
+import org.commcare.formplayer.services.BrowserValuesProvider;
+import org.commcare.formplayer.utils.TestContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.TimeZone;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = TestContext.class)
+public class BrowserValuesProviderTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    BrowserValuesProvider browserValuesProvider = null;
+
+    @Before
+    public void setUp() throws Exception {
+        this.browserValuesProvider = new BrowserValuesProvider();
+    }
+
+    @Test
+    public void testCheckTzDiscrepancy() throws Exception {
+        // Should not throw an exception.
+        browserValuesProvider.checkTzDiscrepancy(null, -1);
+        browserValuesProvider.checkTzDiscrepancy(TimeZone.getTimeZone("America/New_York"), -14400000);
+    }
+
+    @Test
+    public void testCheckTzDiscrepancyNullTz() throws Exception {
+        thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
+        browserValuesProvider.checkTzDiscrepancy(null, -14400000);
+    }
+
+    @Test
+    public void testCheckTzDiscrepancyFalseTz() throws Exception {
+        thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
+        browserValuesProvider.checkTzDiscrepancy(TimeZone.getTimeZone("America/New_York"), 0);
+    }
+
+    @Test
+    public void testCheckTzDiscrepancyFalseNonsenseTz() throws Exception {
+        thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
+        browserValuesProvider.checkTzDiscrepancy(TimeZone.getTimeZone("adaf"), -1);
+    }
+
+}


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11203

If the browser passes up the timezone information, the browser timezone provider uses that timezone ID string as the timezone so the shared commcare core code that does date functions can have tz context.

## Flow
[Browser](https://github.com/dimagi/commcare-hq/pull/28647) sends up IANA tz (e.g. "America/New_York"). ---> 
[Formplayer](https://github.com/dimagi/formplayer/pull/768) uses the tz from the browser as a info for its timezone provider --> 
[the shared commcare-core ](https://github.com/dimagi/commcare-core/pull/935)code that does date maniplations uses the timezone provider.


## Note
This change should not be coupled to the commcare-hq PR nor the commcare-core PR, because without the tz from the browser it should fallback to the tz offset. 
If we rely on timezones, we need to update the java code or periodically run the timezone updater tool https://www.oracle.com/java/technologies/javase/tzupdater-readme.html.

## Testing
The timezone IDs should be in the IANA format. There is code to log any discrepancy between the timezone ID passed from the browser and the offset passed in by the browser, which sends a sentry exception so we can get an overview of any discrepancies. 

## Final Result
(deployed on staging)
<img width="455" alt="Screen Shot 2020-10-08 at 7 16 45 PM" src="https://user-images.githubusercontent.com/615126/95926023-3c671000-0d89-11eb-909f-d5bd9ae9fe59.png">
Note: -5 from EST when current offset is -4 in EDT.
