### PR TITLE
Removed breadcrumb from autolaunch actions

### DIFF
--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -216,11 +216,13 @@ public class MenuSession implements HereFunctionHandlerListener {
             return false;
         }
         try {
+            boolean addBreadcrumb = true;
             if (screen instanceof EntityScreen) {
                 if (input.startsWith("action ") || !confirmed) {
                     EntityScreen entityScreen = (EntityScreen)screen;
                     if (input.startsWith("action ") && entityScreen.getAutoLaunchAction() != null) {
                         sessionWrapper.executeStackOperations(entityScreen.getAutoLaunchAction().getStackOperations(), entityScreen.getEvalContext());
+                        addBreadcrumb = false;
                     } else {
                         screen.init(sessionWrapper);
                         if (screen.shouldBeSkipped()) {
@@ -236,7 +238,9 @@ public class MenuSession implements HereFunctionHandlerListener {
             }
             Screen previousScreen = screen;
             screen = getNextScreen(needsDetail, allowAutoLaunch);
-            addTitle(input, previousScreen);
+            if (addBreadcrumb) {
+                addTitle(input, previousScreen);
+            }
             return true;
         } catch(ArrayIndexOutOfBoundsException | NullPointerException e) {
             throw new RuntimeException("Screen " + screen + "  handling input " + input +


### PR DESCRIPTION
Minor bugfix. Previously when using a search-first workflow, breadcrumbs on the case search screen were:

`Home > App Name > Menu Name > Search Button Label`

But both the menu name and search button label options redirected the user back to the search screen.

Now breadcrumbs in that scenario are just:

`Home > App Name > Menu Name `