### PR TITLE
Ability to require search for a case list

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -192,6 +192,13 @@ public class WebAppContext implements WebMvcConfigurer {
     }
 
     @Bean
+    public RedisTemplate<String, String> redisSetTemplate() {
+        StringRedisTemplate template = new StringRedisTemplate(jedisConnFactory());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
     public RedisTemplate<String, Long> redisTemplateLong() {
         RedisTemplate template = new RedisTemplate<String, Long>();
         template.setConnectionFactory(jedisConnFactory());

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -108,7 +108,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
         this.requireSearch = requireSearch;
     }
 
-    @JsonSetter(value = "searchText")
+    @JsonGetter(value = "searchText")
     public String getSearchText() {
         return this.searchText;
     }

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -17,6 +17,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
 
     private EntityDetailResponse[] entityDetailList;
     private boolean isPersistentDetail;
+    private boolean requireSearch;
 
     public EntityDetailListResponse() {}
 
@@ -94,5 +95,15 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     @JsonSetter(value = "isPersistentDetail")
     public void setPersistentDetail(boolean persistentDetail) {
         this.isPersistentDetail = persistentDetail;
+    }
+
+    @JsonGetter(value = "requireSearch")
+    public boolean getRequireSearch() {
+        return requireSearch;
+    }
+
+    @JsonSetter(value = "requireSearch")
+    public void setRequireSearch(boolean requireSearch) {
+        this.requireSearch = requireSearch;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -113,7 +113,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
         return this.searchText;
     }
 
-    @JsonGetter(value = "searchText")
+    @JsonSetter(value = "searchText")
     public void setSearchText(String searchText) {
         this.searchText = searchText;
     }

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -18,6 +18,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     private EntityDetailResponse[] entityDetailList;
     private boolean isPersistentDetail;
     private boolean requireSearch;
+    private String searchText;
 
     public EntityDetailListResponse() {}
 
@@ -105,5 +106,15 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     @JsonSetter(value = "requireSearch")
     public void setRequireSearch(boolean requireSearch) {
         this.requireSearch = requireSearch;
+    }
+
+    @JsonSetter(value = "searchText")
+    public String getSearchText() {
+        return this.searchText;
+    }
+
+    @JsonGetter(value = "searchText")
+    public void setSearchText(String searchText) {
+        this.searchText = searchText;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -33,6 +33,7 @@ public class EntityListResponse extends MenuBean {
     private Tile[] tiles;
     private int[] widthHints;
     private int numEntitiesPerRow;
+    private boolean requireSearch;
     private boolean useUniformUnits;
     private int[] sortIndices;
 
@@ -73,7 +74,11 @@ public class EntityListResponse extends MenuBean {
             }
             entities = processEntitiesForCaseDetail(detail, reference, ec, neededDatum);
         } else {
-            Vector<TreeReference> references = nextScreen.getReferences();
+            Vector<TreeReference> references = new Vector<TreeReference>();
+            this.requireSearch = nextScreen.getShortDetail().doesRequireSearch();
+            if (!this.requireSearch || searchText != null && !"".equals(searchText)) {
+                references = nextScreen.getReferences();
+            }
             List<EntityBean> entityList = processEntitiesForCaseList(detail, references, ec, searchText, neededDatum, sortIndex, isFuzzySearchEnabled);
             if (entityList.size() > CASE_LENGTH_LIMIT && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
                 // we're doing pagination
@@ -215,6 +220,14 @@ public class EntityListResponse extends MenuBean {
 
     public void setSortIndices(int[] sortIndices) {
         this.sortIndices = sortIndices;
+    }
+
+    public boolean getRequireSearch() {
+        return this.requireSearch;
+    }
+
+    public void setRequireSearch(boolean requireSearch) {
+        this.requireSearch = requireSearch;
     }
 
     static class LogNotifier implements EntitySortNotificationInterface {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -34,6 +34,7 @@ public class EntityListResponse extends MenuBean {
     private int[] widthHints;
     private int numEntitiesPerRow;
     private boolean requireSearch;
+    private String searchText;
     private boolean useUniformUnits;
     private int[] sortIndices;
 
@@ -76,7 +77,8 @@ public class EntityListResponse extends MenuBean {
         } else {
             Vector<TreeReference> references = new Vector<TreeReference>();
             this.requireSearch = nextScreen.getShortDetail().doesRequireSearch();
-            if (!this.requireSearch || searchText != null && !"".equals(searchText)) {
+            this.searchText = searchText;
+            if (!this.requireSearch || this.searchText != null && !"".equals(this.searchText)) {
                 references = nextScreen.getReferences();
             }
             List<EntityBean> entityList = processEntitiesForCaseList(detail, references, ec, searchText, neededDatum, sortIndex, isFuzzySearchEnabled);
@@ -228,6 +230,14 @@ public class EntityListResponse extends MenuBean {
 
     public void setRequireSearch(boolean requireSearch) {
         this.requireSearch = requireSearch;
+    }
+
+    public String getSearchText() {
+        return this.searchText;
+    }
+
+    public void setSearchText(String searchText) {
+        this.searchText = searchText;
     }
 
     static class LogNotifier implements EntitySortNotificationInterface {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -76,7 +76,7 @@ public class EntityListResponse extends MenuBean {
             entities = processEntitiesForCaseDetail(detail, reference, ec, neededDatum);
         } else {
             Vector<TreeReference> references = new Vector<TreeReference>();
-            this.requireSearch = nextScreen.getShortDetail().doesRequireSearch();
+            this.requireSearch = nextScreen.getShortDetail().isSearchRequired();
             this.searchText = searchText;
             if (!this.requireSearch || this.searchText != null && !"".equals(this.searchText)) {
                 references = nextScreen.getReferences();

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -12,11 +12,15 @@ import org.commcare.resources.model.UnresolvedResourceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.SimpleTimer;
+
+import javax.annotation.Resource;
 
 /**
  * The InstallService handles configuring the application,
@@ -38,6 +42,12 @@ public class InstallService {
 
     @Autowired
     private CategoryTimingHelper categoryTimingHelper;
+
+    @Autowired
+    private RedisTemplate redisSetTemplate;
+
+    @Resource(name = "redisSetTemplate")
+    private SetOperations<String, String> redisSessionCache;
 
     private final Log log = LogFactory.getLog(InstallService.class);
 
@@ -81,6 +91,7 @@ public class InstallService {
             engine.initEnvironment();
             installTimer.end();
             installTimer.record();
+            redisSessionCache.getOperations().delete(storageFactory.getUsername());
             return new Pair<>(engine, newInstall);
         } catch (UnresolvedResourceException e) {
             log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -58,6 +58,7 @@ public class MenuSessionFactory {
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen) screen;
+                entityScreen.init(menuSession.getSessionWrapper());
                 SessionDatum neededDatum = entityScreen.getSession().getNeededDatum();
                 Set<String> entityIds = entityScreen.getReferenceMap().keySet();
                 for (StackFrameStep step: steps) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -121,6 +121,10 @@ public class MenuSessionRunnerService {
             );
         } else if (nextScreen instanceof EntityScreen) {
             // We're looking at a case list or detail screen
+            nextScreen.init(menuSession.getSessionWrapper());
+            if (nextScreen.shouldBeSkipped()) {
+                return getNextMenu(menuSession, detailSelection, offset, searchText, sortIndex);
+            }
             addHereFuncHandler((EntityScreen)nextScreen, menuSession);
             menuResponseBean = new EntityListResponse(
                     (EntityScreen)nextScreen,

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -203,10 +203,11 @@ public class MenuSessionRunnerService {
             );
         }
         NotificationMessage notificationMessage = null;
-        String cacheValue = String.join("|", selections);
+        String cacheValue;
         String cacheKey = UserUtils.getFullUserDetail(menuSession.getUsername(), menuSession.getAsUser(), menuSession.getDomain());
         for (int i = 1; i <= selections.length; i++) {
             String selection = selections[i - 1];
+            cacheValue = String.join("|", Arrays.copyOfRange(selections,0,i));
             boolean confirmed = redisSessionCache.isMember(cacheKey, cacheValue);
 
             // minimal entity screens are only safe if there will be no further selection
@@ -246,6 +247,7 @@ public class MenuSessionRunnerService {
                 searchText,
                 sortIndex
         );
+        cacheValue = String.join("|", selections);
         redisSessionCache.add(cacheKey, cacheValue);
 
         if (nextResponse != null) {

--- a/src/main/java/org/commcare/formplayer/util/UserUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/UserUtils.java
@@ -25,4 +25,14 @@ public class UserUtils {
             return username;
         }
     }
+
+    public static String getFullUserDetail(String username, String asUsername, String domain) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(domain);
+        builder.append("_").append(username);
+        if (asUsername != null) {
+            builder.append("_").append(asUsername);
+        }
+        return builder.toString();
+    }
 }

--- a/src/main/java/org/commcare/formplayer/util/UserUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/UserUtils.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.util;
 
+import org.commcare.modern.database.TableBuilder;
+
 /**
  * Utility methods for dealing with users
  */
@@ -29,7 +31,7 @@ public class UserUtils {
     public static String getFullUserDetail(String username, String asUsername, String domain) {
         StringBuilder builder = new StringBuilder();
         builder.append(domain);
-        builder.append("_").append(username);
+        builder.append("_").append(TableBuilder.scrubName(username));
         if (asUsername != null) {
             builder.append("_").append(asUsername);
         }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -19,6 +19,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.MediaType;
@@ -135,6 +136,9 @@ public class BaseTestClass {
 
     @Mock
     private ValueOperations<String, Long> valueOperations;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private SetOperations<String, String> redisSessionCache;
 
     protected ObjectMapper mapper;
 

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
@@ -95,6 +96,10 @@ public class TestContext {
         return Mockito.mock(ValueOperations.class);
     }
 
+    @Bean
+    public SetOperations<String, String> redisSetTemplate() {
+        return Mockito.mock(SetOperations.class, Mockito.RETURNS_DEEP_STUBS);
+    }
 
     @Bean
     public ValueOperations<String, FormVolatilityRecord> redisVolatilityDict() {


### PR DESCRIPTION
See https://github.com/dimagi/commcare-hq/pull/28677

This PR checks case list details for the `requireSearch` flag before fetching entities.

It also adds the `requireSearch` flag and the search text to the response so that web apps can display appropriate messaging.

Depends on https://github.com/dimagi/commcare-core/pull/939