### PR TITLE
fix session list view for old sessions (with 'null' version)

### DIFF
--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -22,7 +22,7 @@ public class SerializableFormSession implements Serializable{
     private String id;
 
     @Version
-    private int version;
+    private Integer version;
 
     @Column(name="instancexml")
     private String instanceXml;
@@ -257,7 +257,7 @@ public class SerializableFormSession implements Serializable{
         return dateCreated;
     }
 
-    public int getVersion() {
+    public Integer getVersion() {
         return version;
     }
 }

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -2,8 +2,10 @@ package org.commcare.formplayer.repo;
 
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -14,4 +16,14 @@ public interface FormSessionRepo extends JpaRepository<SerializableFormSession, 
         nativeQuery = true
     )
     List<SerializableFormSession> findUserSessions(@Param("username") String username);
+
+    /**
+     * @deprecated: remove this once the ``version`` column is fully populated
+     * @param id
+     */
+    @Deprecated
+    @Transactional
+    @Modifying
+    @Query(value = "DELETE SerializableFormSession WHERE id = :id")
+    void deleteSessionById(@Param("id") String id);
 }

--- a/src/main/java/org/commcare/formplayer/services/FormSessionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormSessionService.java
@@ -98,6 +98,8 @@ public class FormSessionService {
 
     @CacheEvict
     public void deleteSessionById(String id) {
-        formSessionRepo.deleteById(id);
+        // Replace code below with this line once the 'version' column is fully populated.
+        //  formSessionRepo.deleteById(id);
+        formSessionRepo.deleteSessionById(id);
     }
 }

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -9,10 +9,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.persistence.EntityManager;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,6 +30,9 @@ public class FormSessionRepoTest {
 
     @Autowired
     private EntityManager entityManager;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     public void testSaveAndLoad() {
@@ -62,5 +69,23 @@ public class FormSessionRepoTest {
         formSessionRepo.saveAndFlush(loaded);
         assertThat(loaded.getDateCreated()).isEqualTo(dateCreated);
         assertThat(loaded.getVersion()).isEqualTo(2);
+    }
+
+    /**
+     * Test that the session is deleted correctly even if ``version`` is null
+     * as is the case with legacy data.
+     */
+    @Test
+    public void testDeleteSession__nullVersion() {
+        SerializableFormSession session = new SerializableFormSession();
+        session.incrementSequence();
+        formSessionRepo.saveAndFlush(session);
+        entityManager.clear();
+
+        jdbcTemplate.update("update formplayer_sessions set version = null where id = ?", session.getId());
+        formSessionRepo.deleteSessionById(session.getId());
+
+        Optional<SerializableFormSession> byId = formSessionRepo.findById(session.getId());
+        assertThat(byId).isEmpty();
     }
 }


### PR DESCRIPTION
The addition of the `version` column has caused two bugs in the session list view:
* null values caused null pointer exception since the type of `version` was `int`
* deleting old sessions did not work as the DB layer interpreted the `null` version as meaning the model was not saved

QA also found this bug on staging: https://dimagi-dev.atlassian.net/browse/QA-2589