### PR TITLE
limit form sessions returned by incomplete session view to those of the correct domain & login user

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/IncompleteSessionController.java
+++ b/src/main/java/org/commcare/formplayer/application/IncompleteSessionController.java
@@ -43,7 +43,9 @@ public class IncompleteSessionController extends AbstractBaseController{
                                            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
         String scrubbedUsername = TableBuilder.scrubName(getSessionRequest.getUsername());
 
-        List<FormSessionListView> formplayerSessions = formSessionService.getSessionsForUser(scrubbedUsername);
+        List<FormSessionListView> formplayerSessions = formSessionService.getSessionsForUser(
+                scrubbedUsername, getSessionRequest.getDomain()
+        );
 
         ArrayList<FormSessionListView> sessions = new ArrayList<>();
         Set<String> formplayerSessionIds = new HashSet<>();

--- a/src/main/java/org/commcare/formplayer/application/IncompleteSessionController.java
+++ b/src/main/java/org/commcare/formplayer/application/IncompleteSessionController.java
@@ -44,7 +44,7 @@ public class IncompleteSessionController extends AbstractBaseController{
         String scrubbedUsername = TableBuilder.scrubName(getSessionRequest.getUsername());
 
         List<FormSessionListView> formplayerSessions = formSessionService.getSessionsForUser(
-                scrubbedUsername, getSessionRequest.getDomain()
+                scrubbedUsername, getSessionRequest.getDomain(), getSessionRequest.getRestoreAs()
         );
 
         ArrayList<FormSessionListView> sessions = new ArrayList<>();

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -8,12 +8,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.lang.Nullable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface FormSessionRepo extends JpaRepository<SerializableFormSession, String> {
-    List<FormSessionListView> findByUsernameAndDomain(String username, String domain, Sort sort);
+    List<FormSessionListView> findByUsernameAndDomainAndAsUser(String username, String domain, String asUser, Sort sort);
+    List<FormSessionListView> findByUsernameAndDomainAndAsUserIsNull(String username, String domain, Sort sort);
 
     /**
      * @deprecated: to be removed once custom sorting is no longer required (once
@@ -23,10 +25,30 @@ public interface FormSessionRepo extends JpaRepository<SerializableFormSession, 
     @Query(
             value = "SELECT id, title, dateopened, datecreated, sessiondata " +
                     "FROM formplayer_sessions WHERE username = :username AND domain = :domain " +
+                    "AND asuser = :asuser " +
                     "ORDER BY dateopened\\:\\:timestamptz DESC",
             nativeQuery = true
     )
-    List<FormSessionListViewRaw> findUserSessions(@Param("username") String username, @Param("domain") String domain);
+    List<FormSessionListViewRaw> findUserSessionsAsUser(
+            @Param("username") String username,
+            @Param("domain") String domain,
+            @Param("asuser") String asUser);
+
+    /**
+     * @deprecated: to be removed once custom sorting is no longer required (once
+     * the dateCreated field is fully populated)
+     */
+    @Deprecated
+    @Query(
+            value = "SELECT id, title, dateopened, datecreated, sessiondata " +
+                    "FROM formplayer_sessions WHERE username = :username AND domain = :domain " +
+                    "AND asuser is null " +
+                    "ORDER BY dateopened\\:\\:timestamptz DESC",
+            nativeQuery = true
+    )
+    List<FormSessionListViewRaw> findUserSessions(
+            @Param("username") String username,
+            @Param("domain") String domain);
 /**
      * @deprecated: remove this once the ``version`` column is fully populated
      * @param id

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -14,8 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface FormSessionRepo extends JpaRepository<SerializableFormSession, String> {
-    List<FormSessionListView> findByUsernameAndDomainAndAsUser(String username, String domain, String asUser, Sort sort);
-    List<FormSessionListView> findByUsernameAndDomainAndAsUserIsNull(String username, String domain, Sort sort);
+    List<FormSessionListView> findByUsernameAndDomainAndAsUserOrderByDateCreatedDesc(String username, String domain, String asUser);
+    List<FormSessionListView> findByUsernameAndDomainAndAsUserIsNullOrderByDateCreatedDesc(String username, String domain);
 
     /**
      * @deprecated: to be removed once custom sorting is no longer required (once

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -46,7 +46,7 @@ public interface FormSessionRepo extends JpaRepository<SerializableFormSession, 
                     "ORDER BY dateopened\\:\\:timestamptz DESC",
             nativeQuery = true
     )
-    List<FormSessionListViewRaw> findUserSessions(
+    List<FormSessionListViewRaw> findUserSessionsNullAsUser(
             @Param("username") String username,
             @Param("domain") String domain);
 /**

--- a/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormSessionRepo.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface FormSessionRepo extends JpaRepository<SerializableFormSession, String> {
-    List<FormSessionListView> findByUsername(String username, Sort sort);
+    List<FormSessionListView> findByUsernameAndDomain(String username, String domain, Sort sort);
 
     /**
      * @deprecated: to be removed once custom sorting is no longer required (once
@@ -22,11 +22,11 @@ public interface FormSessionRepo extends JpaRepository<SerializableFormSession, 
     @Deprecated
     @Query(
             value = "SELECT id, title, dateopened, datecreated, sessiondata " +
-                    "FROM formplayer_sessions WHERE username = :username " +
+                    "FROM formplayer_sessions WHERE username = :username AND domain = :domain " +
                     "ORDER BY dateopened\\:\\:timestamptz DESC",
             nativeQuery = true
     )
-    List<FormSessionListViewRaw> findUserSessions(@Param("username") String username);
+    List<FormSessionListViewRaw> findUserSessions(@Param("username") String username, @Param("domain") String domain);
 /**
      * @deprecated: remove this once the ``version`` column is fully populated
      * @param id

--- a/src/main/java/org/commcare/formplayer/services/FormSessionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormSessionService.java
@@ -98,11 +98,11 @@ public class FormSessionService {
         List<FormSessionListViewRaw> userSessionsRaw;
         if (asUser == null) {
             // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
-            // return formSessionRepo.findByUsernameAndDomainAndAsUserIsNull(username, domain, Sort.by(Sort.Direction.DESC, "dateCreated"));
+            // return formSessionRepo.findByUsernameAndDomainAndAsUserIsNullOrderByDateCreatedDesc(username, domain);
             userSessionsRaw = formSessionRepo.findUserSessions(username, domain);
         } else {
             // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
-            // return formSessionRepo.findByUsernameAndDomainAndAsUser(username, domain, asUser, Sort.by(Sort.Direction.DESC, "dateCreated"));
+            // return formSessionRepo.findByUsernameAndDomainAndAsUserOrderByDateCreatedDesc(username, domain, asUser);
             userSessionsRaw = formSessionRepo.findUserSessionsAsUser(username, domain, asUser);
         }
         return userSessionsRaw.stream().map((session) -> new FormSessionListView() {

--- a/src/main/java/org/commcare/formplayer/services/FormSessionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormSessionService.java
@@ -93,11 +93,11 @@ public class FormSessionService {
         return session.get();
     }
 
-    public List<FormSessionListView> getSessionsForUser(String username) {
+    public List<FormSessionListView> getSessionsForUser(String username, String domain) {
         // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
-        // return formSessionRepo.findByUsername(username, Sort.by(Sort.Direction.DESC, "dateCreated"));
+        // return formSessionRepo.findByUsernameAndDomain(username, domain, Sort.by(Sort.Direction.DESC, "dateCreated"));
 
-        List<FormSessionListViewRaw> userSessionsRaw = formSessionRepo.findUserSessions(username);
+        List<FormSessionListViewRaw> userSessionsRaw = formSessionRepo.findUserSessions(username, domain);
         return userSessionsRaw.stream().map((session) -> new FormSessionListView() {
             @Override
             public String getId() {

--- a/src/main/java/org/commcare/formplayer/services/FormSessionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormSessionService.java
@@ -18,6 +18,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.SerializationUtils;
 
@@ -93,11 +94,17 @@ public class FormSessionService {
         return session.get();
     }
 
-    public List<FormSessionListView> getSessionsForUser(String username, String domain) {
-        // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
-        // return formSessionRepo.findByUsernameAndDomain(username, domain, Sort.by(Sort.Direction.DESC, "dateCreated"));
-
-        List<FormSessionListViewRaw> userSessionsRaw = formSessionRepo.findUserSessions(username, domain);
+    public List<FormSessionListView> getSessionsForUser(String username, String domain, @Nullable String asUser) {
+        List<FormSessionListViewRaw> userSessionsRaw;
+        if (asUser == null) {
+            // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
+            // return formSessionRepo.findByUsernameAndDomainAndAsUserIsNull(username, domain, Sort.by(Sort.Direction.DESC, "dateCreated"));
+            userSessionsRaw = formSessionRepo.findUserSessions(username, domain);
+        } else {
+            // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
+            // return formSessionRepo.findByUsernameAndDomainAndAsUser(username, domain, asUser, Sort.by(Sort.Direction.DESC, "dateCreated"));
+            userSessionsRaw = formSessionRepo.findUserSessionsAsUser(username, domain, asUser);
+        }
         return userSessionsRaw.stream().map((session) -> new FormSessionListView() {
             @Override
             public String getId() {

--- a/src/main/java/org/commcare/formplayer/services/FormSessionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormSessionService.java
@@ -99,7 +99,7 @@ public class FormSessionService {
         if (asUser == null) {
             // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
             // return formSessionRepo.findByUsernameAndDomainAndAsUserIsNullOrderByDateCreatedDesc(username, domain);
-            userSessionsRaw = formSessionRepo.findUserSessions(username, domain);
+            userSessionsRaw = formSessionRepo.findUserSessionsNullAsUser(username, domain);
         } else {
             // Replace blow code with this line once we can remove custom ordering on ``dateOpened``
             // return formSessionRepo.findByUsernameAndDomainAndAsUserOrderByDateCreatedDesc(username, domain, asUser);

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -1,6 +1,5 @@
 package org.commcare.formplayer.repo;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.commcare.formplayer.objects.FormSessionListView;
@@ -12,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.lang.Nullable;
 import org.springframework.util.SerializationUtils;
@@ -134,7 +132,7 @@ public class FormSessionRepoTest {
         String dateOpened = session.getDateOpened();
         Map<String, String> sessionData = session.getSessionData();
         formSessionRepo.save(session);
-        List<FormSessionListViewRaw> userSessions = formSessionRepo.findUserSessions("momo", "domain");
+        List<FormSessionListViewRaw> userSessions = formSessionRepo.findUserSessionsNullAsUser("momo", "domain");
         assertThat(userSessions).hasSize(1);
         assertThat(userSessions.get(0).getTitle()).isEqualTo("More Momo");
         assertThat(userSessions.get(0).getDateOpened()).isEqualTo(dateOpened);
@@ -148,11 +146,11 @@ public class FormSessionRepoTest {
     public void testGetListViewRaw_filterByDomain() {
         formSessionRepo.save(getSession("domain1", "session1"));
         formSessionRepo.save(getSession("domain2", "session2"));
-        List<FormSessionListViewRaw> userSessions = formSessionRepo.findUserSessions("momo", "domain1");
+        List<FormSessionListViewRaw> userSessions = formSessionRepo.findUserSessionsNullAsUser("momo", "domain1");
         assertThat(userSessions).hasSize(1);
         assertThat(userSessions.get(0).getTitle()).isEqualTo("session1");
 
-        userSessions = formSessionRepo.findUserSessions("momo", "domain2");
+        userSessions = formSessionRepo.findUserSessionsNullAsUser("momo", "domain2");
         assertThat(userSessions).hasSize(1);
         assertThat(userSessions.get(0).getTitle()).isEqualTo("session2");
     }
@@ -170,7 +168,7 @@ public class FormSessionRepoTest {
         assertThat(userSessions).hasSize(1);
         assertThat(userSessions.get(0).getTitle()).isEqualTo("session_user2");
 
-        userSessions = formSessionRepo.findUserSessions("momo", "domain1");
+        userSessions = formSessionRepo.findUserSessionsNullAsUser("momo", "domain1");
         assertThat(userSessions).hasSize(1);
         assertThat(userSessions.get(0).getTitle()).isEqualTo("session_momo");
     }

--- a/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
@@ -134,8 +134,8 @@ public class FormSessionServiceTest {
 
         FormSessionListViewRaw rawView = createProjection(FormSessionListViewRaw.class, backingMap);
 
-        when(formSessionRepo.findUserSessions(anyString())).thenReturn(ImmutableList.of(rawView));
-        List<FormSessionListView> sessions = formSessionService.getSessionsForUser("username");
+        when(formSessionRepo.findUserSessions(anyString(), anyString())).thenReturn(ImmutableList.of(rawView));
+        List<FormSessionListView> sessions = formSessionService.getSessionsForUser("username", "domain");
 
         HashMap<String, Object> expected = new HashMap<>(backingMap);
         expected.put("sessionData", sessionData);

--- a/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
@@ -122,6 +122,9 @@ public class FormSessionServiceTest {
         assertFalse(getCachedSession(sessionId).isPresent());
     }
 
+    /**
+     * Test that the conversion from FormSessionListViewRaw to FormSessionListView works as expected
+     */
     @Test
     public void testGetSessionsForUser() {
         ImmutableMap<String, String> sessionData = ImmutableMap.of("a", "1", "b", "2");
@@ -135,7 +138,7 @@ public class FormSessionServiceTest {
         FormSessionListViewRaw rawView = createProjection(FormSessionListViewRaw.class, backingMap);
 
         when(formSessionRepo.findUserSessions(anyString(), anyString())).thenReturn(ImmutableList.of(rawView));
-        List<FormSessionListView> sessions = formSessionService.getSessionsForUser("username", "domain");
+        List<FormSessionListView> sessions = formSessionService.getSessionsForUser("username", "domain", null);
 
         HashMap<String, Object> expected = new HashMap<>(backingMap);
         expected.put("sessionData", sessionData);

--- a/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormSessionServiceTest.java
@@ -137,7 +137,7 @@ public class FormSessionServiceTest {
 
         FormSessionListViewRaw rawView = createProjection(FormSessionListViewRaw.class, backingMap);
 
-        when(formSessionRepo.findUserSessions(anyString(), anyString())).thenReturn(ImmutableList.of(rawView));
+        when(formSessionRepo.findUserSessionsNullAsUser(anyString(), anyString())).thenReturn(ImmutableList.of(rawView));
         List<FormSessionListView> sessions = formSessionService.getSessionsForUser("username", "domain", null);
 
         HashMap<String, Object> expected = new HashMap<>(backingMap);


### PR DESCRIPTION
This PR adds filtering to the session list view query to return only sessions for the domain of the request and the 'user' + 'asUser' combination.

Confirmed with @dimagi/product that this should be fixed to only show sessions appropriate to the domain and user combo.

Can be reviewed by commit.

https://dimagi-dev.atlassian.net/browse/SAAS-11862

Extract from the ticket:

The incomplete forms list view shows all sessions for the logged in user including:

1. forms that the user completed in any domain they have access to
  * If a web user has access to multiple domains and they have incomplete forms, the list view shows all forms across all domains
  * forms that the user completed with all ‘login as’ users that they have used
2. If a user using “login as” with multiple other users, all incomplete forms across all combinations of “main” user + “login as” user will be shown.
  * This cause errors I think since the “main” user may not have access to the cases required by the incomplete form belonging to a “login as” user (see screenshot attached above showing “does not exist” text).
![image](https://user-images.githubusercontent.com/249606/108225821-f6f68d00-7144-11eb-90e8-662e78ee4b3a.png)
