### PR TITLE
Revert "Revert "only update changing fields when saving form sessions""

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 plugins {
     id 'org.springframework.boot' version '2.2.0.RELEASE'
     id "com.gorylenko.gradle-git-properties" version "2.2.4"
+    id "io.freefair.lombok" version "5.3.0"
 }
 
 springBoot {

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.objects;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -7,242 +9,147 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Date;
 import java.util.Map;
 
-/**
- * Created by willpride on 1/19/16.
- */
 @Entity
-@Table(name = "formplayer_sessions")
+@Table(name="formplayer_sessions")
 @EntityListeners(AuditingEntityListener.class)
 public class SerializableFormSession implements Serializable{
+    @Getter
     @Id
-    @GeneratedValue( generator = "uuid" )
-    @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
+    @GeneratedValue( generator="uuid" )
+    @GenericGenerator(name="uuid", strategy="org.hibernate.id.UUIDGenerator")
     private String id;
 
+    @Getter
     @Version
     private Integer version;
 
-    @Column(name="instancexml")
-    private String instanceXml;
-
-    @Column(name="formxml")
-    private String formXml;
-
-    private String username;
-
-    @Column(name="initlang")
-    private String initLang;
-
-    @Column(name="sequenceid")
-    @Convert(converter = IntStringConverter.class)
-    private Integer sequenceId;
-
-    @Column(name="sessiondata")
-    @Convert(converter = ByteArrayConverter.class)
-    private Map<String, String> sessionData;
-
-    private String domain;
-
-    @Column(name="posturl")
-    private String postUrl;
-
-    @Column(name="menu_session_id")
-    private String menuSessionId;
-    private String title;
-
-    // legacy field to be removed once `dateCreated` is fully populated
-    @Column(name="dateopened")
+    /**
+     * Deprecated: to be removed once `dateCreated` is fully populated
+     */
+    @Getter
+    @Column(name="dateopened", updatable=false)
     private String dateOpened;
 
+    @Getter
     @CreatedDate
     @Column(name="datecreated")
     private Instant dateCreated;
 
-    @Column(name="onequestionperscreen")
-    private boolean oneQuestionPerScreen;
+    @Getter
+    @Column(updatable=false)
+    private String domain;
 
-    @Column(name="asuser")
+    @Getter
+    @Column(name="asuser", updatable=false)
     private String asUser;
 
-    @Column(name="currentindex")
-    private String currentIndex = "0";
-
-    @Column(name="appid")
+    @Getter
+    @Column(name="appid", updatable=false)
     private String appId;
 
+    @Getter
+    @Column(name="caseid", updatable=false)
+    private String restoreAsCaseId;
+
+    @Getter
+    @Column(name="posturl", updatable=false)
+    private String postUrl;
+
+    @Getter
+    @Column(name="menu_session_id", updatable=false)
+    private String menuSessionId;
+
+    @Getter
+    @Column(updatable=false)
+    private String title;
+
+    @Getter
+    @Column(name="onequestionperscreen", updatable=false)
+    private boolean oneQuestionPerScreen;
+
+    @Getter
+    @Setter
+    @Column(name="formxml", updatable=false)
+    private String formXml;
+
+    @Getter
+    @Setter
+    @Column(name="instancexml")
+    private String instanceXml;
+
+    @Getter
+    @Column(updatable=false)
+    private String username;
+
+    @Getter
+    @Setter
+    @Column(name="initlang")
+    private String initLang;
+
+    /**
+     * Deprecated. To be replaced by ``version``
+     */
+    @Getter
+    @Column(name="sequenceid")
+    @Convert(converter=IntStringConverter.class)
+    private Integer sequenceId;
+
+    @Getter
+    @Column(name="sessiondata")
+    @Convert(converter=ByteArrayConverter.class)
+    private Map<String, String> sessionData;
+
+    @Getter
+    @Setter
+    @Column(name="currentindex")
+    private String currentIndex;
+
+    @Getter
     @Column(name="functioncontext")
-    @Convert(converter = ByteArrayConverter.class)
+    @Convert(converter=ByteArrayConverter.class)
     private Map<String, FunctionHandler[]> functionContext;
 
+    @Getter
     @Column(name="inpromptmode")
     private boolean inPromptMode;
-
-    @Column(name="caseid")
-    private String restoreAsCaseId;
 
     public SerializableFormSession() { }
     public SerializableFormSession(String id) {
         this.id = id;
     }
 
-    public String getInstanceXml() {
-        return instanceXml;
-    }
-
-    public void setInstanceXml(String instanceXml) {
-        this.instanceXml = instanceXml;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    @Override
-    public String toString(){
-        return "Session [id=" + id + ", sequence=" + sequenceId + ", username=" + username
-                + " domain=" + domain + ", instance=" + instanceXml + "]";
-    }
-
-    public String getFormXml() {
-        return formXml;
-    }
-
-    public void setFormXml(String formXml) {
-        this.formXml = formXml;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getInitLang() {
-        return initLang;
-    }
-
-    public void setInitLang(String initLang) {
-        this.initLang = initLang;
-    }
-
-    public int getSequenceId() {
-        return sequenceId;
-    }
-
-    public void setSequenceId(int sequenceId) {
-        this.sequenceId = sequenceId;
-    }
-
-    public Map<String, String> getSessionData() {
-        return sessionData;
-    }
-
-    public void setSessionData(Map<String, String> sessionData) {
-        this.sessionData = sessionData;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(String domain) {
+    public SerializableFormSession(
+            String domain,
+            String appId,
+            String username,
+            String asUser,
+            String restoreAsCaseId,
+            String postUrl,
+            String menuSessionId,
+            String title,
+            boolean oneQuestionPerScreen,
+            String initLang,
+            boolean inPromptMode,
+            Map<String, String> sessionData,
+            Map<String, FunctionHandler[]> functionContext) {
         this.domain = domain;
-    }
-
-    public void setPostUrl(String postUrl) {
-        this.postUrl = postUrl;
-    }
-
-    public String getPostUrl() {
-        return postUrl;
-    }
-
-    public String getMenuSessionId() {
-        return menuSessionId;
-    }
-
-    public void setMenuSessionId(String menuSessionId) {
-        this.menuSessionId = menuSessionId;
-    }
-
-    public String getDateOpened() {
-        return dateOpened;
-    }
-
-    public void setDateOpened(String dateOpened) {
-        this.dateOpened = dateOpened;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public boolean getOneQuestionPerScreen() {
-        return oneQuestionPerScreen;
-    }
-
-    public void setOneQuestionPerScreen(boolean oneQuestionPerScreen) {
-        this.oneQuestionPerScreen = oneQuestionPerScreen;
-    }
-
-    public String getCurrentIndex() {
-        return currentIndex;
-    }
-
-    public void setCurrentIndex(String currentIndex) {
-        this.currentIndex = currentIndex;
-    }
-
-    public String getAsUser() {
-        return asUser;
-    }
-
-    public void setAsUser(String asUser) {
         this.asUser = asUser;
-    }
-
-    public String getAppId() {
-        return appId;
-    }
-
-    public void setAppId(String appId) {
         this.appId = appId;
-    }
-
-    public Map<String, FunctionHandler[]> getFunctionContext() {
-        return functionContext;
-    }
-
-    public void setFunctionContext(Map<String, FunctionHandler[]> functionContext) {
-        this.functionContext = functionContext;
-    }
-
-    public boolean getInPromptMode() {
-        return inPromptMode;
-    }
-
-    public void setInPromptMode(boolean inPromptMode) {
-        this.inPromptMode = inPromptMode;
-    }
-
-    public void setRestoreAsCaseId(String restoreAsCaseId) {
         this.restoreAsCaseId = restoreAsCaseId;
-    }
-
-    public String getRestoreAsCaseId() {
-        return restoreAsCaseId;
+        this.postUrl = postUrl;
+        this.menuSessionId = menuSessionId;
+        this.title = title;
+        this.oneQuestionPerScreen = oneQuestionPerScreen;
+        this.username = username;
+        this.initLang = initLang;
+        this.sessionData = sessionData;
+        this.functionContext = functionContext;
+        this.inPromptMode = inPromptMode;
+        this.dateOpened = new Date().toString();
+        this.currentIndex = "0";
     }
 
     public void incrementSequence() {
@@ -253,11 +160,9 @@ public class SerializableFormSession implements Serializable{
         }
     }
 
-    public Instant getDateCreated() {
-        return dateCreated;
-    }
-
-    public Integer getVersion() {
-        return version;
+    @Override
+    public String toString(){
+        return "Session [id=" + id + ", sequence=" + sequenceId + ", username=" + username
+                + " domain=" + domain + ", instance=" + instanceXml + "]";
     }
 }

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -95,7 +95,8 @@ public class FormSession {
         loadInstanceXml(formDef, session.getInstanceXml());
         formDef.setSendCalloutHandler(formSendCalloutHandler);
         setupJavaRosaObjects();
-        if (session.getOneQuestionPerScreen() || session.getInPromptMode()) {
+
+        if (session.isOneQuestionPerScreen() || session.isInPromptMode()) {
             FormIndex formIndex = JsonActionUtils.indexFromString(session.getCurrentIndex(), this.formDef);
             formController.jumpToIndex(formIndex);
             formEntryModel.setQuestionIndex(JsonActionUtils.indexFromString(session.getCurrentIndex(), formDef));
@@ -123,22 +124,11 @@ public class FormSession {
                        String caseId) throws Exception {
 
         this.formDef = formDef;
-        session = new SerializableFormSession();
-        session.setUsername(TableBuilder.scrubName(username));
-        session.setInitLang(locale);
-        session.setDomain(domain);
-        session.setTitle(formDef.getTitle());
-        session.setDateOpened(new Date().toString());
-        session.setOneQuestionPerScreen(oneQuestionPerScreen);
-        session.setCurrentIndex("0");
-        session.setAsUser(asUser);
-        session.setAppId(appId);
-        session.setMenuSessionId(menuSessionId);
-        session.setPostUrl(postUrl);
-        session.setSessionData(sessionData);
-        session.setInPromptMode(inPromptMode);
-        session.setFunctionContext(functionContext);
-        session.setRestoreAsCaseId(caseId);
+        session = new SerializableFormSession(
+                domain, appId, TableBuilder.scrubName(username), asUser, caseId,
+                postUrl, menuSessionId, formDef.getTitle(), oneQuestionPerScreen,
+                locale, inPromptMode, sessionData, functionContext
+        );
 
         formDef.setSendCalloutHandler(formSendCalloutHandler);
         this.sandbox = sandbox;
@@ -324,7 +314,7 @@ public class FormSession {
     }
 
     public JSONArray getFormTree() {
-        if (session.getOneQuestionPerScreen()) {
+        if (session.isOneQuestionPerScreen()) {
             return JsonActionUtils.getOneQuestionPerScreenJSON(formController.getFormEntryController().getModel(),
                     formController.getFormEntryController(),
                     formController.getFormIndex());
@@ -494,13 +484,13 @@ public class FormSession {
                 formEntryModel,
                 answer != null ? answer.toString() : null,
                 answerIndex,
-                session.getOneQuestionPerScreen(),
+                session.isOneQuestionPerScreen(),
                 session.getCurrentIndex(),
                 false,
                 true);
 
         FormEntryResponseBean response = new ObjectMapper().readValue(jsonObject.toString(), FormEntryResponseBean.class);
-        if (!session.getInPromptMode() || !Constants.ANSWER_RESPONSE_STATUS_POSITIVE.equals(response.getStatus())) {
+        if (!session.isInPromptMode() || !Constants.ANSWER_RESPONSE_STATUS_POSITIVE.equals(response.getStatus())) {
             return response;
         }
         return getNextFormNavigation();

--- a/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
@@ -84,23 +84,23 @@ public class FormSessionServiceTest {
 
         // save a session
         SerializableFormSession session = new SerializableFormSession(sessionId);
-        session.setSequenceId(1);
+        session.incrementSequence();
         formSessionService.saveSession(session);
 
         // cache is populated on save
-        assertEquals(1, getCachedSession(sessionId).get().getSequenceId());
+        assertEquals(0, getCachedSession(sessionId).get().getSequenceId());
 
         // get session hits the cache (repo is mocked)
         session = formSessionService.getSessionById(sessionId);
-        assertEquals(1, session.getSequenceId());
+        assertEquals(0, session.getSequenceId());
 
         // update session
-        session.setSequenceId(2);
+        session.incrementSequence();
         formSessionService.saveSession(session);
 
         // cache and find return updated session
-        assertEquals(2, getCachedSession(sessionId).get().getSequenceId());
-        assertEquals(2, formSessionService.getSessionById(sessionId).getSequenceId());
+        assertEquals(1, getCachedSession(sessionId).get().getSequenceId());
+        assertEquals(1, formSessionService.getSessionById(sessionId).getSequenceId());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -35,6 +35,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.integration.support.locks.LockRegistry;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -208,7 +209,7 @@ public class BaseTestClass {
                 SerializableFormSession session = (SerializableFormSession) invocation.getArguments()[0];
                 if (session.getId() == null) {
                     // this is normally taken care of by Hibernate
-                    session.setId(UUID.randomUUID().toString());
+                    ReflectionTestUtils.setField(session,"id",UUID.randomUUID().toString());
                 }
                 sessionMap.put(session.getId(), session);
                 return session;


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-690

* Setting [updatable=false](https://www.objectdb.com/api/java/jpa/Column/updatable) on the fields tells the DB layer that it shouldn't include those fields in update statements.
  * fields that get updated are: `sequenceId`, `version`, `currentIndex`, `instanceXml`, `initLang` (locale) 
* Refactor the model to more accurately reflect it's usage and use [Lombok](https://projectlombok.org/features/GetterSetter) to auto generate the required getters and setters