### PR TITLE
Revert 791 jls/autolaunch action round 2

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -60,6 +60,9 @@ public class EntityListResponse extends MenuBean {
         EntityDatum neededDatum = (EntityDatum) session.getNeededDatum();
         EvaluationContext ec = nextScreen.getEvalContext();
 
+        this.actions = processActions(nextScreen.getSession());
+        this.autolaunch = processAutolaunch(nextScreen.getSession());
+
         // When detailSelection is not null it means we're processing a case detail, not a case list.
         // We will shortcircuit the computation to just get the relevant detailSelection.
         if (detailSelection != null) {
@@ -73,6 +76,9 @@ public class EntityListResponse extends MenuBean {
                 detail = longDetails[0];
             }
             entities = processEntitiesForCaseDetail(detail, reference, ec, neededDatum);
+        } else if (this.autolaunch != null) {
+            // This is a case list that the UI is going to skip, so don't bother processing entities
+            entities = new EntityBean[0];
         } else {
             Vector<TreeReference> references = nextScreen.getReferences();
             List<EntityBean> entityList = processEntitiesForCaseList(detail, references, ec, searchText, neededDatum, sortIndex, isFuzzySearchEnabled);
@@ -89,8 +95,6 @@ public class EntityListResponse extends MenuBean {
         processTitle(session);
         processCaseTiles(detail);
         this.styles = processStyles(detail);
-        this.actions = processActions(nextScreen.getSession());
-        this.autolaunch = processAutolaunch(nextScreen.getSession());   // TODO: skip some other processing?
         Pair<String[], int[]> pair = processHeader(detail, ec, sortIndex);
         this.headers = pair.first;
         this.widthHints = pair.second;

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -270,7 +270,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     private static DisplayElement[] processActions(SessionWrapper session) {
-        Vector<Action> actions = getActions(session);
+        Vector<Action> actions = getActionDefinitions(session);
         ArrayList<DisplayElement> displayActions = new ArrayList<>();
         for (Action action: actions) {
             displayActions.add(new DisplayElement(action, session.getEvaluationContext()));
@@ -281,7 +281,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     private static String processAutolaunch(SessionWrapper session) {
-        Vector<Action> actions = getActions(session);
+        Vector<Action> actions = getActionDefinitions(session);
         String ret = null;
         int index = 0;
         for (Action action: actions) {
@@ -293,7 +293,7 @@ public class EntityListResponse extends MenuBean {
         return ret;
     }
 
-    private static Vector<Action> getActions(SessionWrapper session) {
+    private static Vector<Action> getActionDefinitions(SessionWrapper session) {
         EntityDatum datum = (EntityDatum) session.getNeededDatum();
         if (session.getFrame().getSteps().lastElement().getElementType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
             return new Vector<Action>();

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -28,6 +28,7 @@ import java.util.Vector;
 public class EntityListResponse extends MenuBean {
     private EntityBean[] entities;
     private DisplayElement[] actions;
+    private String autolaunch;
     private Style[] styles;
     private String[] headers;
     private Tile[] tiles;
@@ -89,6 +90,7 @@ public class EntityListResponse extends MenuBean {
         processCaseTiles(detail);
         this.styles = processStyles(detail);
         this.actions = processActions(nextScreen.getSession());
+        this.autolaunch = processAutolaunch(nextScreen.getSession());   // TODO: skip some other processing?
         Pair<String[], int[]> pair = processHeader(detail, ec, sortIndex);
         this.headers = pair.first;
         this.widthHints = pair.second;
@@ -264,11 +266,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     private static DisplayElement[] processActions(SessionWrapper session) {
-        EntityDatum datum = (EntityDatum) session.getNeededDatum();
-        if (session.getFrame().getSteps().lastElement().getElementType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
-            return null;
-        }
-        Vector<Action> actions = session.getDetail((datum).getShortDetail()).getCustomActions(session.getEvaluationContext());
+        Vector<Action> actions = getActions(session);
         ArrayList<DisplayElement> displayActions = new ArrayList<>();
         for (Action action: actions) {
             displayActions.add(new DisplayElement(action, session.getEvaluationContext()));
@@ -276,6 +274,27 @@ public class EntityListResponse extends MenuBean {
         DisplayElement[] ret = new DisplayElement[actions.size()];
         displayActions.toArray(ret);
         return ret;
+    }
+
+    private static String processAutolaunch(SessionWrapper session) {
+        Vector<Action> actions = getActions(session);
+        String ret = null;
+        int index = 0;
+        for (Action action: actions) {
+            if (action.isAutoLaunching()) {
+                ret = "action " + index;
+            }
+            index = index + 1;
+        }
+        return ret;
+    }
+
+    private static Vector<Action> getActions(SessionWrapper session) {
+        EntityDatum datum = (EntityDatum) session.getNeededDatum();
+        if (session.getFrame().getSteps().lastElement().getElementType().equals(SessionFrame.STATE_QUERY_REQUEST)) {
+            return new Vector<Action>();
+        }
+        return session.getDetail((datum).getShortDetail()).getCustomActions(session.getEvaluationContext());
     }
 
     public EntityBean[] getEntities() {
@@ -296,6 +315,14 @@ public class EntityListResponse extends MenuBean {
 
     public DisplayElement[] getActions() {
         return actions;
+    }
+
+    public String getAutolaunch() {
+        return autolaunch;
+    }
+
+    public void setAutolaunch(String autolaunch) {
+        this.autolaunch = autolaunch;
     }
 
     private void setActions(DisplayElement[] actions) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -203,7 +203,8 @@ public class MenuSessionRunnerService {
             // minimal entity screens are only safe if there will be no further selection
             // and we do not need the case detail
             needsDetail = detailSelection != null || i != selections.length;
-            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed);
+            boolean allowAutoLaunch = i == selections.length;
+            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, allowAutoLaunch);
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
                         "Overflowed selections with selection " + selection + " at index " + i,

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -213,11 +213,16 @@ public class MenuSession implements HereFunctionHandlerListener {
         try {
             if (screen instanceof EntityScreen) {
                 if (input.startsWith("action ") || !confirmed) {
-                    screen.init(sessionWrapper);
-                    if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, confirmed, allowAutoLaunch);
+                    if (input.startsWith("action ") && screen.getAutoLaunchAction() != null) {
+                        screen.setPendingAction(screen.getAutoLaunchAction);
+                        screen.updateSession(sessionWrapper);
+                    } else {
+                        screen.init(sessionWrapper);
+                        if (screen.shouldBeSkipped()) {
+                            return handleInput(input, true, confirmed, allowAutoLaunch);
+                        }
+                        screen.handleInputAndUpdateSession(sessionWrapper, input);
                     }
-                    screen.handleInputAndUpdateSession(sessionWrapper, input);
                 } else {
                     sessionWrapper.setDatum(sessionWrapper.getNeededDatum().getDataId(), input);
                 }

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -213,9 +213,9 @@ public class MenuSession implements HereFunctionHandlerListener {
         try {
             if (screen instanceof EntityScreen) {
                 if (input.startsWith("action ") || !confirmed) {
-                    if (input.startsWith("action ") && screen.getAutoLaunchAction() != null) {
-                        screen.setPendingAction(screen.getAutoLaunchAction);
-                        screen.updateSession(sessionWrapper);
+                    EntityScreen entityScreen = (EntityScreen)screen;
+                    if (input.startsWith("action ") && entityScreen.getAutoLaunchAction() != null) {
+                        sessionWrapper.executeStackOperations(entityScreen.getAutoLaunchAction().getStackOperations(), entityScreen.getEvalContext());
                     } else {
                         screen.init(sessionWrapper);
                         if (screen.shouldBeSkipped()) {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -192,7 +192,7 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     public boolean handleInput(String input) throws CommCareSessionException {
-        return handleInput(input, true, false);
+        return handleInput(input, true, false, false);
     }
 
     /**
@@ -201,9 +201,11 @@ public class MenuSession implements HereFunctionHandlerListener {
      *                          or if a list of references is sufficient
      * @param confirmed         Whether the input has been previously validated,
      *                          allowing this step to skip validation
+     * @param allowAutoLaunch   If this step is allow to automatically launch an action,
+     *                          assuming it has an autolaunch action specified.
      */
-    public boolean handleInput(String input, boolean needsDetail, boolean confirmed) throws CommCareSessionException {
-        Screen screen = getNextScreen(needsDetail);
+    public boolean handleInput(String input, boolean needsDetail, boolean confirmed, boolean allowAutoLaunch) throws CommCareSessionException {
+        Screen screen = getNextScreen(needsDetail, allowAutoLaunch);
         log.info("Screen " + screen + " handling input " + input);
         if(screen == null) {
             return false;
@@ -213,7 +215,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 if (input.startsWith("action ") || !confirmed) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, confirmed);
+                        return handleInput(input, true, confirmed, allowAutoLaunch);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input);
                 } else {
@@ -223,7 +225,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 boolean ret = screen.handleInputAndUpdateSession(sessionWrapper, input);
             }
             Screen previousScreen = screen;
-            screen = getNextScreen(needsDetail);
+            screen = getNextScreen(needsDetail, allowAutoLaunch);
             addTitle(input, previousScreen);
             return true;
         } catch(ArrayIndexOutOfBoundsException | NullPointerException e) {
@@ -249,10 +251,14 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     public Screen getNextScreen() throws CommCareSessionException {
-        return getNextScreen(true);
+        return getNextScreen(true, false);
     }
 
     public Screen getNextScreen(boolean needsDetail) throws CommCareSessionException {
+        return getNextScreen(needsDetail, false);
+    }
+
+    public Screen getNextScreen(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
         String next = sessionWrapper.getNeededData(sessionWrapper.getEvaluationContext());
 
         if (next == null) {
@@ -267,7 +273,7 @@ public class MenuSession implements HereFunctionHandlerListener {
             menuScreen.init(sessionWrapper);
             return menuScreen;
         } else if (next.equals(SessionFrame.STATE_DATUM_VAL)) {
-            EntityScreen entityScreen = getEntityScreenForSession(needsDetail);
+            EntityScreen entityScreen = getEntityScreenForSession(needsDetail, allowAutoLaunch);
             if (entityScreen.shouldBeSkipped()) {
                 return getNextScreen();
             }
@@ -293,7 +299,7 @@ public class MenuSession implements HereFunctionHandlerListener {
         entityScreenCache.clear();
     }
 
-    private EntityScreen getEntityScreenForSession(boolean needsDetail) throws CommCareSessionException {
+    private EntityScreen getEntityScreenForSession(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
         EntityDatum datum = (EntityDatum)sessionWrapper.getNeededDatum();
 
         //This is only needed because with remote queries there can be nested datums with the same
@@ -302,7 +308,7 @@ public class MenuSession implements HereFunctionHandlerListener {
 
         String datumKey = datum.getDataId() + ", "+ nodesetHash;
         if (!entityScreenCache.containsKey(datumKey)) {
-            EntityScreen entityScreen = createFreshEntityScreen(needsDetail);
+            EntityScreen entityScreen = createFreshEntityScreen(needsDetail, allowAutoLaunch);
             entityScreenCache.put(datumKey, entityScreen);
             return entityScreen;
         } else {
@@ -310,8 +316,8 @@ public class MenuSession implements HereFunctionHandlerListener {
         }
     }
 
-    private EntityScreen createFreshEntityScreen(boolean needsDetail) throws CommCareSessionException {
-        EntityScreen entityScreen = new EntityScreen(false, needsDetail, sessionWrapper);
+    private EntityScreen createFreshEntityScreen(boolean needsDetail, boolean allowAutoLaunch) throws CommCareSessionException {
+        EntityScreen entityScreen = new EntityScreen(false, needsDetail, allowAutoLaunch, sessionWrapper);
         return entityScreen;
     }
 


### PR DESCRIPTION
Depends on https://github.com/dimagi/commcare-core/pull/961
Will update the commcare core ref when that is merged.

This is the formplayer component of the autolaunch fixes. The biggest change is allowing the `MenuSession` in formplayer to directly update the `SessionWrapper` rather than having the cli handle the input, to bypass rendering those cli screens.