### PR TITLE
Record distribution timings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation group: 'redis.clients', name: 'jedis'
 
     //Unmanaged Dependencies
-    implementation group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.3'
+    implementation group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '2.11.0'
     implementation group: 'io.sentry', name: 'sentry', version: '1.7.28'
     implementation group: 'org.apache.directory.studio', name: 'org.apache.commons.io', version: '2.4'
     implementation group: 'org.json', name: 'json', version: '20201115'

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -100,7 +100,7 @@ public class MetricsAspect {
 
         datadog.increment(Constants.DATADOG_REQUESTS, datadogArgs);
         datadog.recordExecutionTime(Constants.DATADOG_TIMINGS, timer.durationInMs(), datadogArgs);
-
+        datadog.recordDistribution(Constants.DATADOG_DISTRIBUTION_TIMINGS, timer.durationInMs(), datadogArgs);
 
         long intolerableRequestThreshold = 60 * 1000;
 

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -117,6 +117,7 @@ public class Constants {
     // Datadog metrics
     public static final String DATADOG_REQUESTS = "requests";
     public static final String DATADOG_TIMINGS = "timings";
+    public static final String DATADOG_DISTRIBUTION_TIMINGS = "distribution.timings";
     public static final String DATADOG_GRANULAR_TIMINGS = "granular.timings";
     public static final String DATADOG_RESTORE_COUNT = "restore.count";
 

--- a/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
@@ -60,6 +60,12 @@ public class FormplayerDatadog {
         datadogClient.increment(aspect, datadogTags);
     }
 
+    public void recordDistribution(String aspect, final long value, List<Tag> additionalTags) {
+        List<String> tagsToSend = formattedTags(additionalTags);
+        String[] datadogTags = tagsToSend.toArray(new String[tagsToSend.size()]);
+        datadogClient.recordDistributionValue(aspect, value, datadogTags);
+    }
+
     // Private Helpers
     private List<String> formattedTags(List<Tag> transientTags) {
         List<String> formattedTags = new ArrayList<>();


### PR DESCRIPTION
Datadog's [distribution](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution) metric would allow us to choose between various percentiles in datadog rather than relying on config file changes. This PR adds a distribution type metric for formplayer request timings. For more information on the datadog client, see [here](https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/StatsDClient.java#L508-L524).

Note this also upgrades the [java datadog client](https://github.com/DataDog/java-dogstatsd-client/blob/master/CHANGELOG.md) to 2.11.0.