### PR TITLE
Add slow request thresholds for specific requests

### DIFF
--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -164,7 +164,7 @@ public class MetricsAspect {
     }
 
     private String getSentryMessageForSlowRequest(String category) {
-        Map<String, Long> messages = new HashMap<>();
+        Map<String, String> messages = new HashMap<>();
         messages.put(EXTREMELY_SLOW_REQUEST, "This request took a long time");
         messages.put(SLOW_REQUEST, "This request was slow");
         if (messages.containsKey(category)) {


### PR DESCRIPTION
Lowering thresholds for `submit-all`, `answer` and `nagivate_menu` requests. See this [JIRA ticket](https://dimagi-dev.atlassian.net/browse/USH-619?focusedCommentId=116560&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-116560) for more details about # of additional requests that will be sent to sentry due to this change.