### PR TITLE
Auto launching of actions, round 2

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -60,6 +60,9 @@ public class EntityListResponse extends MenuBean {
         EntityDatum neededDatum = (EntityDatum) session.getNeededDatum();
         EvaluationContext ec = nextScreen.getEvalContext();
 
+        this.actions = processActions(nextScreen.getSession());
+        this.autolaunch = processAutolaunch(nextScreen.getSession());
+
         // When detailSelection is not null it means we're processing a case detail, not a case list.
         // We will shortcircuit the computation to just get the relevant detailSelection.
         if (detailSelection != null) {
@@ -73,6 +76,9 @@ public class EntityListResponse extends MenuBean {
                 detail = longDetails[0];
             }
             entities = processEntitiesForCaseDetail(detail, reference, ec, neededDatum);
+        } else if (this.autolaunch != null) {
+            // This is a case list that the UI is going to skip, so don't bother processing entities
+            entities = new EntityBean[0];
         } else {
             Vector<TreeReference> references = nextScreen.getReferences();
             List<EntityBean> entityList = processEntitiesForCaseList(detail, references, ec, searchText, neededDatum, sortIndex, isFuzzySearchEnabled);
@@ -89,8 +95,6 @@ public class EntityListResponse extends MenuBean {
         processTitle(session);
         processCaseTiles(detail);
         this.styles = processStyles(detail);
-        this.actions = processActions(nextScreen.getSession());
-        this.autolaunch = processAutolaunch(nextScreen.getSession());   // TODO: skip some other processing?
         Pair<String[], int[]> pair = processHeader(detail, ec, sortIndex);
         this.headers = pair.first;
         this.widthHints = pair.second;

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -270,7 +270,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     private static DisplayElement[] processActions(SessionWrapper session) {
-        Vector<Action> actions = getActions(session);
+        Vector<Action> actions = getActionDefinitions(session);
         ArrayList<DisplayElement> displayActions = new ArrayList<>();
         for (Action action: actions) {
             displayActions.add(new DisplayElement(action, session.getEvaluationContext()));
@@ -281,7 +281,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     private static String processAutolaunch(SessionWrapper session) {
-        Vector<Action> actions = getActions(session);
+        Vector<Action> actions = getActionDefinitions(session);
         String ret = null;
         int index = 0;
         for (Action action: actions) {
@@ -293,7 +293,7 @@ public class EntityListResponse extends MenuBean {
         return ret;
     }
 
-    private static Vector<Action> getActions(SessionWrapper session) {
+    private static Vector<Action> getActionDefinitions(SessionWrapper session) {
         EntityDatum datum = (EntityDatum) session.getNeededDatum();
         if (session.getFrame().getSteps().lastElement().getElementType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
             return new Vector<Action>();

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -28,6 +28,7 @@ import java.util.Vector;
 public class EntityListResponse extends MenuBean {
     private EntityBean[] entities;
     private DisplayElement[] actions;
+    private String autolaunch;
     private Style[] styles;
     private String[] headers;
     private Tile[] tiles;
@@ -89,6 +90,7 @@ public class EntityListResponse extends MenuBean {
         processCaseTiles(detail);
         this.styles = processStyles(detail);
         this.actions = processActions(nextScreen.getSession());
+        this.autolaunch = processAutolaunch(nextScreen.getSession());   // TODO: skip some other processing?
         Pair<String[], int[]> pair = processHeader(detail, ec, sortIndex);
         this.headers = pair.first;
         this.widthHints = pair.second;
@@ -264,11 +266,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     private static DisplayElement[] processActions(SessionWrapper session) {
-        EntityDatum datum = (EntityDatum) session.getNeededDatum();
-        if (session.getFrame().getSteps().lastElement().getElementType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
-            return null;
-        }
-        Vector<Action> actions = session.getDetail((datum).getShortDetail()).getCustomActions(session.getEvaluationContext());
+        Vector<Action> actions = getActions(session);
         ArrayList<DisplayElement> displayActions = new ArrayList<>();
         for (Action action: actions) {
             displayActions.add(new DisplayElement(action, session.getEvaluationContext()));
@@ -276,6 +274,27 @@ public class EntityListResponse extends MenuBean {
         DisplayElement[] ret = new DisplayElement[actions.size()];
         displayActions.toArray(ret);
         return ret;
+    }
+
+    private static String processAutolaunch(SessionWrapper session) {
+        Vector<Action> actions = getActions(session);
+        String ret = null;
+        int index = 0;
+        for (Action action: actions) {
+            if (action.isAutoLaunching()) {
+                ret = "action " + index;
+            }
+            index = index + 1;
+        }
+        return ret;
+    }
+
+    private static Vector<Action> getActions(SessionWrapper session) {
+        EntityDatum datum = (EntityDatum) session.getNeededDatum();
+        if (session.getFrame().getSteps().lastElement().getElementType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
+            return new Vector<Action>();
+        }
+        return session.getDetail((datum).getShortDetail()).getCustomActions(session.getEvaluationContext());
     }
 
     public EntityBean[] getEntities() {
@@ -296,6 +315,14 @@ public class EntityListResponse extends MenuBean {
 
     public DisplayElement[] getActions() {
         return actions;
+    }
+
+    public String getAutolaunch() {
+        return autolaunch;
+    }
+
+    public void setAutolaunch(String autolaunch) {
+        this.autolaunch = autolaunch;
     }
 
     private void setActions(DisplayElement[] actions) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -203,8 +203,7 @@ public class MenuSessionRunnerService {
             // minimal entity screens are only safe if there will be no further selection
             // and we do not need the case detail
             needsDetail = detailSelection != null || i != selections.length;
-            boolean allowAutoLaunch = i == selections.length;
-            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, allowAutoLaunch);
+            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed);
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
                         "Overflowed selections with selection " + selection + " at index " + i,

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -192,7 +192,7 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     public boolean handleInput(String input) throws CommCareSessionException {
-        return handleInput(input, true, false, false);
+        return handleInput(input, true, false);
     }
 
     /**
@@ -201,11 +201,9 @@ public class MenuSession implements HereFunctionHandlerListener {
      *                          or if a list of references is sufficient
      * @param confirmed         Whether the input has been previously validated,
      *                          allowing this step to skip validation
-     * @param allowAutoLaunch   If this step is allow to automatically launch an action,
-     *                          assuming it has an autolaunch action specified.
      */
-    public boolean handleInput(String input, boolean needsDetail, boolean confirmed, boolean allowAutoLaunch) throws CommCareSessionException {
-        Screen screen = getNextScreen(needsDetail, allowAutoLaunch);
+    public boolean handleInput(String input, boolean needsDetail, boolean confirmed) throws CommCareSessionException {
+        Screen screen = getNextScreen(needsDetail);
         log.info("Screen " + screen + " handling input " + input);
         if(screen == null) {
             return false;
@@ -215,7 +213,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 if (input.startsWith("action ") || !confirmed) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, confirmed, allowAutoLaunch);
+                        return handleInput(input, true, confirmed);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input);
                 } else {
@@ -225,7 +223,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 boolean ret = screen.handleInputAndUpdateSession(sessionWrapper, input);
             }
             Screen previousScreen = screen;
-            screen = getNextScreen(needsDetail, allowAutoLaunch);
+            screen = getNextScreen(needsDetail);
             addTitle(input, previousScreen);
             return true;
         } catch(ArrayIndexOutOfBoundsException | NullPointerException e) {
@@ -251,14 +249,10 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     public Screen getNextScreen() throws CommCareSessionException {
-        return getNextScreen(true, false);
+        return getNextScreen(true);
     }
 
     public Screen getNextScreen(boolean needsDetail) throws CommCareSessionException {
-        return getNextScreen(needsDetail, false);
-    }
-
-    public Screen getNextScreen(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
         String next = sessionWrapper.getNeededData(sessionWrapper.getEvaluationContext());
 
         if (next == null) {
@@ -273,7 +267,7 @@ public class MenuSession implements HereFunctionHandlerListener {
             menuScreen.init(sessionWrapper);
             return menuScreen;
         } else if (next.equals(SessionFrame.STATE_DATUM_VAL)) {
-            EntityScreen entityScreen = getEntityScreenForSession(needsDetail, allowAutoLaunch);
+            EntityScreen entityScreen = getEntityScreenForSession(needsDetail);
             if (entityScreen.shouldBeSkipped()) {
                 return getNextScreen();
             }
@@ -299,7 +293,7 @@ public class MenuSession implements HereFunctionHandlerListener {
         entityScreenCache.clear();
     }
 
-    private EntityScreen getEntityScreenForSession(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
+    private EntityScreen getEntityScreenForSession(boolean needsDetail) throws CommCareSessionException {
         EntityDatum datum = (EntityDatum)sessionWrapper.getNeededDatum();
 
         //This is only needed because with remote queries there can be nested datums with the same
@@ -308,7 +302,7 @@ public class MenuSession implements HereFunctionHandlerListener {
 
         String datumKey = datum.getDataId() + ", "+ nodesetHash;
         if (!entityScreenCache.containsKey(datumKey)) {
-            EntityScreen entityScreen = createFreshEntityScreen(needsDetail, allowAutoLaunch);
+            EntityScreen entityScreen = createFreshEntityScreen(needsDetail);
             entityScreenCache.put(datumKey, entityScreen);
             return entityScreen;
         } else {
@@ -316,8 +310,8 @@ public class MenuSession implements HereFunctionHandlerListener {
         }
     }
 
-    private EntityScreen createFreshEntityScreen(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
-        EntityScreen entityScreen = new EntityScreen(false, needsDetail, allowAutoLaunch, sessionWrapper);
+    private EntityScreen createFreshEntityScreen(boolean needsDetail) throws CommCareSessionException {
+        EntityScreen entityScreen = new EntityScreen(false, needsDetail, sessionWrapper);
         return entityScreen;
     }
 


### PR DESCRIPTION
https://github.com/dimagi/formplayer/pull/783/ "works" by [executing the autolaunch action](https://github.com/dimagi/commcare-core/blob/1c8d2a04c1219d99e9afd923d2556f3fe2c02e7c/src/cli/java/org/commcare/util/screen/EntityScreen.java#L87-L91) inside the `EntityScreen` constructor. Since that action doesn't get a session frame the same way a real user action would, there are downstream problems, notably the inability to actually claim cases.

Instead of figuring out how to make a better fake user action, this PR changes formplayer's case list response to include a flag telling web apps to immediately make an additional request to case claim. This should mimic real behavior better. Most of the logic from https://github.com/dimagi/formplayer/pull/783/ is retained so that if the case list does have an autolaunch action, it'll still skip unnecessary processing.

Depends on https://github.com/dimagi/commcare-core/pull/960