### PR TITLE
Move to refreshing one time after all answers have been registered

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -279,6 +279,7 @@ public class MenuSessionRunnerService {
         if (queryDictionary != null) {
             screen.answerPrompts(queryDictionary);
         }
+        screen.refreshItemSetChoices();
     }
 
 


### PR DESCRIPTION
[Issue](https://github.com/dimagi/commcare-core/pull/972/files#r564570490)

This was a regression introduced by https://github.com/dimagi/commcare-core/pull/972/files, So reverting to original approach here and still reserving the [main fix ](https://github.com/dimagi/commcare-core/pull/972/files#diff-6815b1dc78a9b3d06ce7631378492ba2472c305a7b229dd8a159d201e8fd773dR145-R150) from that PR.

@orangejenny  I think this will still need some Web Apps work, Formplayer now send a null value as as `displays[].value` for the dependent itemset  whose value should be cleared, though doesn't seem like Web Apps is reading that and setting it to the search field again. 

cross-request: https://github.com/dimagi/commcare-core/pull/973