### PR TITLE
Send form name to datadog for granular timings on submit requests

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -154,6 +154,11 @@ public class FormController extends AbstractBaseController{
         FormSession formEntrySession = new FormSession(serializableFormSession, restoreFactory, formSendCalloutHandler, storageFactory, raven);
         SubmitResponseBean submitResponseBean;
 
+        // package additional args to pass to category timing helper
+        Map<String, String> extras = new HashMap<String, String>();
+        extras.put(CategoryTimingHelper.DOMAIN, submitRequestBean.getDomain());
+        extras.put(CategoryTimingHelper.FORM_NAME, formEntrySession.getTitle());
+
         SimpleTimer validationTimer = new SimpleTimer();
         validationTimer.start();
         submitResponseBean = validateSubmitAnswers(formEntrySession.getFormEntryController(),
@@ -161,7 +166,7 @@ public class FormController extends AbstractBaseController{
                 submitRequestBean.getAnswers(),
                 formEntrySession.getSkipValidation());
         validationTimer.end();
-        categoryTimingHelper.recordCategoryTiming(validationTimer, Constants.TimingCategories.VALIDATE_SUBMISSION, null, submitRequestBean.getDomain());
+        categoryTimingHelper.recordCategoryTiming(validationTimer, Constants.TimingCategories.VALIDATE_SUBMISSION, null, extras);
 
         FormVolatilityRecord volatilityRecord = formEntrySession.getSessionVolatilityRecord();
 
@@ -183,7 +188,7 @@ public class FormController extends AbstractBaseController{
 
                 categoryTimingHelper.recordCategoryTiming(purgeCasesTimer, Constants.TimingCategories.PURGE_CASES,
                         purgeCasesTimer.durationInMs() > 2 ?
-                                "Purging cases took some time" : "Probably didn't have to purge cases", submitRequestBean.getDomain());
+                                "Purging cases took some time" : "Probably didn't have to purge cases", extras);
 
                 ResponseEntity<String> submitResponse = submitService.submitForm(
                         formEntrySession.getInstanceXml(),
@@ -258,7 +263,7 @@ public class FormController extends AbstractBaseController{
                 }
             }
             navTimer.end();
-            categoryTimingHelper.recordCategoryTiming(navTimer, Constants.TimingCategories.END_OF_FORM_NAV, null, submitRequestBean.getDomain());
+            categoryTimingHelper.recordCategoryTiming(navTimer, Constants.TimingCategories.END_OF_FORM_NAV, null, extras);
         }
         return submitResponseBean;
     }

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -1,10 +1,5 @@
 package org.commcare.formplayer.services;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-
 import com.timgroup.statsd.StatsDClient;
 
 import org.apache.commons.logging.Log;
@@ -14,6 +9,11 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 import org.commcare.formplayer.util.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -57,7 +57,7 @@ public class CategoryTimingHelper {
         }
 
         public void record() {
-            parent.recordCategoryTiming(this, category, sentryMessage, domain);
+            parent.recordCategoryTiming(this, category, sentryMessage, Collections.singletonMap(DOMAIN, domain));
         }
     }
 
@@ -75,16 +75,13 @@ public class CategoryTimingHelper {
     public void recordCategoryTiming(Timing timing, String category, String sentryMessage) {
         recordCategoryTiming(timing, category, sentryMessage, null);
     }
-    public void recordCategoryTiming(Timing timing, String category, String sentryMessage, String domain) {
-        recordCategoryTiming(timing, category, sentryMessage, Collections.singletonMap(DOMAIN, domain));
-    }
 
     /**
      * @param extras - optional arguments, the following keys are accepted:
      *               CategoryTimingHelper.DOMAIN,
      *               CategoryTimingHelper.FORM_NAME,
      */
-    public void recordCategoryTiming(Timing timing, String category, String sentryMessage, @Nullable Map<String, String> extras) {
+    public void recordCategoryTiming(Timing timing, String category, String sentryMessage, Map<String, String> extras) {
         raven.newBreadcrumb()
                 .setCategory(category)
                 .setMessage(sentryMessage)

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -78,6 +78,12 @@ public class CategoryTimingHelper {
     public void recordCategoryTiming(Timing timing, String category, String sentryMessage, String domain) {
         recordCategoryTiming(timing, category, sentryMessage, Collections.singletonMap(DOMAIN, domain));
     }
+
+    /**
+     * @param extras - optional arguments, the following keys are accepted:
+     *               CategoryTimingHelper.DOMAIN,
+     *               CategoryTimingHelper.FORM_NAME,
+     */
     public void recordCategoryTiming(Timing timing, String category, String sentryMessage, Map<String, String> extras) {
         raven.newBreadcrumb()
                 .setCategory(category)

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -77,9 +77,8 @@ public class CategoryTimingHelper {
     }
 
     /**
-     * @param extras - optional arguments, the following keys are accepted:
-     *               CategoryTimingHelper.DOMAIN,
-     *               CategoryTimingHelper.FORM_NAME,
+     * @param extras - optional tag/value pairs to send to datadog
+     * NOTE: if adding a new tag, add a constant for the tag name 
      */
     public void recordCategoryTiming(Timing timing, String category, String sentryMessage, Map<String, String> extras) {
         raven.newBreadcrumb()
@@ -93,11 +92,8 @@ public class CategoryTimingHelper {
         datadogArgs.add("request:" + RequestUtils.getRequestEndpoint(request));
         datadogArgs.add("duration:" + timing.getDurationBucket());
         if (extras != null) {
-            if (extras.containsKey(DOMAIN)) {
-                datadogArgs.add("domain:" + extras.get(DOMAIN));
-            }
-            if (extras.containsKey(FORM_NAME)) {
-                datadogArgs.add("form_name:" + extras.get(FORM_NAME));
+            for (Map.Entry<String, String> entry : extras.entrySet()) {
+                datadogArgs.add(entry.getKey() + ":" + entry.getValue());
             }
         }
 

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -73,7 +73,7 @@ public class CategoryTimingHelper {
         recordCategoryTiming(timing, category, null);
     }
     public void recordCategoryTiming(Timing timing, String category, String sentryMessage) {
-        recordCategoryTiming(timing, category, sentryMessage, Collections.emptyMap());
+        recordCategoryTiming(timing, category, sentryMessage, null);
     }
     public void recordCategoryTiming(Timing timing, String category, String sentryMessage, String domain) {
         recordCategoryTiming(timing, category, sentryMessage, Collections.singletonMap(DOMAIN, domain));
@@ -84,7 +84,7 @@ public class CategoryTimingHelper {
      *               CategoryTimingHelper.DOMAIN,
      *               CategoryTimingHelper.FORM_NAME,
      */
-    public void recordCategoryTiming(Timing timing, String category, String sentryMessage, Map<String, String> extras) {
+    public void recordCategoryTiming(Timing timing, String category, String sentryMessage, @Nullable Map<String, String> extras) {
         raven.newBreadcrumb()
                 .setCategory(category)
                 .setMessage(sentryMessage)
@@ -95,11 +95,13 @@ public class CategoryTimingHelper {
         datadogArgs.add("category:" + category);
         datadogArgs.add("request:" + RequestUtils.getRequestEndpoint(request));
         datadogArgs.add("duration:" + timing.getDurationBucket());
-        if (extras.containsKey(DOMAIN)) {
-            datadogArgs.add("domain:" + extras.get(DOMAIN));
-        }
-        if (extras.containsKey(FORM_NAME)) {
-            datadogArgs.add("form_name:" + extras.get(FORM_NAME));
+        if (extras != null) {
+            if (extras.containsKey(DOMAIN)) {
+                datadogArgs.add("domain:" + extras.get(DOMAIN));
+            }
+            if (extras.containsKey(FORM_NAME)) {
+                datadogArgs.add("form_name:" + extras.get(FORM_NAME));
+            }
         }
 
         datadogStatsDClient.recordExecutionTime(


### PR DESCRIPTION
In addition to sending form names to sentry, we also want to send to datadog to allow for filtering there. Some slight changes were made to the `recordTimingCategory` method to make it easy to add more data in the future. I kept the method overloading that was already in place to not break existing calls.