### PR TITLE
skip json creation on validation

### DIFF
--- a/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
+++ b/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
@@ -83,7 +83,7 @@ public class JsonActionUtils {
         return new JSONObject().put(ApiConstants.QUESTION_EVENT_KEY,
                 PromptToJson.parseQuestionType(model, new JSONObject()));
     }
-
+             
     /**
      * Answer the question, return the updated JSON representation of the question tree
      *
@@ -98,7 +98,8 @@ public class JsonActionUtils {
                                                   FormEntryPrompt prompt,
                                                   boolean oneQuestionPerScreen,
                                                   FormIndex navIndex,
-                                                  boolean skipValidation) {
+                                                  boolean skipValidation,
+                                                  boolean returnTree) {
         JSONObject ret = new JSONObject();
         IAnswerData answerData;
         int result;
@@ -115,12 +116,14 @@ public class JsonActionUtils {
                 return ret;
             }
         }
+
         IAnswerData currentAnswerData = model.getForm().getInstance().resolveReference(prompt.getIndex().getReference()).getValue();
         if (skipValidation && answerData != null && currentAnswerData != null && answerData.uncast().getValue().equals(currentAnswerData.uncast().getValue())) {
             result = FormEntryController.ANSWER_OK;
         } else {
             result = controller.answerQuestion(prompt.getIndex(), answerData);
         }
+
         if (result == FormEntryController.ANSWER_REQUIRED_BUT_EMPTY) {
             ret.put(ApiConstants.RESPONSE_STATUS_KEY, "validation-error");
             ret.put(ApiConstants.ERROR_TYPE_KEY, "required");
@@ -129,13 +132,14 @@ public class JsonActionUtils {
             ret.put(ApiConstants.ERROR_TYPE_KEY, "constraint");
             ret.put(ApiConstants.ERROR_REASON_KEY, prompt.getConstraintText());
         } else if (result == FormEntryController.ANSWER_OK) {
-            if (oneQuestionPerScreen) {
-                ret.put(ApiConstants.QUESTION_TREE_KEY, getOneQuestionPerScreenJSON(
-                    model, controller, navIndex));
-            } else {
-                ret.put(ApiConstants.QUESTION_TREE_KEY, getFullFormJSON(model, controller));
+            if (returnTree) {
+                if (oneQuestionPerScreen) {
+                    ret.put(ApiConstants.QUESTION_TREE_KEY, getOneQuestionPerScreenJSON(
+                                                                                        model, controller, navIndex));
+                } else {
+                    ret.put(ApiConstants.QUESTION_TREE_KEY, getFullFormJSON(model, controller));
+                }
             }
-
             ret.put(ApiConstants.RESPONSE_STATUS_KEY, "accepted");
         }
         return ret;
@@ -155,11 +159,12 @@ public class JsonActionUtils {
                                                   String ansIndex,
                                                   boolean oneQuestionPerScreen,
                                                   String navIndex,
-                                                  boolean skipValidation) {
+                                                  boolean skipValidation,
+                                                  boolean returnTree) {
         FormIndex answerIndex = indexFromString(ansIndex, model.getForm());
         FormEntryPrompt prompt = model.getQuestionPrompt(answerIndex);
         FormIndex navigationIndex = indexFromString(navIndex, model.getForm());
-        return questionAnswerToJson(controller, model, answer, prompt, oneQuestionPerScreen, navigationIndex, skipValidation);
+        return questionAnswerToJson(controller, model, answer, prompt, oneQuestionPerScreen, navigationIndex, skipValidation, returnTree);
     }
 
     /**

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -313,7 +313,8 @@ public class FormController extends AbstractBaseController{
                             key,
                             false,
                             null,
-                            skipValidation);
+                            skipValidation,
+                            false);
             if(!answerResult.get(ApiConstants.RESPONSE_STATUS_KEY).equals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)) {
                 submitResponseBean.setStatus(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE);
                 ErrorBean error = new ErrorBean();

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -610,7 +610,8 @@ public class FormSession {
                 answerIndex,
                 oneQuestionPerScreen,
                 currentIndex,
-                false);
+                false,
+                true);
 
         FormEntryResponseBean response = new ObjectMapper().readValue(jsonObject.toString(), FormEntryResponseBean.class);
         if (!inPromptMode || !Constants.ANSWER_RESPONSE_STATUS_POSITIVE.equals(response.getStatus())) {


### PR DESCRIPTION
We were generating the full form json (`tree` attribute that gets passed to the front end) after every answer validation, when we don't need it at all during the validation stage. We never pass that back to the front end regardless of whether or not validation is successful. We do still need that when answering individual questions, which is why this is a flag for now, although I would like to refactor some of this code so that each part can call what they need, rather than having one method with a bunch of flags.