### PR TITLE
browser tz provider discrepancy check better logging

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/BrowserValuesProvider.java
+++ b/src/main/java/org/commcare/formplayer/services/BrowserValuesProvider.java
@@ -31,14 +31,19 @@ public class BrowserValuesProvider extends TimezoneProvider {
         }
 
         try {
-            checkTzDiscrepancy(timezoneFromBrowser, timezoneOffsetMillis, new Date());
+            checkTzDiscrepancy(bean, timezoneFromBrowser, new Date());
         } catch (TzDiscrepancyException e) {
             raven.sendRavenException(e, Event.Level.WARNING);
         }
     }
 
-    public void checkTzDiscrepancy(TimeZone tz, int reportedTzOffsetMillis, Date date) throws TzDiscrepancyException {
-        if (tz == null && reportedTzOffsetMillis == -1) {
+    public void checkTzDiscrepancy(AuthenticatedRequestBean bean,
+                                   TimeZone tz,
+                                   Date date) throws TzDiscrepancyException {
+        int reportedTzOffsetMillis = bean.getTzOffset();
+        String reportedTzId = bean.getTzFromBrowser();
+
+        if (reportedTzId == null && reportedTzOffsetMillis == -1) {
             return;
         }
         int tzOffsetFromTz = 0;
@@ -50,8 +55,8 @@ public class BrowserValuesProvider extends TimezoneProvider {
             }
         }
         String tzName = (tz == null) ? null : tz.getDisplayName();
-        String errorMsg = String.format("Reported timezone %s has offset %d which is different than reported" +
-                "offset %d", tzName, tzOffsetFromTz, reportedTzOffsetMillis);
+        String errorMsg = String.format("Reported timezone %s generated tz name %s with offset %d which is different " +
+                "than reported offset %d", reportedTzId, tzName, tzOffsetFromTz, reportedTzOffsetMillis);
         throw new TzDiscrepancyException(errorMsg);
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/BrowserValuesProviderTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/BrowserValuesProviderTest.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.tests;
 
+import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.services.BrowserValuesProvider;
 import org.commcare.formplayer.utils.TestContext;
 import org.junit.Before;
@@ -18,6 +19,10 @@ import java.util.TimeZone;
 @ContextConfiguration(classes = TestContext.class)
 public class BrowserValuesProviderTest {
 
+    static final String NY_TZ_ID = "America/New_York";
+    static final TimeZone NY_TZ = TimeZone.getTimeZone(NY_TZ_ID);
+    static final int NY_DST_TZ_OFFSET = -14400000;
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -33,27 +38,37 @@ public class BrowserValuesProviderTest {
     @Test
     public void testCheckTzDiscrepancy() throws Exception {
         // Should not throw an exception.
-        browserValuesProvider.checkTzDiscrepancy(null, -1, this.date);
-        browserValuesProvider.checkTzDiscrepancy(TimeZone.getTimeZone("America/New_York"),
-                -14400000, this.date);
+        AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
+        bean.setTzOffset(-1);
+        browserValuesProvider.checkTzDiscrepancy(bean, null, this.date);
+
+        bean.setTzOffset(NY_DST_TZ_OFFSET);
+        bean.setTzFromBrowser(NY_TZ_ID);
+        browserValuesProvider.checkTzDiscrepancy(bean, NY_TZ, this.date);
     }
 
     @Test
     public void testCheckTzDiscrepancyNullTz() throws Exception {
         thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
-        browserValuesProvider.checkTzDiscrepancy(null, -14400000, this.date);
+        AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
+        bean.setTzOffset(NY_DST_TZ_OFFSET);
+        browserValuesProvider.checkTzDiscrepancy(bean, null, this.date);
     }
 
     @Test
     public void testCheckTzDiscrepancyFalseTz() throws Exception {
         thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
-        browserValuesProvider.checkTzDiscrepancy(TimeZone.getTimeZone("America/New_York"), 0, this.date);
+        AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
+        bean.setTzOffset(0);
+        browserValuesProvider.checkTzDiscrepancy(bean, NY_TZ, this.date);
     }
 
     @Test
     public void testCheckTzDiscrepancyFalseNonsenseTz() throws Exception {
         thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
-        browserValuesProvider.checkTzDiscrepancy(TimeZone.getTimeZone("adaf"), -1, this.date);
+        AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
+        bean.setTzOffset(NY_DST_TZ_OFFSET);
+        browserValuesProvider.checkTzDiscrepancy(bean, TimeZone.getTimeZone("adaf"), this.date);
     }
 
 }


### PR DESCRIPTION
I realized that I was not logging to sentry the tz id that the browser reports, which made troubleshooting harder. This tries to answer the question of whether the reported tz id from the browser is `null` or another value that is not recognized by the java timezones. 

Example error message `Reported timezone America/New_York generated tz name Eastern Standard Time with offset -18000000 which is different than reported offset -18000`

This is more out of curiosity, and most likely this feature will be closed out soon with the following steps:

1. we will stop logging to sentry and *might* log to console instead to avoid sentry costs
2. if the number of users/browsers affected is not reasonable, we will disable the `%Z` for now.