### PR TITLE
Add form_name tag to datadog metrics for submit-all requests

### DIFF
--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -62,7 +62,7 @@ public class MetricsAspect {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
             // only tag metrics with form_name if one of these requests
-            if (requestPath == 'submit-all' || requestPath == 'answer') {
+            if (requestPath == "submit-all" || requestPath == "answer") {
                 String sessionId = bean.getSessionId();
                 if (sessionId != null) {
                     try {

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -62,7 +62,7 @@ public class MetricsAspect {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
             // only tag metrics with form_name if one of these requests
-            if (requestPath == "submit-all" || requestPath == "answer") {
+            if (requestPath.equals("submit-all") || requestPath.equals("answer")) {
                 String sessionId = bean.getSessionId();
                 if (sessionId != null) {
                     try {

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -111,9 +111,8 @@ public class MetricsAspect {
         );
 
         if (fetchTimer != null) {
-            datadogArgs.add("task:fetch_form_session");
             datadogStatsDClient.recordExecutionTime(
-                    "test_timings",
+                    "fetch_form_session",
                     fetchTimer.durationInMs(),
                     datadogArgs.toArray(new String[datadogArgs.size()])
             );

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -63,7 +63,7 @@ public class MetricsAspect {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
             // only tag metrics with form_name if one of these requests
-            if (requestPath.equals("submit-all") || requestPath.equals("answer")) {
+            if (requestPath.equals("submit-all")) {
                 String sessionId = bean.getSessionId();
                 if (sessionId != null) {
                     try {
@@ -111,6 +111,7 @@ public class MetricsAspect {
         );
 
         if (fetchTimer != null) {
+            datadogArgs.add("task:fetch_form_session");
             datadogStatsDClient.recordExecutionTime(
                     "test_timings",
                     fetchTimer.durationInMs(),

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.aspects;
 
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
+import org.commcare.formplayer.beans.SessionResponseBean;
 import io.sentry.event.Breadcrumb;
 import io.sentry.event.Event;
 import com.timgroup.statsd.StatsDClient;
@@ -9,12 +10,18 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
+import org.commcare.formplayer.exceptions.FormNotFoundException;
+import org.commcare.formplayer.objects.SerializableFormSession;
+import org.commcare.formplayer.repo.FormSessionRepo;
 import org.commcare.formplayer.services.InstallService;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.services.SubmitService;
 import org.commcare.formplayer.util.*;
 
 import javax.servlet.http.HttpServletRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This aspect records various metrics for every request.
@@ -41,15 +48,31 @@ public class MetricsAspect {
     @Autowired
     private InstallService installService;
 
+    @Autowired
+    protected FormSessionRepo formSessionRepo;
+
     @Around(value = "@annotation(org.springframework.web.bind.annotation.RequestMapping)")
     public Object logRequest(ProceedingJoinPoint joinPoint) throws Throwable {
         Object[] args = joinPoint.getArgs();
         String domain = "<unknown>";
+        String formName = null;
 
         String requestPath = RequestUtils.getRequestEndpoint(request);
         if (args != null && args.length > 0 && args[0] instanceof AuthenticatedRequestBean) {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
+            // only tag metrics with form_name if one of these requests
+            if (requestPath == 'submit-all' || requestPath == 'answer') {
+                String sessionId = bean.getSessionId();
+                if (sessionId != null) {
+                    try {
+                        SerializableFormSession serializableFormSession = formSessionRepo.findOneWrapped(bean.getSessionId());
+                        formName = serializableFormSession.getTitle();
+                    } catch (FormNotFoundException e) {
+
+                    }
+                }
+            }
         }
 
         SimpleTimer timer = new SimpleTimer();
@@ -57,30 +80,32 @@ public class MetricsAspect {
         Object result = joinPoint.proceed();
         timer.end();
 
+        List<String> datadogArgs = new ArrayList<>();
+        datadogArgs.add("domain:" + domain);
+        datadogArgs.add("request:" + requestPath);
+        datadogArgs.add("duration:" + timer.getDurationBucket());
+        datadogArgs.add("unblocked_time:" + getUnblockedTimeBucket(timer));
+        datadogArgs.add("blocked_time:" + getBlockedTimeBucket());
+        datadogArgs.add("restore_blocked_time:" + getRestoreBlockedTimeBucket());
+        datadogArgs.add("install_blocked_time:" + getInstallBlockedTimeBucket());
+        datadogArgs.add("submit_blocked_time:" + getSubmitBlockedTimeBucket());
+
+        // optional datadog args
+        if (formName != null) {
+            datadogArgs.add("form_name:" + formName);
+        }
+
         datadogStatsDClient.increment(
                 Constants.DATADOG_REQUESTS,
-                "domain:" + domain,
-                "request:" + requestPath,
-                "duration:" + timer.getDurationBucket(),
-                "unblocked_time:" + getUnblockedTimeBucket(timer),
-                "blocked_time:" + getBlockedTimeBucket(),
-                "restore_blocked_time:" + getRestoreBlockedTimeBucket(),
-                "install_blocked_time:" + getInstallBlockedTimeBucket(),
-                "submit_blocked_time:" + getSubmitBlockedTimeBucket()
+                datadogArgs.toArray(new String[datadogArgs.size()])
         );
 
         datadogStatsDClient.recordExecutionTime(
                 Constants.DATADOG_TIMINGS,
                 timer.durationInMs(),
-                "domain:" + domain,
-                "request:" + requestPath,
-                "duration:" + timer.getDurationBucket(),
-                "unblocked_time:" + getUnblockedTimeBucket(timer),
-                "blocked_time:" + getBlockedTimeBucket(),
-                "restore_blocked_time:" + getRestoreBlockedTimeBucket(),
-                "install_blocked_time:" + getInstallBlockedTimeBucket(),
-                "submit_blocked_time:" + getSubmitBlockedTimeBucket()
+                datadogArgs.toArray(new String[datadogArgs.size()])
         );
+
         if (timer.durationInMs() >= 60 * 1000) {
             sendTimingWarningToSentry(timer);
         }


### PR DESCRIPTION
This current implementation will become moot with plans to improve how we interact with the datadog client, but if we want to merge for now this is what it looks like. 