### PR TITLE
use exists instead of count

### DIFF
--- a/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
@@ -117,10 +117,9 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
         byte[] sessionDataBytes = writeToBytes(session.getSessionData());
         byte[] functionContextBytes = writeToBytes(session.getFunctionContext());
 
-        int sessionCount = this.jdbcTemplate.queryForObject(
-                replaceTableName("select count(*) from %s where id = ?"), Integer.class, session.getId());
+        boolean session_exists = existsById(session.getId());
 
-        if(sessionCount > 0){
+        if(session_exists){
             String query = replaceTableName("UPDATE %s SET instanceXml = ?, sessionData = ?, " +
                     "sequenceId = ?, currentIndex = ?, postUrl = ?, initLang = ? WHERE id = ?");
             this.jdbcTemplate.update(query,


### PR DESCRIPTION
Switch from `count` to `exists` since it's has better performance. Ideally we should add a DB ID field to this table so that we can tell if the data is persisted or not without having to do a DB query. 