### PR TITLE
add column to form session table to replace incorrectly typed columns

### DIFF
--- a/src/main/java/org/commcare/formplayer/configuration/JpaAuditConfiguration.java
+++ b/src/main/java/org/commcare/formplayer/configuration/JpaAuditConfiguration.java
@@ -1,0 +1,28 @@
+package org.commcare.formplayer.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+/**
+ * This class is required to enable auditing features in JPA.
+ * Currently we only use this for tracking creation dates
+ * on models.
+ */
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+public class JpaAuditConfiguration {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAware<String>() {
+            @Override
+            public Optional<String> getCurrentAuditor() {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/src/main/java/org/commcare/formplayer/db/migration/V19__form_session_correctly_typed_fields.java
+++ b/src/main/java/org/commcare/formplayer/db/migration/V19__form_session_correctly_typed_fields.java
@@ -1,0 +1,14 @@
+package org.commcare.formplayer.db.migration;
+
+import java.util.Arrays;
+
+public class V19__form_session_correctly_typed_fields extends BaseFormplayerMigration {
+
+    @Override
+    public Iterable<String> getSqlStatements() {
+        return Arrays.asList(
+                "ALTER TABLE formplayer_sessions ADD COLUMN datecreated timestamp with time zone",
+                "CREATE INDEX ON formplayer_sessions (datecreated)",
+        );
+    }
+}

--- a/src/main/java/org/commcare/formplayer/db/migration/V19__form_session_correctly_typed_fields.java
+++ b/src/main/java/org/commcare/formplayer/db/migration/V19__form_session_correctly_typed_fields.java
@@ -9,6 +9,7 @@ public class V19__form_session_correctly_typed_fields extends BaseFormplayerMigr
         return Arrays.asList(
                 "ALTER TABLE formplayer_sessions ADD COLUMN datecreated timestamp with time zone",
                 "CREATE INDEX ON formplayer_sessions (datecreated)",
+                "ALTER TABLE formplayer_sessions ADD COLUMN version integer"
         );
     }
 }

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -1,9 +1,12 @@
 package org.commcare.formplayer.objects;
 
 import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.Map;
 
 /**
@@ -11,6 +14,7 @@ import java.util.Map;
  */
 @Entity
 @Table(name = "formplayer_sessions")
+@EntityListeners(AuditingEntityListener.class)
 public class SerializableFormSession implements Serializable{
     @Id
     @GeneratedValue( generator = "uuid" )
@@ -45,8 +49,13 @@ public class SerializableFormSession implements Serializable{
     private String menuSessionId;
     private String title;
 
+    // legacy field to be removed once `dateCreated` is fully populated
     @Column(name="dateopened")
     private String dateOpened;
+
+    @CreatedDate
+    @Column(name="datecreated")
+    private Instant dateCreated;
 
     @Column(name="onequestionperscreen")
     private boolean oneQuestionPerScreen;
@@ -240,4 +249,13 @@ public class SerializableFormSession implements Serializable{
             sequenceId += 1;
         }
     }
+
+    public Instant getDateCreated() {
+        return dateCreated;
+    }
+
+    public void setDateCreated(Date dateCreated) {
+        this.dateCreated = dateCreated;
+    }
+
 }

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -21,6 +21,9 @@ public class SerializableFormSession implements Serializable{
     @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
     private String id;
 
+    @Version
+    private int version;
+
     @Column(name="instancexml")
     private String instanceXml;
 
@@ -254,8 +257,7 @@ public class SerializableFormSession implements Serializable{
         return dateCreated;
     }
 
-    public void setDateCreated(Date dateCreated) {
-        this.dateCreated = dateCreated;
+    public int getVersion() {
+        return version;
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -57,8 +57,10 @@ public class FormSessionRepoTest {
         assertThat(loaded).usingRecursiveComparison().ignoringFields("dateCreated", "version").isEqualTo(session);
         Instant dateCreated = loaded.getDateCreated();
         assertThat(dateCreated).isNotNull();
+        assertThat(loaded.getVersion()).isEqualTo(1);
 
         formSessionRepo.saveAndFlush(loaded);
         assertThat(loaded.getDateCreated()).isEqualTo(dateCreated);
+        assertThat(loaded.getVersion()).isEqualTo(2);
     }
 }

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -1,7 +1,6 @@
 package org.commcare.formplayer.repo;
 
 import com.google.common.collect.ImmutableMap;
-
 import org.commcare.formplayer.objects.FunctionHandler;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.utils.JpaTestUtils;
@@ -9,15 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-import java.util.Date;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import javax.persistence.EntityManager;
+import java.time.Instant;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnableJpaAuditing
 public class FormSessionRepoTest {
 
     @Autowired
@@ -53,6 +54,11 @@ public class FormSessionRepoTest {
         SerializableFormSession loaded = JpaTestUtils.unwrapProxy(
                 formSessionRepo.getOne(session.getId())
         );
-        assertThat(loaded).usingRecursiveComparison().isEqualTo(session);
+        assertThat(loaded).usingRecursiveComparison().ignoringFields("dateCreated", "version").isEqualTo(session);
+        Instant dateCreated = loaded.getDateCreated();
+        assertThat(dateCreated).isNotNull();
+
+        formSessionRepo.saveAndFlush(loaded);
+        assertThat(loaded.getDateCreated()).isEqualTo(dateCreated);
     }
 }


### PR DESCRIPTION
* `dateOpened` is a date but stored in the DB as a string with a very unhelpful format "Wed Feb 10 17:44:59 SAST 2021"
  * replace it with an auto-generated timestamp column that stores UTC time
* `sequenceId` is an integer but saved in the DB as a string
  * replace it with an auto-incremented `version` column
  * this has the added benefit of providing [optimistic locking](https://docs.jboss.org/hibernate/orm/5.4/userguide/html_single/Hibernate_User_Guide.html#locking-optimistic)
 