### PR TITLE
corrupted ccz handling

### DIFF
--- a/src/main/java/org/commcare/formplayer/engine/FormplayerArchiveFileRoot.java
+++ b/src/main/java/org/commcare/formplayer/engine/FormplayerArchiveFileRoot.java
@@ -47,4 +47,11 @@ public class FormplayerArchiveFileRoot extends ArchiveFileRoot {
             throw new InvalidReferenceException(String.format("Error deriving reference with exception %s.", guidPath), guidPath);
         }
     }
+
+    @Override
+    public String removeArchiveFile(String appId) {
+        String mGUID = super.removeArchiveFile(appId);
+        redisTemplate.delete(String.format("formplayer:archive:%s", mGUID));
+        return mGUID;
+    }
 }

--- a/src/main/java/org/commcare/formplayer/engine/FormplayerConfigEngine.java
+++ b/src/main/java/org/commcare/formplayer/engine/FormplayerConfigEngine.java
@@ -53,7 +53,7 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         ReferenceManager.instance().addReferenceFactory(formplayerArchiveFileRoot);
     }
 
-    private String parseAppId(String url) {
+    public static String parseAppId(String url) {
         String appId = null;
         try {
             List<NameValuePair> params = new URIBuilder(url).getQueryParams();
@@ -103,6 +103,11 @@ public class FormplayerConfigEngine extends CommCareConfigEngine {
         }
         String archiveGUID = this.mArchiveRoot.addArchiveFile(zip, appId);
         init("jr://archive/" + archiveGUID + "/profile.ccpr");
+    }
+
+    public void removeArchive(String archiveURL) {
+       String appId = parseAppId(archiveURL);
+       mArchiveRoot.removeArchiveFile(appId);
     }
 
     @Override

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -18,6 +18,7 @@ import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.SimpleTimer;
 
+
 /**
  * The InstallService handles configuring the application,
  * either from a .ccz or .ccpr reference or existing dbs.
@@ -84,10 +85,12 @@ public class InstallService {
             return new Pair<>(engine, newInstall);
         } catch (UnresolvedResourceException e) {
             log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());
+            formplayerArchiveFileRoot.removeArchiveFile(FormplayerConfigEngine.parseAppId(reference));
             throw new UnresolvedResourceRuntimeException(e);
         } catch (Exception e) {
             log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());
             sqliteDB.deleteDatabaseFile();
+            formplayerArchiveFileRoot.removeArchiveFile(FormplayerConfigEngine.parseAppId(reference));
             throw e;
         }
     }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11333

If the downloaded ccz is corrupted, we still save it in memory and continually hit the same exception.

This handles it so that if we hit those exceptions, we clear the ccz from memory so subsequent requests will try to redownload. 

## Testing

Tested locally.

1. modified cchq the ccz file that is downloaded to return scratch (in [cchq](https://github.com/dimagi/commcare-hq/blob/153e8953ff28a064c4d84ff69e3e1bd0bb397b1a/corehq/ex-submodules/soil/__init__.py#L113), instead of returning the contents we return a string like `x`). 
2. Try to start webapps and it will continually try to download the ccz
<img width="1291" alt="Screen Shot 2020-10-28 at 4 23 23 PM" src="https://user-images.githubusercontent.com/615126/97493364-3c474280-193b-11eb-9ac6-4a59a48b6e1b.png">
3. Fix the cchq code so we return the actual contents
4. retry webapps, and it successfully downloads and runs

## Issues
This can download a lot of ccz's if cchq continually returns invalid files
<img width="513" alt="Screen Shot 2020-10-28 at 4 24 02 PM" src="https://user-images.githubusercontent.com/615126/97493475-60a31f00-193b-11eb-9053-285bacf5cf2c.png">

I don't know if all paths to those exceptions should have the ziparchive file be removed from memory. I also couldn't test the `UnresolvedResourceException` exception path, which is what was the original exception in the issue.

Depends on `https://github.com/dimagi/commcare-core/pull/943`, do not merge until that is in this PR.
