### PR TITLE
Added auto launching of actions

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -203,7 +203,8 @@ public class MenuSessionRunnerService {
             // minimal entity screens are only safe if there will be no further selection
             // and we do not need the case detail
             needsDetail = detailSelection != null || i != selections.length;
-            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed);
+            boolean allowAutoLaunch = i == selections.length;
+            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, allowAutoLaunch);
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
                         "Overflowed selections with selection " + selection + " at index " + i,

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -215,7 +215,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 if (input.startsWith("action ") || !confirmed) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, confirmed);
+                        return handleInput(input, true, confirmed, allowAutoLaunch);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input);
                 } else {
@@ -317,7 +317,7 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     private EntityScreen createFreshEntityScreen(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
-        EntityScreen entityScreen = new EntityScreen(false, needsDetail);
+        EntityScreen entityScreen = new EntityScreen(false, needsDetail, allowAutoLaunch, sessionWrapper);
         return entityScreen;
     }
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-366

Adds support for actions marked as "auto_launch." When a case list with such an action is viewed, the user will not be shown the case list and will instead proceed as though they clicked on the action.

Not especially proud of this code, especially the flag being passed through five layers. Auto-launching case claim only works if the case list is the final result of the `advanceSessionWithSelections` loop that iterates over the current selection. If the action is auto-launched after the case id has been added to selections, the user gets perpetually kicked back to the case claim screen instead of advancing on to the form.

Depends on https://github.com/dimagi/commcare-core/pull/949

HQ changes, which depend on this PR but can be deployed independently, are in https://github.com/dimagi/commcare-hq/pull/28788

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-2109)