### PR TITLE
add flag for skipping full validation

### DIFF
--- a/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
+++ b/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
@@ -116,7 +116,7 @@ public class JsonActionUtils {
             }
         }
 	IAnswerData currentAnswerData = prompt.getAnswerValue();
-	if (skipValidation && answerData != null && currentAnswerData != null && answerData.uncast().equals(currentAnswerData.uncast())) {
+	if (skipValidation && answerData != null && currentAnswerData != null && answerData.uncast().getValue().equals(currentAnswerData.uncast().getValue())) {
 	    result = FormEntryController.ANSWER_OK;
 	} else {
 	    result = controller.answerQuestion(prompt.getIndex(), answerData);

--- a/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
+++ b/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
@@ -101,7 +101,7 @@ public class JsonActionUtils {
 						  boolean skipValidation) {
         JSONObject ret = new JSONObject();
         IAnswerData answerData;
-	boolean answerUnchanged = false;
+	int result;
 
         if (answer == null || answer.equals("None")) {
             answerData = null;
@@ -116,10 +116,11 @@ public class JsonActionUtils {
             }
         }
 	IAnswerData currentAnswerData = prompt.getAnswerValue();
-	if (answerData != null && currentAnswerData != null && answerData.uncast().equals(currentAnswerData.uncast())) {
-	    answerUnchanged = true;
+	if (skipValidation && answerData != null && currentAnswerData != null && answerData.uncast().equals(currentAnswerData.uncast())) {
+	    result = FormEntryController.ANSWER_OK;
+	} else {
+	    result = controller.answerQuestion(prompt.getIndex(), answerData);
 	}
-        int result = controller.answerQuestion(prompt.getIndex(), answerData);
         if (result == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY) {
             ret.put(ApiConstants.RESPONSE_STATUS_KEY, "validation-error");
             ret.put(ApiConstants.ERROR_TYPE_KEY, "required");
@@ -127,7 +128,7 @@ public class JsonActionUtils {
             ret.put(ApiConstants.RESPONSE_STATUS_KEY, "validation-error");
             ret.put(ApiConstants.ERROR_TYPE_KEY, "constraint");
             ret.put(ApiConstants.ERROR_REASON_KEY, prompt.getConstraintText());
-        } else if ((skipValidation && answerUnchanged) || result == FormEntryController.ANSWER_OK) {
+        } else if (result == FormEntryController.ANSWER_OK) {
             if (oneQuestionPerScreen) {
                 ret.put(ApiConstants.QUESTION_TREE_KEY, getOneQuestionPerScreenJSON(
                     model, controller, navIndex));

--- a/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
+++ b/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
@@ -97,11 +97,11 @@ public class JsonActionUtils {
                                                   FormEntryModel model, String answer,
                                                   FormEntryPrompt prompt,
                                                   boolean oneQuestionPerScreen,
-						  FormIndex navIndex,
-						  boolean skipValidation) {
+                                                  FormIndex navIndex,
+                                                  boolean skipValidation) {
         JSONObject ret = new JSONObject();
         IAnswerData answerData;
-	int result;
+        int result;
 
         if (answer == null || answer.equals("None")) {
             answerData = null;
@@ -115,12 +115,12 @@ public class JsonActionUtils {
                 return ret;
             }
         }
-	IAnswerData currentAnswerData = prompt.getAnswerValue();
-	if (skipValidation && answerData != null && currentAnswerData != null && answerData.uncast().getValue().equals(currentAnswerData.uncast().getValue())) {
-	    result = FormEntryController.ANSWER_OK;
-	} else {
-	    result = controller.answerQuestion(prompt.getIndex(), answerData);
-	}
+        IAnswerData currentAnswerData = model.getForm().getInstance().resolveReference(prompt.getIndex().getReference()).getValue();
+        if (skipValidation && answerData != null && currentAnswerData != null && answerData.uncast().getValue().equals(currentAnswerData.uncast().getValue())) {
+            result = FormEntryController.ANSWER_OK;
+        } else {
+            result = controller.answerQuestion(prompt.getIndex(), answerData);
+        }
         if (result == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY) {
             ret.put(ApiConstants.RESPONSE_STATUS_KEY, "validation-error");
             ret.put(ApiConstants.ERROR_TYPE_KEY, "required");
@@ -155,7 +155,7 @@ public class JsonActionUtils {
                                                   String ansIndex,
                                                   boolean oneQuestionPerScreen,
                                                   String navIndex,
-						  boolean skipValidation) {
+                                                  boolean skipValidation) {
         FormIndex answerIndex = indexFromString(ansIndex, model.getForm());
         FormEntryPrompt prompt = model.getQuestionPrompt(answerIndex);
         FormIndex navigationIndex = indexFromString(navIndex, model.getForm());

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -161,8 +161,8 @@ public class FormController extends AbstractBaseController{
         validationTimer.start();
         submitResponseBean = validateSubmitAnswers(formEntrySession.getFormEntryController(),
                 formEntrySession.getFormEntryModel(),
-		submitRequestBean.getAnswers(),
-		formEntrySession.getSkipValidation());
+                submitRequestBean.getAnswers(),
+                formEntrySession.getSkipValidation());
         validationTimer.end();
         categoryTimingHelper.recordCategoryTiming(validationTimer, Constants.TimingCategories.VALIDATE_SUBMISSION, null, submitRequestBean.getDomain());
 
@@ -296,8 +296,8 @@ public class FormController extends AbstractBaseController{
      */
     private SubmitResponseBean validateSubmitAnswers(FormEntryController formEntryController,
                                        FormEntryModel formEntryModel,
-				       Map<String, Object> answers,
-				       boolean skipValidation) {
+                                       Map<String, Object> answers,
+                                       boolean skipValidation) {
         SubmitResponseBean submitResponseBean = new SubmitResponseBean(Constants.SYNC_RESPONSE_STATUS_POSITIVE);
         HashMap<String, ErrorBean> errors = new HashMap<>();
         for(String key: answers.keySet()){
@@ -312,8 +312,8 @@ public class FormController extends AbstractBaseController{
                             answer,
                             key,
                             false,
-			    null,
-			    skipValidation);
+                            null,
+                            skipValidation);
             if(!answerResult.get(ApiConstants.RESPONSE_STATUS_KEY).equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)) {
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 ErrorBean error = new ErrorBean();

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -161,7 +161,8 @@ public class FormController extends AbstractBaseController{
         validationTimer.start();
         submitResponseBean = validateSubmitAnswers(formEntrySession.getFormEntryController(),
                 formEntrySession.getFormEntryModel(),
-                submitRequestBean.getAnswers());
+		submitRequestBean.getAnswers(),
+		formEntrySession.getSkipValidation());
         validationTimer.end();
         categoryTimingHelper.recordCategoryTiming(validationTimer, Constants.TimingCategories.VALIDATE_SUBMISSION, null, submitRequestBean.getDomain());
 
@@ -295,7 +296,8 @@ public class FormController extends AbstractBaseController{
      */
     private SubmitResponseBean validateSubmitAnswers(FormEntryController formEntryController,
                                        FormEntryModel formEntryModel,
-                                       Map<String, Object> answers) {
+				       Map<String, Object> answers,
+				       boolean skipValidation) {
         SubmitResponseBean submitResponseBean = new SubmitResponseBean(Constants.SYNC_RESPONSE_STATUS_POSITIVE);
         HashMap<String, ErrorBean> errors = new HashMap<>();
         for(String key: answers.keySet()){
@@ -310,7 +312,8 @@ public class FormController extends AbstractBaseController{
                             answer,
                             key,
                             false,
-                            null);
+			    null,
+			    skipValidation);
             if(!answerResult.get(ApiConstants.RESPONSE_STATUS_KEY).equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)) {
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 ErrorBean error = new ErrorBean();

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -260,7 +260,7 @@ public class FormSession {
         setVolatilityIndicators();
         setAutoSubmitFlag();
         setSuppressAutosyncFlag();
-	setSkipValidation();
+        setSkipValidation();
     }
 
     private String getPragma(String key) {
@@ -308,12 +308,12 @@ public class FormSession {
     }
 
     private void setSkipValidation() {
-	String shouldSkipValidation = getPragma("Pragma-Skip-Full-Form-Validation");
-	if (shouldSkipValidation != null) {
-	    this.shouldSkipFullFormValidation = true;
-	} else {
-	    this.shouldSkipFullFormValidation = false;
-	}
+        String shouldSkipValidation = getPragma("Pragma-Skip-Full-Form-Validation");
+        if (shouldSkipValidation != null) {
+            this.shouldSkipFullFormValidation = true;
+        } else {
+            this.shouldSkipFullFormValidation = false;
+        }
     }
 
     public boolean getAutoSubmitFlag() {
@@ -325,7 +325,7 @@ public class FormSession {
     }
 
     public boolean getSkipValidation() {
-	return shouldSkipFullFormValidation;
+        return shouldSkipFullFormValidation;
     }
 
     public FormVolatilityRecord getSessionVolatilityRecord() {
@@ -609,8 +609,8 @@ public class FormSession {
                 answer != null ? answer.toString() : null,
                 answerIndex,
                 oneQuestionPerScreen,
-		currentIndex,
-		false);
+                currentIndex,
+                false);
 
         FormEntryResponseBean response = new ObjectMapper().readValue(jsonObject.toString(), FormEntryResponseBean.class);
         if (!inPromptMode || !Constants.ANSWER_RESPONSE_STATUS_POSITIVE.equals(response.getStatus())) {

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -98,6 +98,7 @@ public class FormSession {
     private FormVolatilityRecord sessionVolatilityRecord;
     private boolean shouldAutoSubmit;
     private boolean suppressAutosync;
+    private boolean shouldSkipFullFormValidation;
 
     private void setupJavaRosaObjects() {
         formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_NON_LINEAR);
@@ -259,6 +260,7 @@ public class FormSession {
         setVolatilityIndicators();
         setAutoSubmitFlag();
         setSuppressAutosyncFlag();
+	setSkipValidation();
     }
 
     private String getPragma(String key) {
@@ -305,12 +307,25 @@ public class FormSession {
         }
     }
 
+    private void setSkipValidation() {
+	String shouldSkipValidation = getPragma("Pragma-Skip-Full-Form-Validation");
+	if (shouldSkipValidation != null) {
+	    this.shouldSkipFullFormValidation = true;
+	} else {
+	    this.shouldSkipFullFormValidation = false;
+	}
+    }
+
     public boolean getAutoSubmitFlag() {
         return shouldAutoSubmit;
     }
 
     public boolean getSuppressAutosync() {
         return suppressAutosync;
+    }
+
+    public boolean getSkipValidation() {
+	return shouldSkipFullFormValidation;
     }
 
     public FormVolatilityRecord getSessionVolatilityRecord() {
@@ -594,7 +609,8 @@ public class FormSession {
                 answer != null ? answer.toString() : null,
                 answerIndex,
                 oneQuestionPerScreen,
-                currentIndex);
+		currentIndex,
+		false);
 
         FormEntryResponseBean response = new ObjectMapper().readValue(jsonObject.toString(), FormEntryResponseBean.class);
         if (!inPromptMode || !Constants.ANSWER_RESPONSE_STATUS_POSITIVE.equals(response.getStatus())) {


### PR DESCRIPTION
This allows forms to skip some of the validation that occurs on submit. If the answer in the submission matches the answer formplayer's model, it will no revalidate. This will still catch required questions and changes since the last validation, but will no longer catch the case where a later response invalidates an earlier one. As such, it should be used with caution, but will provide meaningful speed ups when used in that way.