### PR TITLE
Add a function to formplayer to encrypt a string

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -167,4 +167,12 @@ public class UtilController extends AbstractBaseController {
 
         return reporter.generateJSONReport();
     }
+
+    @ApiOperation(value = "Encrypt a string with a given algorithm and key")
+    @RequestMapping(value = Constants.URL_ENCRYPT_STRING, method = RequestMethod.POST)
+    public EncryptStringResponseBean encryptString(@RequestBody EncryptStringRequestBean encryptStringBean) throws Exception {
+        EncryptStringResponseBean responseBean = new EncryptStringResponseBean(encryptStringBean);
+        return responseBean;
+    }
+
 }

--- a/src/main/java/org/commcare/formplayer/beans/EncryptStringRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/EncryptStringRequestBean.java
@@ -1,0 +1,56 @@
+package org.commcare.formplayer.beans;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+/**
+ * Request to encrypt a string with a specified algorithm and key.
+ *
+ * Created by charlie.garrett@gmail.com on 10/23/20.
+ */
+public class EncryptStringRequestBean extends AuthenticatedRequestBean {
+    private String message;
+    private String key;
+    private String algorithm;
+
+    // our JSON-Object mapping lib (Jackson) requires a default constructor
+    public EncryptStringRequestBean(){}
+
+    @JsonGetter(value = "message")
+    public String getMessage() {
+        return message;
+    }
+    @JsonSetter(value = "message")
+    public void setMessage(String message) {
+        if (message != null) {
+            this.message = message;
+        }
+    }
+
+    @JsonGetter(value = "key")
+    public String getKey() {
+        return key;
+    }
+    @JsonSetter(value = "key")
+    public void setKey(String key) {
+        if (key != null) {
+            this.key = key;
+        }
+    }
+
+    @JsonGetter(value = "algorithm")
+    public String getAlgorithm() {
+        return algorithm;
+    }
+    @JsonSetter(value = "algorithm")
+    public void setAlgorithm(String algorithm) {
+        if (algorithm != null) {
+            this.algorithm = algorithm;
+        }
+    }
+
+    @Override
+    public String toString(){
+        return "EncryptStringRequestBean [message=" + message + ", key=" + key + ", algorithm=" + algorithm + "]";
+    }
+}

--- a/src/main/java/org/commcare/formplayer/beans/EncryptStringRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/EncryptStringRequestBean.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 /**
  * Request to encrypt a string with a specified algorithm and key.
  *
- * Created by charlie.garrett@gmail.com on 10/23/20.
  */
 public class EncryptStringRequestBean extends AuthenticatedRequestBean {
     private String message;

--- a/src/main/java/org/commcare/formplayer/beans/EncryptStringResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/EncryptStringResponseBean.java
@@ -1,0 +1,86 @@
+package org.commcare.formplayer.beans;
+
+import org.commcare.formplayer.beans.menus.BaseResponseBean;
+import org.commcare.formplayer.util.Constants;
+
+import io.swagger.annotations.ApiModel;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+
+/**
+ * Created by charlie.garrett@gmail.com on 10/23/20.
+ */
+@ApiModel("Session Response")
+public class EncryptStringResponseBean extends BaseResponseBean {
+
+    private String status;  // Success or failure of the call.
+    private String output;  // Encrypted message on success or error message on failure.
+
+    EncryptStringResponseBean() {}
+
+    public EncryptStringResponseBean(EncryptStringRequestBean request) throws Exception {
+        final String ENCRYPT_ALGO = "AES/GCM/NoPadding";
+        final int TAG_LENGTH_BIT = 128;
+        final int IV_LENGTH_BYTE = 12;
+        final int KEY_LENGTH_BIT = 256;
+
+        if (!request.getAlgorithm().equals("AES")) {
+            this.status = Constants.ENCRYPT_STRING_FAILURE;
+            this.output = String.format("Unknown algorithm \"%s\" for encrypt_string", request.getAlgorithm());
+            return;
+        }
+
+        Base64.Decoder keyDecoder = Base64.getUrlDecoder();
+        byte[] keyBytes = keyDecoder.decode(request.getKey());
+        if (8 * keyBytes.length != KEY_LENGTH_BIT) {
+            this.status = Constants.ENCRYPT_STRING_FAILURE;
+            this.output = String.format("Key should be %d bits long, not %d", KEY_LENGTH_BIT, 8 * keyBytes.length);
+            return;
+        }
+        SecretKey secret = new SecretKeySpec(keyBytes, "AES");
+
+        byte[] iv = new byte[IV_LENGTH_BYTE];
+        new SecureRandom().nextBytes(iv);
+
+        Cipher cipher = Cipher.getInstance(ENCRYPT_ALGO);
+        cipher.init(Cipher.ENCRYPT_MODE, secret, new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+        byte[] encryptedMessage = cipher.doFinal(request.getMessage().getBytes(StandardCharsets.UTF_8));
+        byte[] ivPlusMessage = ByteBuffer.allocate(iv.length + encryptedMessage.length)
+                .put(iv)
+                .put(encryptedMessage)
+                .array();
+        this.status = Constants.ENCRYPT_STRING_SUCCESS;
+        Base64.Encoder outputEncoder = Base64.getUrlEncoder();
+        this.output = outputEncoder.encodeToString(ivPlusMessage);
+    }
+
+    @Override
+    public String toString() {
+        return "EncryptStringResponseBean [status=" + status + ", output=" + output + "]";
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(String output) {
+        this.output = output;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/beans/EncryptStringResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/EncryptStringResponseBean.java
@@ -17,7 +17,8 @@ import java.util.Base64;
 
 
 /**
- * Created by charlie.garrett@gmail.com on 10/23/20.
+ * Response to a string encrypt request.
+ *
  */
 @ApiModel("Session Response")
 public class EncryptStringResponseBean extends BaseResponseBean {

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
     public static final String URL_CHANGE_LANGUAGE = "change_locale";
     public static final String URL_BREAK_LOCKS = "break_locks";
     public static final String URL_CHECK_LOCKS = "check_locks";
+    public static final String URL_ENCRYPT_STRING = "encrypt_string";
 
     // Alternative namings used by SMS
     public static final String URL_NEXT = "next";
@@ -61,6 +62,8 @@ public class Constants {
     public static final String ANSWER_RESPONSE_STATUS_NEGATIVE = "validation-error";
     public static final String SYNC_RESPONSE_STATUS_POSITIVE = "success";
     public static final String SUBMIT_RESPONSE_TOO_MANY_REQUESTS = "too-many-requests";
+    public static final String ENCRYPT_STRING_SUCCESS = "encrypt-string-success";
+    public static final String ENCRYPT_STRING_FAILURE = "encrypt-string-failure";
 
     //Debug output request types
     public static final String BASIC_NO_TRACE = "basic";

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -490,6 +490,23 @@ public class BaseTestClass {
         );
     }
 
+    EncryptStringResponseBean encryptString(String message, String key, String algorithm) throws Exception {
+        EncryptStringRequestBean encryptStringRequestBean = new EncryptStringRequestBean();
+        encryptStringRequestBean.setUsername("encryptuser");
+        encryptStringRequestBean.setDomain("encryptdomain");
+        encryptStringRequestBean.setMessage(message);
+        encryptStringRequestBean.setKey(key);
+        encryptStringRequestBean.setAlgorithm(algorithm);
+
+        return generateMockQuery(
+                ControllerType.UTIL,
+                RequestType.POST,
+                Constants.URL_ENCRYPT_STRING,
+                encryptStringRequestBean,
+                EncryptStringResponseBean.class
+        );
+    }
+
     <T> T getDetails(String requestPath, Class<T> clazz) throws Exception {
         SessionNavigationBean sessionNavigationBean = mapper.readValue
                 (FileUtils.getFile(this.getClass(), requestPath), SessionNavigationBean.class);

--- a/src/test/java/org/commcare/formplayer/tests/EncryptStringTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EncryptStringTests.java
@@ -1,0 +1,121 @@
+package org.commcare.formplayer.tests;
+
+import org.commcare.formplayer.beans.EncryptStringResponseBean;
+import org.commcare.formplayer.util.Constants;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import org.commcare.formplayer.utils.TestContext;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+        classes = {TestContext.class}
+)
+public class EncryptStringTests extends BaseTestClass {
+    public EncryptStringTests() {
+    }
+
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    static final String ENCRYPT_ALGO = "AES/GCM/NoPadding";
+    static final int TAG_LENGTH_BIT = 128;
+    static final int IV_LENGTH_BYTE = 12;
+    static final int KEY_LENGTH_BIT = 256;
+
+    private SecretKey generateSecretKey(int keyLength) throws Exception {
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(keyLength, SecureRandom.getInstanceStrong());
+        return keyGen.generateKey();
+    }
+
+    private String extractAndDecodeMessage(String output, SecretKey secretKey) throws Exception {
+        Base64.Decoder messageDecoder = Base64.getUrlDecoder();
+        byte[] messageBytes = messageDecoder.decode(output);
+
+        ByteBuffer bb = ByteBuffer.wrap(messageBytes);
+        byte[] iv = new byte[IV_LENGTH_BYTE];
+        bb.get(iv);
+
+        byte[] cipherText = new byte[bb.remaining()];
+        bb.get(cipherText);
+
+        Cipher cipher = Cipher.getInstance(ENCRYPT_ALGO);
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+        byte[] plainText = cipher.doFinal(cipherText);
+        return new String(plainText, StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void testEncryptShortMessage() throws Exception {
+        final String message = "A short message to be encrypted";
+
+        SecretKey secretKey = generateSecretKey(KEY_LENGTH_BIT);
+        EncryptStringResponseBean encryptStringResponse =
+            this.encryptString(message,
+                               Base64.getUrlEncoder().encodeToString(secretKey.getEncoded()),
+                               "AES");
+
+        assert encryptStringResponse.getStatus().equals(Constants.ENCRYPT_STRING_SUCCESS);
+        String outputMessage = extractAndDecodeMessage(encryptStringResponse.getOutput(), secretKey);
+        assert message.equals(outputMessage);
+    }
+
+    @Test
+    public void testEncryptLongMessage() throws Exception {
+        final String message = "A longer message to be encrypted by the AES GCM method, which will test that somewhat longer messages can be correctly encrypted";
+
+        SecretKey secretKey = generateSecretKey(KEY_LENGTH_BIT);
+        EncryptStringResponseBean encryptStringResponse =
+            this.encryptString(message,
+                               Base64.getUrlEncoder().encodeToString(secretKey.getEncoded()),
+                               "AES");
+
+        assert encryptStringResponse.getStatus().equals(Constants.ENCRYPT_STRING_SUCCESS);
+        String outputMessage = extractAndDecodeMessage(encryptStringResponse.getOutput(), secretKey);
+        assert message.equals(outputMessage);
+    }
+
+    @Test
+    public void testEncryptWithBadAlgorithm() throws Exception {
+        final String message = "A short message to be encrypted";
+
+        SecretKey secretKey = generateSecretKey(KEY_LENGTH_BIT);
+        EncryptStringResponseBean encryptStringResponse =
+            this.encryptString(message,
+                               Base64.getUrlEncoder().encodeToString(secretKey.getEncoded()),
+                               "DES");
+
+        assert encryptStringResponse.getStatus().equals(Constants.ENCRYPT_STRING_FAILURE);
+        String output = encryptStringResponse.getOutput();
+        assert encryptStringResponse.getOutput().equals("Unknown algorithm \"DES\" for encrypt_string");
+    }
+
+    @Test
+    public void testEncryptWithWrongKeyLength() throws Exception {
+        final String message = "A short message to be encrypted";
+
+        SecretKey secretKey = generateSecretKey(KEY_LENGTH_BIT/2);
+        EncryptStringResponseBean encryptStringResponse =
+            this.encryptString(message,
+                               Base64.getUrlEncoder().encodeToString(secretKey.getEncoded()),
+                               "AES");
+
+        assert encryptStringResponse.getStatus().equals(Constants.ENCRYPT_STRING_FAILURE);
+        String output = encryptStringResponse.getOutput();
+        assert encryptStringResponse.getOutput().equals("Key should be 256 bits long, not 128");
+    }
+}


### PR DESCRIPTION
Jonathan asked me to add a function to formplayer to implement [this specification](https://docs.google.com/document/d/1xpymVJm27Hq4rl1jatb049oVr_Dto27eahaKBwD76Gk/edit?usp=sharing). Here is my initial version, and I made a copy of the specification to [document the implementation](https://docs.google.com/document/d/1OljNDYf-Z9nARKn5ww-ZZf2tWUIknHoEVJ__9Oq7YIo/edit?usp=sharing).

Essentially, it accepts a message string and an encoded secret key, performs AES encryption using the GCM mode and returns the encoded message along with an initialization vector needed to decode it. It is intended to allow other algorithms to be used in the future, but only AES is implemented for now and certain encryption options are hardcoded that the message receiver will need to accomodate.

I'm new to the formplayer and also am not a security expert, so any feedback on better ways to do this would be appreciated.
