### PR TITLE
Increase default lock pool size from 255 to 65k

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
@@ -33,7 +33,7 @@ public class FormplayerLockRegistry implements LockRegistry {
     private final Log log = LogFactory.getLog(FormplayerLockRegistry.class);
 
     public FormplayerLockRegistry() {
-        this(0xFF);
+        this(0xFFFF);
     }
 
     public FormplayerLockRegistry(int mask) {


### PR DESCRIPTION
The default pool available for sandbox ID Hash -> Lock ID is currently very, very small (255) which on a high-concurrency machine could cause significant problems with unintentional locking collisions.

Long term we should probably explore a better way of measuring / reducing the collisions in general due to the high likelihood of overlap (even 65k may not be that much) and due to how uneven Java String hashes are, but this jump should be more than enough short-term unless the hash overlap is extraordinarily non-uniform.