### PR TITLE
Session cache

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -96,12 +95,6 @@ public class FormController extends AbstractBaseController{
 
     @Resource(name="redisVolatilityDict")
     private ValueOperations<String, FormVolatilityRecord> volatilityCache;
-
-    @Autowired
-    private RedisTemplate redisSetTemplate;
-
-    @Resource(name = "redisSetTemplate")
-    private SetOperations<String, String> redisSessionCache;
 
     @Value("${commcarehq.host}")
     private String host;
@@ -215,8 +208,6 @@ public class FormController extends AbstractBaseController{
 
                 // Only delete session immediately after successful submit
                 deleteSession(submitRequestBean.getSessionId());
-                String cacheKey = UserUtils.getFullUserDetail(submitRequestBean.getUsername(), submitRequestBean.getRestoreAs(), submitRequestBean.getDomain());
-                redisSessionCache.getOperations().delete(cacheKey);
                 restoreFactory.commit();
 
             }

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -66,7 +66,6 @@ import org.commcare.formplayer.session.FormSession;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.SimpleTimer;
-import org.commcare.formplayer.util.UserUtils;
 import org.springframework.web.client.HttpClientErrorException;
 
 /**

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
 
 import org.commcare.formplayer.services.CategoryTimingHelper;
@@ -35,7 +34,6 @@ import org.commcare.formplayer.services.QueryRequester;
 import org.commcare.formplayer.services.SyncRequester;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.util.Constants;
-import org.commcare.formplayer.util.UserUtils;
 
 /**
  * Controller (API endpoint) containing all session navigation functionality.

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -21,8 +21,6 @@ import org.commcare.util.screen.Screen;
 import org.javarosa.core.model.instance.TreeReference;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,12 +54,6 @@ public class MenuController extends AbstractBaseController {
 
     @Autowired
     private CategoryTimingHelper categoryTimingHelper;
-
-    @Autowired
-    private RedisTemplate redisSetTemplate;
-
-    @Resource(name = "redisSetTemplate")
-    private SetOperations<String, String> redisSessionCache;
 
     private final Log log = LogFactory.getLog(MenuController.class);
 
@@ -150,9 +142,7 @@ public class MenuController extends AbstractBaseController {
             throw new RuntimeException("Could not find case with ID " + detailSelection);
         }
 
-        String cacheKey = UserUtils.getFullUserDetail(sessionNavigationBean.getUsername(), sessionNavigationBean.getRestoreAs(), sessionNavigationBean.getDomain());
-        String cacheValue = String.join("|", selections);
-        redisSessionCache.add(cacheKey, cacheValue);
+        restoreFactory.cacheSessionSelections(selections);
         return setLocationNeeds(
                 new EntityDetailListResponse(entityScreen,
                         menuSession.getEvalContextWithHereFuncHandler(),

--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -192,6 +192,13 @@ public class WebAppContext implements WebMvcConfigurer {
     }
 
     @Bean
+    public RedisTemplate<String, String> redisSetTemplate() {
+        StringRedisTemplate template = new StringRedisTemplate(jedisConnFactory());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    @Bean
     public RedisTemplate<String, Long> redisTemplateLong() {
         RedisTemplate template = new RedisTemplate<String, Long>();
         template.setConnectionFactory(jedisConnFactory());

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -12,15 +12,11 @@ import org.commcare.resources.model.UnresolvedResourceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.SimpleTimer;
-
-import javax.annotation.Resource;
 
 /**
  * The InstallService handles configuring the application,

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -12,11 +12,15 @@ import org.commcare.resources.model.UnresolvedResourceException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.SimpleTimer;
+
+import javax.annotation.Resource;
 
 /**
  * The InstallService handles configuring the application,
@@ -38,6 +42,12 @@ public class InstallService {
 
     @Autowired
     private CategoryTimingHelper categoryTimingHelper;
+
+    @Autowired
+    private RedisTemplate redisSetTemplate;
+
+    @Resource(name = "redisSetTemplate")
+    private SetOperations<String, String> redisSessionCache;
 
     private final Log log = LogFactory.getLog(InstallService.class);
 
@@ -81,6 +91,7 @@ public class InstallService {
             engine.initEnvironment();
             installTimer.end();
             installTimer.record();
+            redisSessionCache.getOperations().delete(storageFactory.getUsername());
             return new Pair<>(engine, newInstall);
         } catch (UnresolvedResourceException e) {
             log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -43,12 +43,6 @@ public class InstallService {
     @Autowired
     private CategoryTimingHelper categoryTimingHelper;
 
-    @Autowired
-    private RedisTemplate redisSetTemplate;
-
-    @Resource(name = "redisSetTemplate")
-    private SetOperations<String, String> redisSessionCache;
-
     private final Log log = LogFactory.getLog(InstallService.class);
 
     CategoryTimingHelper.RecordingTimer installTimer;
@@ -91,7 +85,6 @@ public class InstallService {
             engine.initEnvironment();
             installTimer.end();
             installTimer.record();
-            redisSessionCache.getOperations().delete(storageFactory.getUsername());
             return new Pair<>(engine, newInstall);
         } catch (UnresolvedResourceException e) {
             log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -58,6 +58,7 @@ public class MenuSessionFactory {
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen) screen;
+                entityScreen.init(menuSession.getSessionWrapper());
                 SessionDatum neededDatum = entityScreen.getSession().getNeededDatum();
                 Set<String> entityIds = entityScreen.getReferenceMap().keySet();
                 for (StackFrameStep step: steps) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -59,6 +59,10 @@ public class MenuSessionFactory {
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen) screen;
                 entityScreen.init(menuSession.getSessionWrapper());
+                if (entityScreen.shouldBeSkipped()) {
+                    screen = menuSession.getNextScreen();
+                    continue;
+                }
                 SessionDatum neededDatum = entityScreen.getSession().getNeededDatum();
                 Set<String> entityIds = entityScreen.getReferenceMap().keySet();
                 for (StackFrameStep step: steps) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -33,7 +33,6 @@ import org.commcare.formplayer.screens.FormplayerSyncScreen;
 import org.commcare.formplayer.session.FormSession;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.util.FormplayerHereFunctionHandler;
-import org.commcare.formplayer.util.UserUtils;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -121,6 +121,10 @@ public class MenuSessionRunnerService {
             );
         } else if (nextScreen instanceof EntityScreen) {
             // We're looking at a case list or detail screen
+            nextScreen.init(menuSession.getSessionWrapper());
+            if (nextScreen.shouldBeSkipped()) {
+                return getNextMenu(menuSession, detailSelection, offset, searchText, sortIndex);
+            }
             addHereFuncHandler((EntityScreen)nextScreen, menuSession);
             menuResponseBean = new EntityListResponse(
                     (EntityScreen)nextScreen,

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -203,10 +203,11 @@ public class MenuSessionRunnerService {
             );
         }
         NotificationMessage notificationMessage = null;
-        String cacheValue = String.join("|", selections);
+        String cacheValue;
         String cacheKey = UserUtils.getFullUserDetail(menuSession.getUsername(), menuSession.getAsUser(), menuSession.getDomain());
         for (int i = 1; i <= selections.length; i++) {
             String selection = selections[i - 1];
+            cacheValue = String.join("|", Arrays.copyOfRange(selections,0,i));
             boolean confirmed = redisSessionCache.isMember(cacheKey, cacheValue);
 
             // minimal entity screens are only safe if there will be no further selection
@@ -246,6 +247,7 @@ public class MenuSessionRunnerService {
                 searchText,
                 sortIndex
         );
+        cacheValue = String.join("|", selections);
         redisSessionCache.add(cacheKey, cacheValue);
 
         if (nextResponse != null) {

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -670,6 +670,11 @@ public class RestoreFactory {
         return String.join("|", selections);
     }
 
+    /**
+     * Adds a sequence of menu selections to the set of validated selections
+     * for a given user session so that certain optimizations can skip validation
+     * @param selections - Array of menu selections (e.g. ["1", "1", <case_id>])
+     */
     public void cacheSessionSelections(String[] selections) {
         String cacheKey = getSessionCacheKey();
         String cacheValue = getSessionCacheValue(selections);
@@ -677,6 +682,11 @@ public class RestoreFactory {
         redisSetTemplate.expire(cacheKey, 1, TimeUnit.HOURS);
     }
 
+    /**
+     * Checks whether a sequence of menu selections has already been validated
+     * for a given user session
+     * @param selections - Array of menu selections (e.g. ["1", "1", <case_id>])
+     */
     public boolean isConfirmedSelection(String[] selections) {
         String cacheKey = getSessionCacheKey();
         String cacheValue = getSessionCacheValue(selections);

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -196,7 +196,11 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     /**
-     * @param input the user step input
+     * @param input       The user step input
+     * @param needsDetail Whether a full entity screen is required for this request
+                          or if a list of references is sufficient
+     * @param confirmed   Whether the input has been previously validated 
+     *                    allowing this step to skip validation
      * @return Whether or not we were able to evaluate to a new screen.
      */
     public boolean handleInput(String input, boolean needsDetail, boolean confirmed) throws CommCareSessionException {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -208,11 +208,11 @@ public class MenuSession implements HereFunctionHandlerListener {
         try {
             if (screen instanceof EntityScreen) {
                 if (input.startsWith("action ") || !confirmed) {
-                        screen.init(sessionWrapper);
-                        if (screen.shouldBeSkipped()) {
-                            return handleInput(input, true, confirmed);
-                        }
-                        screen.handleInputAndUpdateSession(sessionWrapper, input);
+                    screen.init(sessionWrapper);
+                    if (screen.shouldBeSkipped()) {
+                        return handleInput(input, true, confirmed);
+                    }
+                    screen.handleInputAndUpdateSession(sessionWrapper, input);
                 } else {
                     sessionWrapper.setDatum(sessionWrapper.getNeededDatum().getDataId(), input);
                 }

--- a/src/main/java/org/commcare/formplayer/util/UserUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/UserUtils.java
@@ -25,4 +25,14 @@ public class UserUtils {
             return username;
         }
     }
+
+    public static String getFullUserDetail(String username, String asUsername, String domain) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(domain);
+        builder.append("_").append(username);
+        if (asUsername != null) {
+            builder.append("_").append(asUsername);
+        }
+        return builder.toString();
+    }
 }

--- a/src/main/java/org/commcare/formplayer/util/UserUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/UserUtils.java
@@ -27,14 +27,4 @@ public class UserUtils {
             return username;
         }
     }
-
-    public static String getFullUserDetail(String username, String asUsername, String domain) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(domain);
-        builder.append("_").append(TableBuilder.scrubName(username));
-        if (asUsername != null) {
-            builder.append("_").append(asUsername);
-        }
-        return builder.toString();
-    }
 }

--- a/src/main/java/org/commcare/formplayer/util/UserUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/UserUtils.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.util;
 
+import org.commcare.modern.database.TableBuilder;
+
 /**
  * Utility methods for dealing with users
  */
@@ -29,7 +31,7 @@ public class UserUtils {
     public static String getFullUserDetail(String username, String asUsername, String domain) {
         StringBuilder builder = new StringBuilder();
         builder.append(domain);
-        builder.append("_").append(username);
+        builder.append("_").append(TableBuilder.scrubName(username));
         if (asUsername != null) {
             builder.append("_").append(asUsername);
         }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -19,6 +19,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.MediaType;
@@ -135,6 +136,9 @@ public class BaseTestClass {
 
     @Mock
     private ValueOperations<String, Long> valueOperations;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private SetOperations<String, String> redisSessionCache;
 
     protected ObjectMapper mapper;
 

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
@@ -95,6 +96,10 @@ public class TestContext {
         return Mockito.mock(ValueOperations.class);
     }
 
+    @Bean
+    public SetOperations<String, String> redisSetTemplate() {
+        return Mockito.mock(SetOperations.class, Mockito.RETURNS_DEEP_STUBS);
+    }
 
     @Bean
     public ValueOperations<String, FormVolatilityRecord> redisVolatilityDict() {


### PR DESCRIPTION
This PR has two components to hopefully speed up menu navigation.
1) Defers initialization of EntityScreens until necessary
2) Updates the menu session with known valid selections (those previously evaluated) without evaluating the input at the screen level.

It tracks valid selections in redis, keying off a combination of username, restore as user, and domain, and clearing the cache on restore, app install, and form submission.

I don't love the changes to the code organization, especially pushing the initialization and auto advance logic out of the centralized methods (`createFreshEntityScreen` and `getNextScreen`) in `MenuSession.java` and into each of the places that need it, but it was the only way I could figure out how to do it.