### PR TITLE
Small changes to allow forcing user DB sync from HQ

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -59,7 +59,7 @@ public class UtilController extends AbstractBaseController {
     @UserLock
     @UserRestore
     public SyncDbResponseBean syncUserDb(@RequestBody SyncDbRequestBean syncRequest,
-                                         @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
+                                         @CookieValue(value = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken) throws Exception {
         restoreFactory.performTimedSync();
         return new SyncDbResponseBean();
     }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -633,7 +633,10 @@ public class RestoreFactory {
         }
 
         if( asUsername != null) {
-            builder.append("&as=").append(asUsername).append("@").append(domain).append(".commcarehq.org");
+            builder.append("&as=").append(asUsername);
+            if (!asUsername.contains("@")) {
+                builder.append("@").append(domain).append(".commcarehq.org");
+            }
         }
         if (skipFixtures) {
             builder.append("&skip_fixtures=true");


### PR DESCRIPTION
1. Remove the requirement for the `sessionid` cookie to be present. Without this the request with be authenticated using the HMAC digest header.
2. Don't blindly assume that the 'loginas' user is a mobile user. HQ requires that when using HMAC digest auth the `as` parameter is present to indicate which user the sync is for. When forcing the sync of a web user we need to specify the web user as the 'loginas' user.