### PR TITLE
shared references

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -73,7 +73,7 @@ public class EntityListResponse extends MenuBean {
             }
             entities = processEntitiesForCaseDetail(detail, reference, ec, neededDatum);
         } else {
-            Vector<TreeReference> references = ec.expandReference(neededDatum.getNodeset());
+            Vector<TreeReference> references = nextScreen.getReferences();
             List<EntityBean> entityList = processEntitiesForCaseList(detail, references, ec, searchText, neededDatum, sortIndex, isFuzzySearchEnabled);
             if (entityList.size() > CASE_LENGTH_LIMIT && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
                 // we're doing pagination

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -49,7 +49,6 @@ public class EntityListResponse extends MenuBean {
     public EntityListResponse() {}
 
     public EntityListResponse(EntityScreen nextScreen,
-                              EvaluationContext ec,
                               String detailSelection,
                               int offset,
                               String searchText,
@@ -58,6 +57,7 @@ public class EntityListResponse extends MenuBean {
         SessionWrapper session = nextScreen.getSession();
         Detail detail = nextScreen.getShortDetail();
         EntityDatum neededDatum = (EntityDatum) session.getNeededDatum();
+        EvaluationContext ec = nextScreen.getEvalContext();
 
         // When detailSelection is not null it means we're processing a case detail, not a case list.
         // We will shortcircuit the computation to just get the relevant detailSelection.

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -32,6 +32,7 @@ import org.commcare.formplayer.screens.FormplayerQueryScreen;
 import org.commcare.formplayer.screens.FormplayerSyncScreen;
 import org.commcare.formplayer.session.FormSession;
 import org.commcare.formplayer.session.MenuSession;
+import org.commcare.formplayer.util.FormplayerHereFunctionHandler;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -120,9 +121,9 @@ public class MenuSessionRunnerService {
             );
         } else if (nextScreen instanceof EntityScreen) {
             // We're looking at a case list or detail screen
+            addHereFuncHandler((EntityScreen)nextScreen, menuSession);
             menuResponseBean = new EntityListResponse(
                     (EntityScreen)nextScreen,
-                    menuSession.getEvalContextWithHereFuncHandler(),
                     detailSelection,
                     offset,
                     searchText,
@@ -144,6 +145,11 @@ public class MenuSessionRunnerService {
                 ", App Version: " + menuSession.getAppVersion());
         menuResponseBean.setPersistentCaseTile(getPersistentDetail(menuSession, storageFactory.getPropertyManager().isFuzzySearchEnabled()));
         return menuResponseBean;
+    }
+
+    private void addHereFuncHandler(EntityScreen nextScreen, MenuSession menuSession) {
+        EvaluationContext ec = nextScreen.getEvalContext();
+        ec.addFunctionHandler(new FormplayerHereFunctionHandler(menuSession, menuSession.getCurrentBrowserLocation()));
     }
 
     public BaseResponseBean advanceSessionWithSelections(MenuSession menuSession,


### PR DESCRIPTION
Building on https://github.com/dimagi/commcare-core/pull/936
This PR uses the saved reference expansion, and shares evaluation context between the `EntityScreen` and the `EntityListResponse`.