### PR TITLE
check domain access for session auth

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormplayerAuthFilter.java
+++ b/src/main/java/org/commcare/formplayer/application/FormplayerAuthFilter.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.application;
 
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.FormNotFoundException;
+import org.commcare.formplayer.exceptions.SessionAuthException;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.apache.commons.lang3.StringUtils;
@@ -127,9 +128,9 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
 
             try {
                 setUserDetails(request);
-            } catch(SessionAuthUnavailableException saue) {
-                throw AuthorizationFailureException.AuthFailed("User session unavailable",
-                        HttpServletResponse.SC_UNAUTHORIZED);
+            } catch(SessionAuthException saue) {
+                throw AuthorizationFailureException.AuthFailed("Use session authentication failed.",
+                        saue.getResponseCode());
             }
             JSONObject data = RequestUtils.getPostData(request);
 
@@ -205,7 +206,7 @@ public class FormplayerAuthFilter extends OncePerRequestFilter {
         request.setUserDetails(userDetailsBean);
     }
 
-    private void setUserDetails(FormplayerHttpRequest request) {
+    private void setUserDetails(FormplayerHttpRequest request) throws SessionAuthException {
         request.setUserDetails(userDetailsService.getUserDetails(request.getDomain(), getSessionId(request)));
 
     }

--- a/src/main/java/org/commcare/formplayer/exceptions/SessionAuthException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/SessionAuthException.java
@@ -1,0 +1,16 @@
+package org.commcare.formplayer.exceptions;
+
+/**
+ * Thrown when the CommCare session details view returns a 403 response
+ */
+public class SessionAuthException extends Exception {
+    private int responseCode;
+
+    public SessionAuthException(int responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/exceptions/SessionAuthForbiddenException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/SessionAuthForbiddenException.java
@@ -1,0 +1,12 @@
+package org.commcare.formplayer.exceptions;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Thrown when the CommCare session details view returns a 403 response
+ */
+public class SessionAuthForbiddenException extends SessionAuthException {
+    public SessionAuthForbiddenException() {
+        super(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/org/commcare/formplayer/exceptions/SessionAuthUnavailableException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/SessionAuthUnavailableException.java
@@ -1,8 +1,14 @@
 package org.commcare.formplayer.exceptions;
 
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Thrown when FormPlayer identifies that the user's authentication is
  * unavailable and they will need a new session to continue
  */
-public class SessionAuthUnavailableException extends RuntimeException {
+public class SessionAuthUnavailableException extends SessionAuthException {
+
+    public SessionAuthUnavailableException() {
+        super(HttpServletResponse.SC_BAD_REQUEST);
+    }
 }

--- a/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
+++ b/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
@@ -6,6 +6,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.formplayer.beans.auth.HqSessionKeyBean;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.exceptions.SessionAuthException;
+import org.commcare.formplayer.exceptions.SessionAuthForbiddenException;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
 import org.commcare.formplayer.exceptions.UserDetailsException;
 import org.commcare.formplayer.util.Constants;
@@ -17,6 +19,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 
 @Service
 public class HqUserDetailsService {
@@ -34,7 +39,7 @@ public class HqUserDetailsService {
     @Autowired
     private RestTemplate restTemplate;
 
-    public HqUserDetailsBean getUserDetails(String domain, String sessionKey) {
+    public HqUserDetailsBean getUserDetails(String domain, String sessionKey) throws SessionAuthException {
         HttpHeaders headers = new HttpHeaders();
         String data = null;
         try {
@@ -50,6 +55,8 @@ public class HqUserDetailsService {
             return userDetails;
         } catch(HttpClientErrorException.NotFound nfe) {
             throw new SessionAuthUnavailableException();
+        } catch (HttpClientErrorException.Forbidden ex) {
+            throw new SessionAuthForbiddenException();
         }
     }
 


### PR DESCRIPTION
Currently there is no domain access check in either the Formplayer auth or the CommCare session details API.

This PR adds a domain check to the session details service.

PR to add a similar check on the CommCare side is on its way.

https://dimagi-dev.atlassian.net/browse/SAAS-11862