### PR TITLE
use junit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,9 +95,9 @@ dependencies {
     testImplementation project(path: ':commcare', configuration: 'api')
 
     //Versions managed by Spring Dependency Management
-    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    testImplementation group: 'org.springframework.boot', name: 'spring-boot-test'
-    testImplementation group: 'org.springframework', name: 'spring-test'
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
 
     //Unmanaged Dependencies
     testImplementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.5.0'
@@ -109,6 +109,7 @@ dependencies {
 }
 
 test {
+    useJUnitPlatform()
     testLogging {
         exceptionFormat 'full'
         events "passed", "skipped", "failed"

--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -46,6 +46,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.context.request.RequestContextListener;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
@@ -322,5 +323,9 @@ public class WebAppContext implements WebMvcConfigurer {
                         .usingDbTime() // Works on Postgres, MySQL, MariaDb, MS SQL, Oracle, DB2, HSQL and H2
                         .build()
         );
+    }
+
+    @Bean public RequestContextListener requestContextListener(){
+        return new RequestContextListener();
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -615,14 +615,12 @@ public class RestoreFactory {
     }
 
     private HttpHeaders getHmacHeaders(String requestPath) {
-        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
-        if (RequestContextHolder.getRequestAttributes() != null) {
-            FormplayerHttpRequest request = (FormplayerHttpRequest) ((ServletRequestAttributes) attributes).getRequest();
-            if (!request.getRequestValidatedWithHMAC()) {
-                throw new RuntimeException(String.format("Tried getting HMAC Auth for request %s but this request" +
-                        "was not validated with HMAC.", requestPath));
-            }
-        } else {
+        FormplayerHttpRequest request = RequestUtils.getCurrentRequest();
+        if (request == null) {
+            throw new RuntimeException(String.format(
+                    "HMAC Auth not available outside of a web request %s", requestPath
+            ));
+        } else if (!request.getRequestValidatedWithHMAC()) {
             throw new RuntimeException(String.format("Tried getting HMAC Auth for request %s but this request" +
                     "was not validated with HMAC.", requestPath));
         }

--- a/src/main/java/org/commcare/formplayer/util/FormplayerSentry.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerSentry.java
@@ -182,7 +182,7 @@ public class FormplayerSentry {
             synctoken = restoreFactory.getSyncToken();
             sandboxPath = restoreFactory.getSQLiteDB().getDatabaseFileForDebugPurposes();
         }
-        FormplayerHttpRequest request = getRequest();
+        FormplayerHttpRequest request = RequestUtils.getCurrentRequest();
         return (
                 new EventBuilder()
                 .withEnvironment(environment)
@@ -205,7 +205,7 @@ public class FormplayerSentry {
         if (sentryClient == null) {
             return;
         }
-        FormplayerHttpRequest request = getRequest();
+        FormplayerHttpRequest request = RequestUtils.getCurrentRequest();
         if (request != null) {
             setDomain(request.getDomain());
 
@@ -235,14 +235,6 @@ public class FormplayerSentry {
         } catch (Exception e) {
             log.info("Error sending event to Sentry. Ensure that sentryClient is configured. ", e);
         }
-    }
-
-    private FormplayerHttpRequest getRequest() {
-        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
-        if (RequestContextHolder.getRequestAttributes() != null) {
-            return (FormplayerHttpRequest) ((ServletRequestAttributes) attributes).getRequest();
-        }
-        return null;
     }
 
     public String getDomain() {

--- a/src/main/java/org/commcare/formplayer/util/FormplayerSentry.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerSentry.java
@@ -11,6 +11,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.repo.FormSessionRepo;
 import org.commcare.formplayer.services.RestoreFactory;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -49,9 +52,6 @@ public class FormplayerSentry {
 
     @Autowired
     private RestoreFactory restoreFactory;
-
-    @Autowired(required = false)
-    private FormplayerHttpRequest request;
 
     public FormplayerSentry(SentryClient sentryClient) {
         this.sentryClient = sentryClient;
@@ -182,6 +182,7 @@ public class FormplayerSentry {
             synctoken = restoreFactory.getSyncToken();
             sandboxPath = restoreFactory.getSQLiteDB().getDatabaseFileForDebugPurposes();
         }
+        FormplayerHttpRequest request = getRequest();
         return (
                 new EventBuilder()
                 .withEnvironment(environment)
@@ -204,6 +205,7 @@ public class FormplayerSentry {
         if (sentryClient == null) {
             return;
         }
+        FormplayerHttpRequest request = getRequest();
         if (request != null) {
             setDomain(request.getDomain());
 
@@ -233,6 +235,14 @@ public class FormplayerSentry {
         } catch (Exception e) {
             log.info("Error sending event to Sentry. Ensure that sentryClient is configured. ", e);
         }
+    }
+
+    private FormplayerHttpRequest getRequest() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (RequestContextHolder.getRequestAttributes() != null) {
+            return (FormplayerHttpRequest) ((ServletRequestAttributes) attributes).getRequest();
+        }
+        return null;
     }
 
     public String getDomain() {

--- a/src/main/java/org/commcare/formplayer/util/RequestUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/RequestUtils.java
@@ -4,6 +4,9 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -77,5 +80,13 @@ public class RequestUtils {
         SecretKeySpec secret_key = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
         sha256_HMAC.init(secret_key);
         return Base64.encodeBase64String(sha256_HMAC.doFinal(data.getBytes("UTF-8")));
+    }
+
+    public static FormplayerHttpRequest getCurrentRequest() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (RequestContextHolder.getRequestAttributes() != null) {
+            return (FormplayerHttpRequest) ((ServletRequestAttributes) attributes).getRequest();
+        }
+        return null;
     }
 }

--- a/src/main/java/org/commcare/formplayer/util/RequestUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/RequestUtils.java
@@ -84,7 +84,7 @@ public class RequestUtils {
 
     public static FormplayerHttpRequest getCurrentRequest() {
         RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
-        if (RequestContextHolder.getRequestAttributes() != null) {
+        if (attributes != null) {
             return (FormplayerHttpRequest) ((ServletRequestAttributes) attributes).getRequest();
         }
         return null;

--- a/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/impl/PostgresFormSessionRepoTest.java
@@ -3,10 +3,8 @@ package org.commcare.formplayer.repo.impl;
 import org.commcare.formplayer.exceptions.FormNotFoundException;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.repo.FormSessionRepo;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -18,14 +16,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(SpringRunner.class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration
@@ -41,20 +39,20 @@ public class PostgresFormSessionRepoTest {
     @Autowired
     CacheManager cacheManager;
 
-    @After
+    @AfterEach
     public void cleanup() {
         cacheManager.getCache("form_session").clear();
     }
 
-    @Test(expected = FormNotFoundException.class)
+    @Test
     public void testFindOneWrapped_NotFound() {
-        formSessionRepo.findOneWrapped("123");
+        assertThrows(FormNotFoundException.class, () -> formSessionRepo.findOneWrapped("123"));
     }
 
     @Test
     public void testFindOneWrapped_cached() {
         // no cache to start
-        Assert.assertEquals(Optional.empty(), getCachedSession("123"));
+        assertEquals(Optional.empty(), getCachedSession("123"));
 
         // save a session
         SerializableFormSession session = new SerializableFormSession("123");
@@ -62,44 +60,44 @@ public class PostgresFormSessionRepoTest {
         formSessionRepo.save(session);
 
         // cache is populated on save
-        Assert.assertEquals(1, getCachedSession("123").get().getSequenceId());
+        assertEquals(1, getCachedSession("123").get().getSequenceId());
 
         // find works
         session = formSessionRepo.findOneWrapped("123");
-        Assert.assertEquals(1, session.getSequenceId());
-        Assert.assertEquals(session, getCachedSession("123").get());
+        assertEquals(1, session.getSequenceId());
+        assertEquals(session, getCachedSession("123").get());
 
         // update session
         session.setSequenceId(2);
         formSessionRepo.save(session);
 
         // cache and find return updated session
-        Assert.assertEquals(2, getCachedSession("123").get().getSequenceId());
-        Assert.assertEquals(2, formSessionRepo.findOneWrapped("123").getSequenceId());
+        assertEquals(2, getCachedSession("123").get().getSequenceId());
+        assertEquals(2, formSessionRepo.findOneWrapped("123").getSequenceId());
 
         // ensure update is persisted to DB
         cacheManager.getCache("form_session").clear();
-        Assert.assertEquals(2, formSessionRepo.findOneWrapped("123").getSequenceId());
+        assertEquals(2, formSessionRepo.findOneWrapped("123").getSequenceId());
     }
 
     @Test
     public void testDeleteClearsCache() {
         SerializableFormSession session = new SerializableFormSession("123");
         formSessionRepo.save(session);
-        Assert.assertEquals(session, getCachedSession("123").get());
+        assertEquals(session, getCachedSession("123").get());
 
         formSessionRepo.delete(session);
-        Assert.assertEquals(Optional.empty(), getCachedSession("123"));
+        assertEquals(Optional.empty(), getCachedSession("123"));
     }
 
     @Test
     public void testDeleteByIdClearsCache() {
         SerializableFormSession session = new SerializableFormSession("123");
         formSessionRepo.save(session);
-        Assert.assertEquals(session, getCachedSession("123").get());
+        assertEquals(session, getCachedSession("123").get());
 
         formSessionRepo.deleteById(session.getId());
-        Assert.assertEquals(Optional.empty(), getCachedSession("123"));
+        assertEquals(Optional.empty(), getCachedSession("123"));
     }
 
     private Optional<SerializableFormSession> getCachedSession(String id) {

--- a/src/test/java/org/commcare/formplayer/tests/ApplicationUtilsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/ApplicationUtilsTests.java
@@ -1,21 +1,12 @@
 package org.commcare.formplayer.tests;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sqlitedb.ApplicationDB;
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
-import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 
-/**
- * Tests ApplicationUtils
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
 public class ApplicationUtilsTests {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/AsyncRestoreTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/AsyncRestoreTest.java
@@ -3,22 +3,13 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.exceptions.AsyncRetryException;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.utils.FileUtils;
-import org.commcare.formplayer.utils.TestContext;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-/**
- * Created by benrudolph on 10/13/16.
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
 public class AsyncRestoreTest {
 
     @Test
@@ -35,12 +26,12 @@ public class AsyncRestoreTest {
             method.invoke(restoreFactory, asyncResponse, headers);
         } catch (InvocationTargetException invocationException) {
             AsyncRetryException e = (AsyncRetryException) invocationException.getTargetException();
-            Assert.assertEquals(143, e.getDone());
-            Assert.assertEquals(23311, e.getTotal());
-            Assert.assertEquals(30, e.getRetryAfter());
-            Assert.assertEquals("Asynchronous restore under way for large_caseload", e.getMessage());
+            Assertions.assertEquals(143, e.getDone());
+            Assertions.assertEquals(23311, e.getTotal());
+            Assertions.assertEquals(30, e.getRetryAfter());
+            Assertions.assertEquals("Asynchronous restore under way for large_caseload", e.getMessage());
             failure = true;
         }
-        Assert.assertTrue(failure);
+        Assertions.assertTrue(failure);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -12,8 +12,8 @@ import org.commcare.formplayer.sqlitedb.UserDB;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.TimezoneProvider;
 import org.javarosa.core.services.locale.LocalizerManager;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -46,7 +46,6 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.sql.SQLException;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 
 import static org.mockito.Matchers.anyBoolean;
@@ -143,7 +142,7 @@ public class BaseTestClass {
 
     protected ObjectMapper mapper;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         Mockito.reset(formSessionRepoMock);
         Mockito.reset(menuSessionRepoMock);
@@ -199,7 +198,7 @@ public class BaseTestClass {
                 .when(submitServiceMock).submitForm(anyString(), anyString());
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws SQLException {
         if(customConnector != null) {
             customConnector.closeConnection();

--- a/src/test/java/org/commcare/formplayer/tests/BasicEndOfFormTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/BasicEndOfFormTests.java
@@ -4,23 +4,22 @@ import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.utils.TestContext;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 
-/**
- * Tests for basic end of form navigation behaviors
- */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class BasicEndOfFormTests extends BaseTestClass{
 
+    @BeforeEach
     @Override
     public void setUp() throws Exception {
         super.setUp();

--- a/src/test/java/org/commcare/formplayer/tests/BrowserValuesProviderTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/BrowserValuesProviderTest.java
@@ -2,34 +2,26 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.services.BrowserValuesProvider;
-import org.commcare.formplayer.utils.TestContext;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.time.LocalDate;
 import java.util.Date;
 import java.util.TimeZone;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
+@ExtendWith(SpringExtension.class)
 public class BrowserValuesProviderTest {
 
     static final String NY_TZ_ID = "America/New_York";
     static final TimeZone NY_TZ = TimeZone.getTimeZone(NY_TZ_ID);
     static final int NY_DST_TZ_OFFSET = -14400000;
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     BrowserValuesProvider browserValuesProvider = null;
     Date date = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.browserValuesProvider = new BrowserValuesProvider();
         this.date = new Date(1585699200000L); // April 1, 2020 12:00:00 AM
@@ -49,26 +41,29 @@ public class BrowserValuesProviderTest {
 
     @Test
     public void testCheckTzDiscrepancyNullTz() throws Exception {
-        thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
         AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
         bean.setTzOffset(NY_DST_TZ_OFFSET);
-        browserValuesProvider.checkTzDiscrepancy(bean, null, this.date);
+        Assertions.assertThrows(BrowserValuesProvider.TzDiscrepancyException.class, () -> {
+            browserValuesProvider.checkTzDiscrepancy(bean, null, this.date);
+        });
     }
 
     @Test
     public void testCheckTzDiscrepancyFalseTz() throws Exception {
-        thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
         AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
         bean.setTzOffset(0);
-        browserValuesProvider.checkTzDiscrepancy(bean, NY_TZ, this.date);
+        Assertions.assertThrows(BrowserValuesProvider.TzDiscrepancyException.class, () -> {
+            browserValuesProvider.checkTzDiscrepancy(bean, NY_TZ, this.date);
+        });
     }
 
     @Test
     public void testCheckTzDiscrepancyFalseNonsenseTz() throws Exception {
-        thrown.expect(BrowserValuesProvider.TzDiscrepancyException.class);
         AuthenticatedRequestBean bean = new AuthenticatedRequestBean();
         bean.setTzOffset(NY_DST_TZ_OFFSET);
-        browserValuesProvider.checkTzDiscrepancy(bean, TimeZone.getTimeZone("adaf"), this.date);
+        Assertions.assertThrows(BrowserValuesProvider.TzDiscrepancyException.class, () -> {
+            browserValuesProvider.checkTzDiscrepancy(bean, TimeZone.getTimeZone("adaf"), this.date);
+        });
     }
 
 }

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -9,18 +9,18 @@ import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.FileUtils;
 import org.commcare.formplayer.utils.TestContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.Hashtable;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -29,11 +29,12 @@ import static org.mockito.Mockito.when;
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseClaimTests extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("caseclaimdomain", "caseclaimusername");

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbIndexTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbIndexTests.java
@@ -1,25 +1,25 @@
 package org.commcare.formplayer.tests;
 
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.utils.TestStorageUtils;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
-import static junit.framework.Assert.assertEquals;
 import static org.commcare.formplayer.utils.DbTestUtils.evaluate;
 
 /**
  * @author wspride
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseDbIndexTests extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("synctestdomain", "synctestusername");

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbModelQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbModelQueryTests.java
@@ -1,25 +1,25 @@
 package org.commcare.formplayer.tests;
 
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.utils.TestStorageUtils;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
-import static junit.framework.Assert.assertEquals;
 import static org.commcare.formplayer.utils.DbTestUtils.evaluate;
 
 /**
  * @author wspride
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseDbModelQueryTests extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("synctestdomain", "synctestusername");

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbOptimizationsTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbOptimizationsTest.java
@@ -1,24 +1,25 @@
 package org.commcare.formplayer.tests;
 
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.utils.TestStorageUtils;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.commcare.formplayer.utils.DbTestUtils.evaluate;
 
 /**
  * @author wspride
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseDbOptimizationsTest extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("synctestdomain", "synctestusername");

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbQueryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbQueryTest.java
@@ -1,23 +1,25 @@
 package org.commcare.formplayer.tests;
 
-import org.javarosa.core.model.condition.EvaluationContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.utils.TestStorageUtils;
+import org.javarosa.core.model.condition.EvaluationContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+
 import static org.commcare.formplayer.utils.DbTestUtils.evaluate;
 
 /**
  * @author wspride
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseDbQueryTest extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("synctestdomain", "synctestusername");

--- a/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
@@ -4,26 +4,27 @@ import org.commcare.formplayer.beans.menus.EntityBean;
 import org.commcare.formplayer.beans.menus.EntityDetailListResponse;
 import org.commcare.formplayer.beans.menus.EntityDetailResponse;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.javarosa.core.services.PropertyManager;
-import org.javarosa.core.services.properties.Property;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
 import org.commcare.formplayer.mocks.FormPlayerPropertyManagerMock;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.utils.TestContext;
+import org.javarosa.core.services.PropertyManager;
+import org.javarosa.core.services.properties.Property;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+
 import static org.mockito.Mockito.when;
 
 /**
  * Created by willpride on 5/16/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CasePaginationTests extends BaseTestClass {
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("loaddomain", "loaduser");

--- a/src/test/java/org/commcare/formplayer/tests/CaseTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseTests.java
@@ -1,19 +1,19 @@
 package org.commcare.formplayer.tests;
 
-import org.commcare.formplayer.application.SQLiteProperties;
-import org.commcare.formplayer.beans.*;
-import org.commcare.formplayer.sandbox.SqlSandboxUtils;
-import org.commcare.formplayer.sandbox.SqlStorage;
-import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.util.CasePurgeFilter;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.commcare.formplayer.beans.EvaluateXPathResponseBean;
+import org.commcare.formplayer.beans.FormEntryResponseBean;
+import org.commcare.formplayer.beans.NewFormResponse;
+import org.commcare.formplayer.beans.QuestionBean;
+import org.commcare.formplayer.beans.SubmitResponseBean;
+import org.commcare.formplayer.sandbox.SqlStorage;
+import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.util.Iterator;
 
@@ -22,7 +22,7 @@ import java.util.Iterator;
  *
  * This test tests that we can create and delete a case via the form API
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseTests extends BaseTestClass {
 

--- a/src/test/java/org/commcare/formplayer/tests/CaseTilesTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseTilesTest.java
@@ -3,20 +3,21 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
 import org.commcare.formplayer.beans.menus.Tile;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Created by willpride on 4/14/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class CaseTilesTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("casetilesdomain", "casetilesuser");

--- a/src/test/java/org/commcare/formplayer/tests/DeleteApplicationDbsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/DeleteApplicationDbsTests.java
@@ -2,22 +2,23 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.NotificationMessage;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.sqlitedb.ApplicationDB;
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.io.File;
 
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class DeleteApplicationDbsTests extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("casetestdomain", "casetestuser");

--- a/src/test/java/org/commcare/formplayer/tests/DetailNodesetTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/DetailNodesetTest.java
@@ -1,20 +1,21 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.menus.EntityDetailListResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class DetailNodesetTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("detailnodesetdomain", "detailnodesetusername");

--- a/src/test/java/org/commcare/formplayer/tests/DoubleManagementTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/DoubleManagementTest.java
@@ -2,22 +2,25 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
-import org.commcare.formplayer.beans.menus.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
+import org.commcare.formplayer.beans.menus.CommandListResponseBean;
+import org.commcare.formplayer.beans.menus.DisplayElement;
+import org.commcare.formplayer.beans.menus.EntityDetailListResponse;
+import org.commcare.formplayer.beans.menus.EntityListResponse;
 import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Created by willpride on 4/14/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class DoubleManagementTest  extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("doublemgmtdomain", "doublemgmtusername");

--- a/src/test/java/org/commcare/formplayer/tests/EditTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EditTest.java
@@ -1,27 +1,28 @@
 package org.commcare.formplayer.tests;
 
-import org.commcare.formplayer.beans.NewFormResponse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.javarosa.core.model.utils.DateUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.utils.TestContext;
+import org.javarosa.core.model.utils.DateUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.util.Date;
 
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class EditTest extends BaseTestClass {
 
     private final Log log = LogFactory.getLog(EditTest.class);
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("editdomain", "editusername");

--- a/src/test/java/org/commcare/formplayer/tests/Enikshay2bTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/Enikshay2bTests.java
@@ -4,23 +4,24 @@ import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.utils.TestContext;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.util.LinkedHashMap;
 
 /**
  * Tests specific to Enikshay
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class Enikshay2bTests extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("enikshay2domain", "enikshay2username");

--- a/src/test/java/org/commcare/formplayer/tests/EnikshayEndOfFormTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EnikshayEndOfFormTests.java
@@ -5,10 +5,10 @@ import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
 import org.json.JSONObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 import java.util.ArrayList;
@@ -18,11 +18,12 @@ import java.util.LinkedHashMap;
 /**
  * Test that end of form navigations used by Enikshay Private application work
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class EnikshayEndOfFormTests extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("enikshay_privatedomain", "enikshay_privateusername");

--- a/src/test/java/org/commcare/formplayer/tests/EnikshayTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EnikshayTests.java
@@ -2,20 +2,21 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.EntityDetailListResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Tests specific to Enikshay
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class EnikshayTests extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("enikshaydomain", "enikshayusername");

--- a/src/test/java/org/commcare/formplayer/tests/FilterTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FilterTests.java
@@ -3,18 +3,16 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.application.SQLiteProperties;
 import org.commcare.formplayer.beans.SyncDbResponseBean;
 import org.commcare.cases.model.Case;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
-import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.TestContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class FilterTests extends BaseTestClass {
 

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryTest.java
@@ -5,17 +5,19 @@ import org.commcare.formplayer.beans.*;
 import org.commcare.formplayer.beans.menus.ErrorBean;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.TestContext;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class FormEntryTest extends BaseTestClass{
 
@@ -43,9 +45,9 @@ public class FormEntryTest extends BaseTestClass{
 
         QuestionBean[] tree = response.getTree();
 
-        Assert.assertTrue(getInstanceResponse.getOutput().contains("ben rudolph"));
-        Assert.assertTrue(getInstanceResponse.getOutput().contains("William Pride"));
-        Assert.assertNotNull(getInstanceResponse.getXmlns());
+        assertTrue(getInstanceResponse.getOutput().contains("ben rudolph"));
+        assertTrue(getInstanceResponse.getOutput().contains("William Pride"));
+        assertNotNull(getInstanceResponse.getXmlns());
 
         QuestionBean textBean = tree[1];
         assert textBean.getAnswer().equals("William Pride");
@@ -194,10 +196,10 @@ public class FormEntryTest extends BaseTestClass{
 
         Map<String, Object> answers = ImmutableMap.of("0", "", "1", "test", "2", "");
         SubmitResponseBean submitResponseBean = submitForm(answers, sessionId);
-        Assert.assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, submitResponseBean.getStatus());
-        Assert.assertEquals(2, submitResponseBean.getErrors().size());
-        Assert.assertEquals(new ErrorBean("validation-error", "required"), submitResponseBean.getErrors().get("0"));
-        Assert.assertEquals(new ErrorBean("validation-error", "constraint"), submitResponseBean.getErrors().get("1"));
+        assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, submitResponseBean.getStatus());
+        assertEquals(2, submitResponseBean.getErrors().size());
+        assertEquals(new ErrorBean("validation-error", "required"), submitResponseBean.getErrors().get("0"));
+        assertEquals(new ErrorBean("validation-error", "constraint"), submitResponseBean.getErrors().get("1"));
     }
 
     @Test
@@ -207,14 +209,14 @@ public class FormEntryTest extends BaseTestClass{
         String sessionId = newSessionResponse.getSessionId();
 
         FormEntryResponseBean response = answerQuestionGetResult("0", null, sessionId);
-        Assert.assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, response.getStatus());
+        assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, response.getStatus());
         response = answerQuestionGetResult("1", "test", sessionId);
-        Assert.assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, response.getStatus());
+        assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, response.getStatus());
 
         Map<String, Object> answers = ImmutableMap.of("1", "not test");
         SubmitResponseBean submitResponseBean = submitForm(answers, sessionId);
-        Assert.assertEquals(Constants.SYNC_RESPONSE_STATUS_POSITIVE, submitResponseBean.getStatus());
-        Assert.assertEquals(0, submitResponseBean.getErrors().size());
+        assertEquals(Constants.SYNC_RESPONSE_STATUS_POSITIVE, submitResponseBean.getStatus());
+        assertEquals(0, submitResponseBean.getErrors().size());
     }
 
     @Test
@@ -225,6 +227,6 @@ public class FormEntryTest extends BaseTestClass{
 
         Map<String, Object> answers = new HashMap();
         SubmitResponseBean submitResponseBean = submitForm(answers, sessionId, false);
-        Assert.assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, submitResponseBean.getStatus());
+        assertEquals(Constants.ANSWER_RESPONSE_STATUS_NEGATIVE, submitResponseBean.getStatus());
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
@@ -3,11 +3,10 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.FileUtils;
 import org.commcare.formplayer.utils.TestContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
 
@@ -21,7 +20,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class FormValidatorTests extends BaseTestClass {
 

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerDateUtilsTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerDateUtilsTest.java
@@ -1,27 +1,18 @@
 package org.commcare.formplayer.tests;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.util.FormplayerDateUtils;
-import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-/**
- * Tests for FormplayerDateUtils
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
 public class FormplayerDateUtilsTest {
     @Test
     public void testConvertDate() {
         String date = "Mon Oct 17 11:36:50 EDT 2016";
         String iso = FormplayerDateUtils.convertJavaDateStringToISO(date);
-        Assert.assertEquals("2016-10-17T15:36:50Z", iso);
+        Assertions.assertEquals("2016-10-17T15:36:50Z", iso);
 
         date = "Not a real date";
         iso = FormplayerDateUtils.convertJavaDateStringToISO(date);
-        Assert.assertEquals(null, iso);
+        Assertions.assertEquals(null, iso);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerRavenTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerRavenTest.java
@@ -1,27 +1,24 @@
 package org.commcare.formplayer.tests;
 
+import org.commcare.formplayer.util.FormplayerSentry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
 import io.sentry.SentryClient;
 import io.sentry.context.Context;
 import io.sentry.event.Breadcrumb;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.commcare.formplayer.util.FormplayerSentry;
-import org.commcare.formplayer.utils.TestContext;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
 public class FormplayerRavenTest {
     FormplayerSentry raven;
     Context contextMock;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         SentryClient sentryMock = mock(SentryClient.class);
         contextMock = mock(Context.class);

--- a/src/test/java/org/commcare/formplayer/tests/GeoTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/GeoTests.java
@@ -1,20 +1,21 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Tests for geo functionality
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class GeoTests extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("heredoman", "hereusername");

--- a/src/test/java/org/commcare/formplayer/tests/GroupTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/GroupTests.java
@@ -5,11 +5,10 @@ import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.QuestionBean;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 import static org.mockito.Matchers.any;
@@ -18,11 +17,11 @@ import static org.mockito.Matchers.any;
  * Fills out the "Basic Tests > Groups" Form from the QA plan.
  * Provides coverage of fixtures, group expansion, selects from itemsets, conditional selects
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class GroupTests extends BaseTestClass{
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("grouptestdomain", "grouptestuser");

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -2,32 +2,28 @@ package org.commcare.formplayer.tests;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.commcare.formplayer.application.WebAppContext;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
 import org.commcare.formplayer.services.HqUserDetailsService;
 import org.commcare.formplayer.util.Constants;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.OverrideAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@RunWith(SpringRunner.class)
 @RestClientTest(value=HqUserDetailsService.class)
 @AutoConfigureWebClient(registerRestTemplate = true)
 @TestPropertySource(properties = {
@@ -45,7 +41,7 @@ public class HqUserDetailsServiceTests {
     @Autowired
     private MockRestServiceServer server;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.server.reset();
     }
@@ -73,12 +69,14 @@ public class HqUserDetailsServiceTests {
         assertThat(details.getDomains()).isEqualTo(new String[]{"domain"});
     }
 
-    @Test(expected = SessionAuthUnavailableException.class)
+    @Test
     public void noSession() {
         this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
                 .andExpect(jsonPath("$.sessionId").value("invalid"))
                 .andRespond(withStatus(HttpStatus.NOT_FOUND));
 
-        this.service.getUserDetails("domain", "invalid");
+        assertThrows(SessionAuthUnavailableException.class, () -> {
+            this.service.getUserDetails("domain", "invalid");
+        });
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -1,35 +1,29 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
 public class HqUserDetailsTests {
 
     @Test
     public void testWebUserIsAuthorized() {
         HqUserDetailsBean user = new HqUserDetailsBean(new String[]{"domain", "other-domain"}, "aragorn", false);
 
-        Assert.assertTrue(user.isAuthorized("domain", "aragorn"));
-        Assert.assertFalse(user.isAuthorized("wrong-domain", "aragorn"));
-        Assert.assertFalse(user.isAuthorized("domain", "wrong-aragorn"));
+        Assertions.assertTrue(user.isAuthorized("domain", "aragorn"));
+        Assertions.assertFalse(user.isAuthorized("wrong-domain", "aragorn"));
+        Assertions.assertFalse(user.isAuthorized("domain", "wrong-aragorn"));
 
         HqUserDetailsBean superuser = new HqUserDetailsBean(new String[]{"domain", "other-domain"}, "aragorn", true);
-        Assert.assertTrue(superuser.isAuthorized("wrong-domain", "wrong-aragorn"));
+        Assertions.assertTrue(superuser.isAuthorized("wrong-domain", "wrong-aragorn"));
     }
 
     @Test
     public void testCommCareUserIsAuthorized() {
         HqUserDetailsBean user = new HqUserDetailsBean(new String[]{"domain"}, "bilbo", false);
 
-        Assert.assertTrue(user.isAuthorized("domain", "bilbo"));
-        Assert.assertFalse(user.isAuthorized("wrong-domain", "bilbo"));
-        Assert.assertFalse(user.isAuthorized("domain", "wrong-bilbo"));
+        Assertions.assertTrue(user.isAuthorized("domain", "bilbo"));
+        Assertions.assertFalse(user.isAuthorized("wrong-domain", "bilbo"));
+        Assertions.assertFalse(user.isAuthorized("domain", "wrong-bilbo"));
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/IndexedFixtureTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/IndexedFixtureTest.java
@@ -1,20 +1,21 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.NewFormResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class IndexedFixtureTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("indexeddomain", "indexedusername");

--- a/src/test/java/org/commcare/formplayer/tests/InlineCaseTilesTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/InlineCaseTilesTest.java
@@ -2,20 +2,21 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityDetailListResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Created by willpride on 4/14/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class InlineCaseTilesTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("inlinecasetilesdomain", "inlinecasetilesuser");

--- a/src/test/java/org/commcare/formplayer/tests/InstallTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/InstallTests.java
@@ -5,22 +5,23 @@ import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Created by willpride on 1/14/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class InstallTests extends BaseTestClass {
 
     Log log = LogFactory.getLog(InstallTests.class);
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("casetestdomain", "casetestuser");

--- a/src/test/java/org/commcare/formplayer/tests/JsonUtilTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/JsonUtilTests.java
@@ -3,15 +3,15 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.api.json.JsonActionUtils;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.commcare.formplayer.util.FormParseInit;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by willpride on 3/31/16.
  */
 public class JsonUtilTests {
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/LocalizationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/LocalizationTests.java
@@ -3,21 +3,19 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import org.commcare.formplayer.utils.TestContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(
         classes = {TestContext.class}
 )
 public class LocalizationTests extends BaseTestClass {
-    public LocalizationTests() {
-    }
-
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("langsdomain", "langsuser");

--- a/src/test/java/org/commcare/formplayer/tests/MenuDebuggerTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/MenuDebuggerTests.java
@@ -1,19 +1,20 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.EvaluateXPathResponseBean;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.TestContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class MenuDebuggerTests extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("loaddomain", "loaduser");
@@ -25,8 +26,8 @@ public class MenuDebuggerTests extends BaseTestClass{
         EvaluateXPathResponseBean evaluateXPathResponseBean = evaluateMenuXPath(
                "requests/evaluate_xpath/evaluate_xpath_menu.json"
         );
-        Assert.assertEquals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE, evaluateXPathResponseBean.getStatus());
+        Assertions.assertEquals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE, evaluateXPathResponseBean.getStatus());
         // Hack to not have to parse the XML returned
-        Assert.assertTrue(evaluateXPathResponseBean.getOutput().contains("15"));
+        Assertions.assertTrue(evaluateXPathResponseBean.getOutput().contains("15"));
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/NewFormTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/NewFormTests.java
@@ -2,10 +2,9 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.QuestionBean;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 import static org.mockito.Matchers.any;
@@ -13,7 +12,7 @@ import static org.mockito.Matchers.any;
 /**
  * Created by willpride on 1/14/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class NewFormTests extends BaseTestClass{
 

--- a/src/test/java/org/commcare/formplayer/tests/OQPSDateRegression.java
+++ b/src/test/java/org/commcare/formplayer/tests/OQPSDateRegression.java
@@ -2,20 +2,21 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class OQPSDateRegression extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("oqpsdatedomain", "oqpsusername");

--- a/src/test/java/org/commcare/formplayer/tests/ParentChildTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/ParentChildTest.java
@@ -3,10 +3,10 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.TestContext;
 
@@ -15,11 +15,12 @@ import java.util.HashMap;
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class ParentChildTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("parentchilddomain", "parentchildusername");

--- a/src/test/java/org/commcare/formplayer/tests/ReassignCaseTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/ReassignCaseTest.java
@@ -3,13 +3,12 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
 import org.commcare.cases.model.Case;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
-import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.utils.TestContext;
 
 import java.util.HashMap;
@@ -17,11 +16,12 @@ import java.util.HashMap;
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class ReassignCaseTest extends BaseTestClass {
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("reassigndomain", "reassignusername");

--- a/src/test/java/org/commcare/formplayer/tests/RegressionTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/RegressionTests.java
@@ -2,21 +2,22 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.util.screen.CommCareSessionException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Regression tests for fixed behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class RegressionTests extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("doublemgmtdomain", "doublemgmtusername");

--- a/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
@@ -3,21 +3,20 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.QuestionBean;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Created by willpride on 1/14/16.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class RepeatTests extends BaseTestClass{
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("test", "test");

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -2,22 +2,21 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * Created by benrudolph on 1/19/17.
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class RestoreFactoryTest {
 
@@ -28,7 +27,7 @@ public class RestoreFactoryTest {
     @Autowired
     RestoreFactory restoreFactorySpy;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         Mockito.reset(restoreFactorySpy);
         MockitoAnnotations.initMocks(this);
@@ -58,7 +57,7 @@ public class RestoreFactoryTest {
         // Last sync time should be more than a day ago
         mockLastSyncTime(System.currentTimeMillis() - RestoreFactory.ONE_DAY_IN_MILLISECONDS - 1);
 
-        Assert.assertTrue(restoreFactorySpy.isRestoreXmlExpired());
+        Assertions.assertTrue(restoreFactorySpy.isRestoreXmlExpired());
     }
 
     @Test
@@ -67,7 +66,7 @@ public class RestoreFactoryTest {
 
         // Last sync time should be less than a day ago
         mockLastSyncTime(System.currentTimeMillis());
-        Assert.assertFalse(restoreFactorySpy.isRestoreXmlExpired());
+        Assertions.assertFalse(restoreFactorySpy.isRestoreXmlExpired());
     }
 
     @Test
@@ -75,7 +74,7 @@ public class RestoreFactoryTest {
         mockSyncFreq("default-case");
 
         mockLastSyncTime(null);
-        Assert.assertFalse(restoreFactorySpy.isRestoreXmlExpired());
+        Assertions.assertFalse(restoreFactorySpy.isRestoreXmlExpired());
     }
 
     @Test
@@ -85,7 +84,7 @@ public class RestoreFactoryTest {
         // Last sync time should be more than a week ago
         mockLastSyncTime(System.currentTimeMillis() - RestoreFactory.ONE_WEEK_IN_MILLISECONDS - 1);
 
-        Assert.assertTrue(restoreFactorySpy.isRestoreXmlExpired());
+        Assertions.assertTrue(restoreFactorySpy.isRestoreXmlExpired());
     }
 
     @Test
@@ -95,6 +94,6 @@ public class RestoreFactoryTest {
         // Last sync time should be less than a week ago
         mockLastSyncTime(System.currentTimeMillis());
 
-        Assert.assertFalse(restoreFactorySpy.isRestoreXmlExpired());
+        Assertions.assertFalse(restoreFactorySpy.isRestoreXmlExpired());
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/SchedulerTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SchedulerTest.java
@@ -1,21 +1,22 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
 /**
  * This regression test confirms that the suite-fixture in the scheduler is parsed
  * and stored correctly
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class SchedulerTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("schedulerdomain", "schedulerusername");

--- a/src/test/java/org/commcare/formplayer/tests/SmsFormEntryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SmsFormEntryTest.java
@@ -2,17 +2,18 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.utils.TestContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class SmsFormEntryTest extends BaseTestClass{
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("test", "test");

--- a/src/test/java/org/commcare/formplayer/tests/SnapshotTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SnapshotTests.java
@@ -8,11 +8,11 @@ import org.commcare.formplayer.utils.TestContext;
 import org.javarosa.core.services.storage.IMetaData;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
 import org.javarosa.core.util.Iterator;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,16 +26,11 @@ import java.io.IOException;
  *
  * @author ctsims
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class SnapshotTests extends BaseTestClass {
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        copySnapshotResources();
-    }
-
+    @BeforeEach
     private void copySnapshotResources() {
         try {
             File destDirectory = new File(getDatabaseFolderRoot());
@@ -44,7 +39,7 @@ public class SnapshotTests extends BaseTestClass {
                     , destDirectory);
         } catch (IOException exception) {
             exception.printStackTrace();
-            Assert.fail("Error moving snapshot data to test directory");
+            Assertions.fail("Error moving snapshot data to test directory");
         }
     }
 
@@ -52,7 +47,7 @@ public class SnapshotTests extends BaseTestClass {
     public void testUserSandbox() throws Exception {
         UserDB database = getUserDbConnector("snapshot", "snapshot_test", null);
         if (!database.databaseFileExists()) {
-            Assert.fail("Snapshot UserDB Missing for tests you may need to rebuild the snapshot " +
+            Assertions.fail("Snapshot UserDB Missing for tests you may need to rebuild the snapshot " +
                     "with the CreateSnapshotDbs Gradle Task ");
         }
         //Try to enumerate records of each type

--- a/src/test/java/org/commcare/formplayer/tests/SubmitServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SubmitServiceTests.java
@@ -4,9 +4,8 @@ import org.commcare.formplayer.application.RestTemplateConfig;
 import org.commcare.formplayer.services.CategoryTimingHelper;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.services.SubmitService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -16,7 +15,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.SimpleThreadScope;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.WebApplicationContext;
@@ -27,7 +25,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
 
-@RunWith(SpringRunner.class)
 @RestClientTest({SubmitService.class, RestTemplateConfig.class})
 /**
  * Regressions for the submission service processing
@@ -58,7 +55,7 @@ public class SubmitServiceTests {
         }
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.server.reset();
         server= MockRestServiceServer.createServer(errorPassthroughRestTemplate);

--- a/src/test/java/org/commcare/formplayer/tests/SubmitTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SubmitTests.java
@@ -6,13 +6,12 @@ import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.TestContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
@@ -20,7 +19,7 @@ import static org.mockito.Matchers.anyString;
 /**
  * Regression tests for submission behaviors
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class SubmitTests extends BaseTestClass {
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
@@ -1,18 +1,10 @@
 package org.commcare.formplayer.tests;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.commcare.formplayer.util.UserUtils;
-import org.commcare.formplayer.utils.TestContext;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
-/**
- * Created by benrudolph on 2/7/17.
- */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = TestContext.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class UserUtilsTests {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/sandbox/CaseAPITests.java
+++ b/src/test/java/org/commcare/formplayer/tests/sandbox/CaseAPITests.java
@@ -3,12 +3,12 @@ package org.commcare.formplayer.tests.sandbox;
 import org.commcare.cases.ledger.Ledger;
 import org.commcare.cases.model.Case;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.commcare.formplayer.sandbox.SqlHelper;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -20,7 +20,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Vector;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CaseAPITests {
 
@@ -39,7 +39,7 @@ public class CaseAPITests {
     private final String databaseName = ("test.db");
 
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         owner = "owner";
@@ -105,7 +105,7 @@ public class CaseAPITests {
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown(){
         try {
             if(preparedStatement != null) {

--- a/src/test/java/org/commcare/formplayer/tests/sandbox/SqlStorageIndexedTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/sandbox/SqlStorageIndexedTests.java
@@ -1,25 +1,24 @@
 package org.commcare.formplayer.tests.sandbox;
 
-import junit.framework.TestCase;
 import org.commcare.cases.ledger.Ledger;
 import org.commcare.cases.model.Case;
-import org.javarosa.core.services.storage.IStorageIterator;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.sqlitedb.UserDB;
+import org.javarosa.core.services.storage.IStorageIterator;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.Vector;
 
-import static junit.framework.Assert.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SqlStorageIndexedTests {
 
@@ -37,7 +36,7 @@ public class SqlStorageIndexedTests {
 
     UserSqlSandbox sandbox;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         owner = "owner";
         otherOwner = "otherowner";
@@ -94,26 +93,26 @@ public class SqlStorageIndexedTests {
         Case readCase = caseStorage.read(1);
         assertEquals("a_case_name", readCase.getName());
         assertEquals(1, readCase.getID());
-        Assert.assertEquals(1, caseStorage.getNumRecords());
+        assertEquals(1, caseStorage.getNumRecords());
 
         int bID = caseStorage.add(b);
         readCase = caseStorage.read(bID);
         assertEquals(bID, readCase.getID());
         assertEquals("b_case_id", readCase.getCaseId());
-        Assert.assertEquals(2, caseStorage.getNumRecords());
+        assertEquals(2, caseStorage.getNumRecords());
 
         int id = caseStorage.add(c);
-        Assert.assertEquals(3, caseStorage.getNumRecords());
+        assertEquals(3, caseStorage.getNumRecords());
         readCase = caseStorage.getRecordForValue("case-id", "c_case_id");
         assertEquals(id, readCase.getID());
-        Assert.assertEquals(caseStorage.getIDsForValue("case-type", "case_type_ipsum").size(), 3);
+        assertEquals(caseStorage.getIDsForValue("case-type", "case_type_ipsum").size(), 3);
 
         caseStorage.remove(1);
 
-        Assert.assertEquals(2, caseStorage.getNumRecords());
+        assertEquals(2, caseStorage.getNumRecords());
         try {
             caseStorage.read(1);
-            org.junit.Assert.fail();
+            fail();
         } catch (NullPointerException e) {
             //good
         }
@@ -125,7 +124,7 @@ public class SqlStorageIndexedTests {
 
         caseStorage.removeAll();
 
-        Assert.assertEquals(0, caseStorage.getNumRecords());
+        assertEquals(0, caseStorage.getNumRecords());
     }
 
     @Test
@@ -148,7 +147,7 @@ public class SqlStorageIndexedTests {
             Vector ids = ledgerStorage.getIDsForValue("entity_id", "ledger_entity_id");
 
             assertEquals(1, ids.size());
-            assertTrue(String.format("ID Set: %s did not contain 1", ids.toString()), ids.contains(1));
+            assertTrue(ids.contains(1), String.format("ID Set: %s did not contain 1", ids.toString()));
 
             Ledger readLedger2 = ledgerStorage.getRecordForValue("entity_id", "ledger_entity_id_3");
             assertEquals(readLedger2.getID(), 3);
@@ -158,13 +157,13 @@ public class SqlStorageIndexedTests {
             assertEquals(count, 3);
 
             assertTrue(ledgerStorage.exists(1));
-            TestCase.assertFalse(ledgerStorage.exists(-123));
+            assertFalse(ledgerStorage.exists(-123));
 
             IStorageIterator<Ledger> mIterator = ledgerStorage.iterate();
 
-            Assert.assertEquals(1, mIterator.nextID());
-            Assert.assertEquals(2, mIterator.nextID());
-            Assert.assertEquals(3, mIterator.nextID());
+            assertEquals(1, mIterator.nextID());
+            assertEquals(2, mIterator.nextID());
+            assertEquals(3, mIterator.nextID());
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -172,7 +171,7 @@ public class SqlStorageIndexedTests {
         }
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws SQLException {
         if(sandbox != null) {
             sandbox.getConnection().close();

--- a/src/test/java/org/commcare/formplayer/tests/sandbox/UserSqlSandboxTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/sandbox/UserSqlSandboxTest.java
@@ -1,19 +1,18 @@
 package org.commcare.formplayer.tests.sandbox;
 
 import org.commcare.core.parse.ParseUtils;
+import org.commcare.formplayer.sandbox.UserSqlSandbox;
+import org.commcare.formplayer.sqlitedb.UserDB;
 import org.javarosa.core.api.ClassNameHasher;
 import org.javarosa.core.model.User;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.commcare.formplayer.sandbox.UserSqlSandbox;
-import org.commcare.formplayer.sqlitedb.UserDB;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for the SqlSandsbox API. Just initializes and makes sure we can access at the moment.
@@ -25,7 +24,7 @@ public class UserSqlSandboxTest {
     private UserSqlSandbox sandbox;
     private final String username = "sandbox-test-user";
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         new UserDB("a", "b", null).deleteDatabaseFolder();
 
@@ -42,14 +41,14 @@ public class UserSqlSandboxTest {
     @Test
     public void test() throws Exception {
         sandbox = new UserSqlSandbox(new UserDB("a", "b", null));
-        Assert.assertEquals(sandbox.getCaseStorage().getNumRecords(), 6);
-        Assert.assertEquals(sandbox.getLedgerStorage().getNumRecords(), 3);
-        Assert.assertEquals(sandbox.getUserFixtureStorage().getNumRecords(), 4);
+        assertEquals(sandbox.getCaseStorage().getNumRecords(), 6);
+        assertEquals(sandbox.getLedgerStorage().getNumRecords(), 3);
+        assertEquals(sandbox.getUserFixtureStorage().getNumRecords(), 4);
         User loggedInUser = sandbox.getLoggedInUser();
         assertEquals(loggedInUser.getUsername(), "test");
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws SQLException {
         sandbox.getConnection().close();
         new UserDB("a", "b", null).deleteDatabaseFolder();

--- a/src/test/java/org/commcare/formplayer/utils/DbTestUtils.java
+++ b/src/test/java/org/commcare/formplayer/utils/DbTestUtils.java
@@ -6,7 +6,7 @@ import org.javarosa.xpath.expr.FunctionUtils;
 import org.javarosa.xpath.expr.XPathExpression;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by willpride on 3/8/17.
@@ -16,6 +16,6 @@ public class DbTestUtils {
         XPathExpression expr;
         expr = XPathParseTool.parseXPath(xpath);
         String result = FunctionUtils.toString(expr.eval(ec));
-        assertEquals("XPath: " + xpath, expectedValue, result);
+        assertEquals(expectedValue, result, "XPath: " + xpath);
     }
 }

--- a/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
+++ b/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
@@ -3,13 +3,15 @@ package org.commcare.formplayer.utils;
 import org.commcare.formplayer.application.SQLiteProperties;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
 import org.commcare.formplayer.tests.BaseTestClass;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 
 import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**
@@ -25,7 +27,7 @@ import java.io.File;
  *
  * @author ctsims
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class GenerateSnapshotDatabases extends BaseTestClass {
 
@@ -33,6 +35,7 @@ public class GenerateSnapshotDatabases extends BaseTestClass {
     public static String snapshotDbDirectory = "src/test/resources/snapshot/";
 
     @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         configureRestoreFactory("snapshot", "snapshot_test");
@@ -60,7 +63,7 @@ public class GenerateSnapshotDatabases extends BaseTestClass {
 
             //ensure the landing zone is clear
             if (new File(SQLiteProperties.getDataDir()).exists()) {
-                Assert.fail("Couldn't remove existing snapshot assets");
+                fail("Couldn't remove existing snapshot assets");
             }
             syncDb();
             doInstall("sandbox_reference/snapshot.json");

--- a/src/test/java/tests/RequestResponseLoggingFilterTest.java
+++ b/src/test/java/tests/RequestResponseLoggingFilterTest.java
@@ -4,14 +4,13 @@ import org.commcare.formplayer.application.RequestResponseLoggingFilter;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.apache.commons.logging.Log;
 import org.json.JSONObject;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.commcare.formplayer.util.FormplayerHttpRequest;
 import org.commcare.formplayer.utils.TestContext;
 
@@ -23,13 +22,13 @@ import java.io.IOException;
 
 import static org.mockito.Mockito.*;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
 public class RequestResponseLoggingFilterTest {
 
     Log log = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.log = mock(Log.class);
     }


### PR DESCRIPTION
@dimagi/formplayer 
Make tests use Junit5

Junit4 has been removed removed from spring 2.4 (we're on 2.2). We will still have to include the dependency since commcare-core requires Junit4

I'm not sure if we can upgrade commcare-core to Junit5 since it's used by commcare-android which also uses Junit4 and can't be upgraded easily to 5 because of some of the test tools it makes use of.