### PR TITLE
bulk clear purged indices

### DIFF
--- a/src/main/java/org/commcare/formplayer/api/process/FormRecordProcessorHelper.java
+++ b/src/main/java/org/commcare/formplayer/api/process/FormRecordProcessorHelper.java
@@ -124,9 +124,7 @@ public class FormRecordProcessorHelper extends XmlFormRecordProcessor {
         removedCaseCount = casesRemoved.size();
 
         FormplayerCaseIndexTable indexTable = new FormplayerCaseIndexTable(sandbox);
-        for (int recordId : casesRemoved) {
-            indexTable.clearCaseIndices(recordId);
-        }
+        indexTable.clearCaseIndices(casesRemoved);
 
 
         SqlStorage<Ledger> stockStorage = sandbox.getLedgerStorage();


### PR DESCRIPTION
This removes one component of the case purge process that scales unnecessarily with the number of cases being purged by changing one sql delete per case to one bulk delete (using a method we already have).

The two methods are [defined here](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/database/models/FormplayerCaseIndexTable.java#L108-L127)