### PR TITLE
Sk/cache form session

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-jdbc'
     implementation group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
     implementation group: 'org.xerial', name: 'sqlite-jdbc'
     implementation group: 'redis.clients', name: 'jedis'
 
@@ -85,6 +86,7 @@ dependencies {
     implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '4.14.0'
     implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '4.14.0'
     implementation group: 'io.micrometer', name: 'micrometer-registry-statsd', version: '1.3.0'
+    runtimeOnly group: 'com.github.ben-manes.caffeine', name: 'jcache', version: '2.8.8'
 
     implementation fileTree(dir: 'libs', include: '*.jar')
     implementation project(path: ':commcare', configuration: 'api')

--- a/src/main/java/org/commcare/formplayer/Application.java
+++ b/src/main/java/org/commcare/formplayer/Application.java
@@ -10,6 +10,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -29,6 +30,7 @@ import java.io.IOException;
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"repo.*", "objects.*"})
 @EntityScan("objects.*")
+@EnableCaching
 public class Application {
 
     // Allows logging of sensitive data.

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -31,6 +31,11 @@ public class SerializableFormSession implements Serializable{
     private boolean inPromptMode;
     private String restoreAsCaseId;
 
+    public SerializableFormSession() { }
+    public SerializableFormSession(String id) {
+        this.id = id;
+    }
+
     public String getInstanceXml() {
         return instanceXml;
     }

--- a/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepo.java
@@ -95,12 +95,10 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
     }
 
     @Override
-    @Lock(LockModeType.OPTIMISTIC)
     public <S extends SerializableFormSession> Iterable<S> saveAll(Iterable<S> entities) {
-        for(SerializableFormSession session: entities){
-            save(session);
-        }
-        return entities;
+        // removed support due to caching implications
+        // we could support caching for this with aspectj weaving
+        throw new UnsupportedOperationException();
     }
 
     private byte[] writeToBytes(Object object){
@@ -267,17 +265,15 @@ public class PostgresFormSessionRepo implements FormSessionRepo {
 
     @Override
     public void deleteAll(Iterable<? extends SerializableFormSession> entities) {
-        for(SerializableFormSession session: entities){
-            deleteById(session.getId());
-        }
+        // removed support due to caching implications
+        // we could support caching for this with aspectj weaving
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void deleteAll() {
-        Iterable<SerializableFormSession> allSessions = findAll();
-        for(SerializableFormSession session: allSessions){
-            deleteById(session.getId());
-        }
+        // removed support due to caching implications, also it's dangerous
+        throw new UnsupportedOperationException();
     }
 
     // helper class for mapping a db row to a serialized session

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,4 +27,4 @@ management.metrics.enable.spring.integration=false
 # caching (override type in application.properties to enable)
 spring.cache.type=none
 spring.cache.cache-names=form_session
-spring.cache.caffeine.spec=maximumSize=10000,expireAfterAccess=600s
+spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=300s

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,3 +23,8 @@ management.metrics.web.server.request.autotime.enabled=false
 management.metrics.enable.logback=false
 management.metrics.enable.system=false
 management.metrics.enable.spring.integration=false
+
+# caching (override type in application.properties to enable)
+spring.cache.type=none
+spring.cache.cache-names=form_session
+spring.cache.caffeine.spec=maximumSize=10000,expireAfterAccess=600s

--- a/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
@@ -58,25 +58,28 @@ public class PostgresFormSessionRepoTest {
 
         // save a session
         SerializableFormSession session = new SerializableFormSession("123");
-        session.setAppId("app1");
+        session.setSequenceId(1);
         formSessionRepo.save(session);
 
         // cache is populated on save
-        Assert.assertEquals("app1", getCachedSession("123").get().getAppId());
+        Assert.assertEquals(1, getCachedSession("123").get().getSequenceId());
 
         // find works
         session = formSessionRepo.findOneWrapped("123");
-        Assert.assertEquals("app1", session.getAppId());
+        Assert.assertEquals(1, session.getSequenceId());
         Assert.assertEquals(session, getCachedSession("123").get());
 
         // update session
-        session.setAppId("app2");
+        session.setSequenceId(2);
         formSessionRepo.save(session);
 
         // cache and find return updated session
-        Assert.assertEquals("app2", getCachedSession("123").get().getAppId());
-        Assert.assertEquals("app2", formSessionRepo.findOneWrapped("123").getAppId());
+        Assert.assertEquals(2, getCachedSession("123").get().getSequenceId());
+        Assert.assertEquals(2, formSessionRepo.findOneWrapped("123").getSequenceId());
 
+        // ensure update is persisted to DB
+        cacheManager.getCache("form_session").clear();
+        Assert.assertEquals(2, formSessionRepo.findOneWrapped("123").getSequenceId());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
@@ -1,0 +1,122 @@
+package org.commcare.formplayer.repo.impl;
+
+import org.commcare.formplayer.exceptions.FormNotFoundException;
+import org.commcare.formplayer.objects.SerializableFormSession;
+import org.commcare.formplayer.repo.FormSessionRepo;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ContextConfiguration
+@Transactional
+public class PostgresFormSessionRepoTest {
+
+    @Autowired
+    PostgresFormSessionRepo formSessionRepo;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    CacheManager cacheManager;
+
+    @After
+    public void cleanup() {
+        cacheManager.getCache("form_session").clear();
+    }
+
+    @Test(expected = FormNotFoundException.class)
+    public void testFindOneWrapped_NotFound() {
+        formSessionRepo.findOneWrapped("123");
+    }
+
+    @Test
+    public void testFindOneWrapped_cached() {
+        // no cache to start
+        Assert.assertEquals(Optional.empty(), getCachedSession("123"));
+
+        // save a session
+        SerializableFormSession session = new SerializableFormSession("123");
+        session.setAppId("app1");
+        formSessionRepo.save(session);
+
+        // cache is populated on save
+        Assert.assertEquals("app1", getCachedSession("123").get().getAppId());
+
+        // find works
+        session = formSessionRepo.findOneWrapped("123");
+        Assert.assertEquals("app1", session.getAppId());
+        Assert.assertEquals(session, getCachedSession("123").get());
+
+        // update session
+        session.setAppId("app2");
+        formSessionRepo.save(session);
+
+        // cache and find return updated session
+        Assert.assertEquals("app2", getCachedSession("123").get().getAppId());
+        Assert.assertEquals("app2", formSessionRepo.findOneWrapped("123").getAppId());
+
+    }
+
+    @Test
+    public void testDeleteClearsCache() {
+        SerializableFormSession session = new SerializableFormSession("123");
+        formSessionRepo.save(session);
+        Assert.assertEquals(session, getCachedSession("123").get());
+
+        formSessionRepo.delete(session);
+        Assert.assertEquals(Optional.empty(), getCachedSession("123"));
+    }
+
+    @Test
+    public void testDeleteByIdClearsCache() {
+        SerializableFormSession session = new SerializableFormSession("123");
+        formSessionRepo.save(session);
+        Assert.assertEquals(session, getCachedSession("123").get());
+
+        formSessionRepo.deleteById(session.getId());
+        Assert.assertEquals(Optional.empty(), getCachedSession("123"));
+    }
+
+    private Optional<SerializableFormSession> getCachedSession(String id) {
+        return ofNullable(cacheManager.getCache("form_session")).map(c -> c.get(id, SerializableFormSession.class));
+    }
+
+    @EnableCaching
+    @Configuration
+    @AutoConfigurationPackage
+    public static class CachingTestConfig {
+
+        @Bean
+        public FormSessionRepo formSessionRepo() {
+            return new PostgresFormSessionRepo();
+        }
+
+        @Bean
+        public CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("form_session");
+        }
+
+    }
+}

--- a/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
@@ -33,7 +33,7 @@ import static java.util.Optional.ofNullable;
 public class PostgresFormSessionRepoTest {
 
     @Autowired
-    PostgresFormSessionRepo formSessionRepo;
+    FormSessionRepo formSessionRepo;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -63,7 +63,7 @@ public class BaseTestClass {
 
     private MockMvc mockFormController;
 
-    private MockMvc mockUtilController;
+    protected MockMvc mockUtilController;
 
     private MockMvc mockMenuController;
 

--- a/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
@@ -1,76 +1,33 @@
 package org.commcare.formplayer.tests;
 
-import org.commcare.formplayer.Application;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.StringHttpMessageConverter;
-import org.springframework.mock.http.MockHttpOutputMessage;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.web.context.WebApplicationContext;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.FileUtils;
+import org.commcare.formplayer.utils.TestContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
-
 import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes=Application.class)
-@AutoConfigureMockMvc
-@WebAppConfiguration
-public class FormValidatorTests {
+@ContextConfiguration(classes = TestContext.class)
+public class FormValidatorTests extends BaseTestClass {
 
     private MediaType contentType = new MediaType(MediaType.APPLICATION_XML.getType(),
             MediaType.APPLICATION_XML.getSubtype(),
             Charset.forName("utf8"));
-
-    private MockMvc mockMvc;
-
-    private HttpMessageConverter string2HttpMessageConverter;
-
-    @Autowired
-    private WebApplicationContext webApplicationContext;
-
-    @Autowired
-    void setConverters(HttpMessageConverter<?>[] converters) {
-        Optional<HttpMessageConverter<?>> converterOptional = Iterables.tryFind(Arrays.asList(converters), new Predicate<HttpMessageConverter<?>>() {
-            @Override
-            public boolean apply(HttpMessageConverter<?> hmc) {
-                return hmc instanceof StringHttpMessageConverter;
-            }
-        });
-
-        assertTrue("the XML message converter must not be null", converterOptional.isPresent());
-        this.string2HttpMessageConverter = converterOptional.get();
-    }
-
-
-    @Before
-    public void setup() throws Exception {
-        this.mockMvc = webAppContextSetup(webApplicationContext).build();
-    }
 
     @Test
     public void testValidateForm() throws Exception {
@@ -112,8 +69,8 @@ public class FormValidatorTests {
     }
 
     public void testValidateForm(String formXML, List<ResultMatcher> matchers) throws Exception {
-        ResultActions actions = mockMvc.perform(post(String.format("/%s", Constants.URL_VALIDATE_FORM))
-                .content(this.xml(formXML))
+        ResultActions actions = mockUtilController.perform(post(String.format("/%s", Constants.URL_VALIDATE_FORM))
+                .content(formXML)
                 .contentType(contentType))
                 .andExpect(status().isOk())
                 .andDo(log());
@@ -123,11 +80,5 @@ public class FormValidatorTests {
         }
     }
 
-    protected String xml(Object o) throws IOException {
-        MockHttpOutputMessage mockHttpOutputMessage = new MockHttpOutputMessage();
-        this.string2HttpMessageConverter.write(
-                o, MediaType.APPLICATION_XML, mockHttpOutputMessage);
-        return mockHttpOutputMessage.getBodyAsString();
-    }
 
 }


### PR DESCRIPTION
Form sessions are fetched multiple times per request, sometimes as much as 3 or 4 times. These objects are expensive to fetch since they line in a remote DB and are large.

Some places they are fetched outside of the controllers:

* [LockAspect](https://github.com/dimagi/formplayer/blob/0a6850fdbeb61d8c5dedcda4c4c338e350fbd275/src/main/java/org/commcare/formplayer/aspects/LockAspect.java#L110)
* [UserRestoreAspect](https://github.com/dimagi/formplayer/blob/0a6850fdbeb61d8c5dedcda4c4c338e350fbd275/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java#L78)
* [FormplayerAuthFilter](https://github.com/dimagi/formplayer/blob/4bb52e8791a597ecbc41ed36e66b3739439d845f/src/main/java/org/commcare/formplayer/application/FormplayerAuthFilter.java#L187)
* [FormplayerStorageFactory](https://github.com/dimagi/formplayer/blob/162db2cd7bb0e6f09f9091c5ea03d4b1bee1481b/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java#L55)

This PR adds caching support to the FormSessionRepo that will fetch the session from cache if it is available. This is analogous to how we use quickcache in HQ. By default the cache will use a NOOPCache which does nothing making this safe to deploy as is. The actual cache can be configured by local config.

I want to test this out using an in memory cache [Caffeine](https://github.com/ben-manes/caffeine/). I think it is unnecessary to use a cache like redis since there is no need to have the cache be accessible across machines (due to persistent request routing). This also makes the caching quite safe since there will not be race conditions between machines.

In terms of memory usage, the cache is currently configured to hold a max of 500 objects. The DB size of form sessions is 1MB on average so possible memory usage is 0.5GB. The cache is also configured to expire objects 5min after last access.

Note: I'm not sure if there is a better way to accomplish this that doesn't involve caching. I had thought of making a request scoped bean that would hold the session object as described here: http://www.javabyexamples.com/request-scoped-data-with-spring-mvc/. The advantage of the caching approach is that subsequent request still benefit from the cache and don't have to do a DB query to get the session object.