### PR TITLE
reuse 'as' parameter when doing a force sync

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -680,12 +680,12 @@ public class RestoreFactory {
                     unEncodedAsUsername += "@" + domain + ".commcarehq.org";
                 }
                 builderQueryParamEncoded(builder, "as", unEncodedAsUsername);
+            } else if (getHqAuth() == null && username != null) {
+                // HQ requesting to force a sync for a user
+                builderQueryParamEncoded(builder, "as", username);
             }
             if (skipFixtures) {
                 builderQueryParamEncoded(builder, "skip_fixtures", "true");
-            }
-            if (getHqAuth() == null && username != null) {
-                builderQueryParamEncoded(builder, "for", username);
             }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(String.format("Restore Error: " + e.getMessage()));


### PR DESCRIPTION
Since the introduction of the `for` parameter was problematic due to how SMS forms works (https://github.com/dimagi/commcare-hq/pull/29092) we can just reuse the 'as' field and update HQ to record the auth type.