### PR TITLE
add interrupt check at decompress

### DIFF
--- a/src/main/java/org/commcare/formplayer/sandbox/ArchivableFile.java
+++ b/src/main/java/org/commcare/formplayer/sandbox/ArchivableFile.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.zip.GZIPInputStream;
 
+import org.javarosa.core.model.condition.RequestAbandonedException;
 import org.commcare.formplayer.exceptions.InterruptedRuntimeException;
 import org.commcare.formplayer.exceptions.SqlArchiveLockException;
 
@@ -71,6 +72,9 @@ public class ArchivableFile extends File {
             int len;
             while ((len = gis.read(buffer)) != -1) {
                 fos.write(buffer, 0, len);
+                if (Thread.interrupted()) {
+                    throw new RequestAbandonedException();
+                }
             }
         }
     }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-10840

Followed https://github.com/dimagi/commcare-core/pull/893

A few points:
- We also have [InterruptedRuntimeException](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/exceptions/InterruptedRuntimeException.java) which might be better?
- `Thread.interrupted()` clears the interrupted status as opposed to Thread.currentThread().isInterrupted(), I can't think of why clearing it would be a problem for us, but something to think about.