### PR TITLE
Kev/distributed lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     implementation group: 'org.simpleframework', name: 'simple-xml', version: '2.7.1'
     implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-spring', version: '4.23.0'
     implementation group: 'net.javacrumbs.shedlock', name: 'shedlock-provider-jdbc-template', version: '4.23.0'
+    implementation group: 'org.redisson', name: 'redisson', version: '3.15.0'
     runtimeOnly group: 'com.github.ben-manes.caffeine', name: 'jcache', version: '2.8.8'
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Feb 15 17:39:42 EST 2021
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Feb 15 17:39:42 EST 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -127,6 +127,7 @@ public class MenuController extends AbstractBaseController {
                                                     @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
                                                     HttpServletRequest request) throws Exception {
         String[] selections = sessionNavigationBean.getSelections();
+        Thread.sleep(45000);
         MenuSession menuSession;
         menuSession = getMenuSessionFromBean(sessionNavigationBean);
         BaseResponseBean response = runnerService.advanceSessionWithSelections(

--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -21,6 +21,7 @@ import org.commcare.formplayer.repo.impl.PostgresMenuSessionRepo;
 import org.commcare.formplayer.services.BrowserValuesProvider;
 import org.commcare.formplayer.services.FormattedQuestionsService;
 import org.commcare.formplayer.services.FormplayerLockRegistry;
+import org.commcare.formplayer.services.FormplayerRedisLockRegistry;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.modern.reference.ArchiveFileRoot;
 import org.springframework.beans.factory.annotation.Value;
@@ -122,6 +123,11 @@ public class WebAppContext implements WebMvcConfigurer {
     @Bean
     public FormplayerLockRegistry userLockRegistry() {
         return new FormplayerLockRegistry();
+    }
+
+    @Bean
+    public FormplayerRedisLockRegistry userRedisLockRegistry() {
+        return new FormplayerRedisLockRegistry("S", "TEST_PREFIX_", "topic_", 1, 3);
     }
 
     @Bean

--- a/src/main/java/org/commcare/formplayer/aspects/LockAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/LockAspect.java
@@ -17,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.commcare.formplayer.services.CategoryTimingHelper;
 import org.commcare.formplayer.services.FormplayerLockRegistry;
-import org.commcare.formplayer.services.FormplayerLockRegistry.FormplayerReentrantLock;
+import org.commcare.formplayer.services.FormplayerRedisLockRegistry;
+// import org.commcare.formplayer.services.FormplayerLockRegistry.FormplayerReentrantLock;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerSentry;
 import org.commcare.formplayer.util.RequestUtils;
@@ -35,7 +36,7 @@ import java.util.concurrent.locks.Lock;
 public class LockAspect {
 
     @Autowired
-    private FormplayerLockRegistry userLockRegistry;
+    private FormplayerRedisLockRegistry userLockRegistry;
 
     @Autowired
     private StatsDClient datadogStatsDClient;
@@ -136,7 +137,7 @@ public class LockAspect {
     }
 
     private Lock getLockAndBlock(String username) throws LockError {
-        FormplayerReentrantLock lock = userLockRegistry.obtain(username);
+        Lock lock = userLockRegistry.obtain(username);
         if (obtainLock(lock)) {
             return lock;
         } else {
@@ -145,7 +146,7 @@ public class LockAspect {
         }
     }
 
-    private boolean obtainLock(FormplayerReentrantLock lock) {
+    private boolean obtainLock(Lock lock) {
         CategoryTimingHelper.RecordingTimer timer = categoryTimingHelper.newTimer(Constants.TimingCategories.WAIT_ON_LOCK);
         timer.start();
         try {

--- a/src/main/java/org/commcare/formplayer/services/FormplayerRedisLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerRedisLockRegistry.java
@@ -1,0 +1,115 @@
+package org.commcare.formplayer.services;
+
+import org.redisson.Redisson;
+import org.redisson.api.RBucket;
+import org.redisson.api.RLock;
+import org.redisson.api.RTopic;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.listener.MessageListener;
+import org.redisson.config.Config;
+import org.springframework.integration.support.locks.LockRegistry;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+public class FormplayerRedisLockRegistry implements LockRegistry {
+
+    private final RedissonClient redisson;
+    CountDownLatch latch = new CountDownLatch(1);
+
+    class LockMetadata {
+        public String lockId;
+        public String serverName = "server1";
+        public Integer serverThreadId = 14;
+
+        public LockMetadata(String lockId) {
+            this.lockId = lockId;
+        }
+    }
+
+    public FormplayerRedisLockRegistry() {
+        final Config config = new Config();
+        config.useSingleServer().setAddress("redis://127.0.0.1:6379");
+        this.redisson = Redisson.create(config);
+        RTopic topic = redisson.getTopic("topic");
+        topic.addListener(LockMetadata.class, new MessageListener<LockMetadata>() {
+            @Override
+            public void onMessage(CharSequence channel, LockMetadata lockMetadata) {
+                System.out.println("debug to be removed " + channel.toString());
+                receiveEvictMessage(lockMetadata);
+            }
+        });
+        System.out.println("debug to be removed");
+    }
+
+    @Override
+    public Lock obtain(Object lockKey) {
+        return obtain(lockKey, true);
+    }
+
+    public Lock obtain(Object lockKey, boolean writeLock) {
+        ReadWriteLock rwLock = this.redisson.getReadWriteLock(lockKey.toString());
+        if (writeLock) {
+            return rwLock.writeLock();
+        }
+        return rwLock.readLock();
+    }
+
+    public boolean obtainAndLock(Object lockKey, boolean writeLock) {
+        String lockKeyString = lockKey.toString();
+        Lock lock = this.obtain(lockKeyString, writeLock);
+
+        boolean didLock = false;
+        for (int i = 0; i < 3; i++) {
+            try {
+                didLock = lock.tryLock(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            RBucket<LockMetadata> bucket = redisson.getBucket(lockKeyString);
+            if (didLock) {
+                // TODO: Check if there is something in bucket already
+                bucket.set(new LockMetadata(lockKeyString), 100, TimeUnit.SECONDS);
+                return didLock;
+            } else {
+                LockMetadata lockMetadata = bucket.get();
+                if (lockMetadata != null) {
+                    // TODO: set time check
+                    if (true) {
+                        throw new Error("Lock currently held within lease time");
+                    } else {
+                        sendEvictMessage(lockMetadata);
+                    }
+                }
+            }
+        }
+
+        return didLock;
+    }
+
+
+
+    private void sendEvictMessage(LockMetadata lockMetadata) {
+        RTopic topic = redisson.getTopic("topic");
+        topic.publish(lockMetadata);
+    }
+
+    private void receiveEvictMessage(LockMetadata lockMetadata) {
+        // TODO: Check if severname is this server
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getId() == lockMetadata.serverThreadId) {
+                if (redisson.getLock(lockMetadata.lockId).isHeldByThread(t.getId())
+                        && t.isAlive()) {
+                    t.interrupt();
+                }
+            }
+        }
+    }
+
+
+
+
+}

--- a/src/main/java/org/commcare/formplayer/services/FormplayerRedisLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerRedisLockRegistry.java
@@ -9,39 +9,48 @@ import org.redisson.api.listener.MessageListener;
 import org.redisson.config.Config;
 import org.springframework.integration.support.locks.LockRegistry;
 
+import java.io.Serializable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 
 public class FormplayerRedisLockRegistry implements LockRegistry {
 
-    private final RedissonClient redisson;
     CountDownLatch latch = new CountDownLatch(1);
+    private static final String REDIS_TOPIC_EVICT = "EVICT";
 
-    class LockMetadata {
-        public String lockId;
-        public String serverName = "server1";
-        public Integer serverThreadId = 14;
+    private final RedissonClient redisson;
+    private final String serverName;
 
-        public LockMetadata(String lockId) {
-            this.lockId = lockId;
-        }
-    }
+    private int tryLockDurationInSeconds;
+    private int nonEvictionDurationInSeconds;
 
-    public FormplayerRedisLockRegistry() {
+    public FormplayerRedisLockRegistry(String serverName, String redisIpcTopic, int tryLockDurationInSeconds,
+                                       int nonEvictionDurationInSeconds) {
+        this.serverName = serverName;
+        this.tryLockDurationInSeconds = tryLockDurationInSeconds;
+        this.nonEvictionDurationInSeconds = nonEvictionDurationInSeconds;
+
+        // TODO: make configurable.
         final Config config = new Config();
         config.useSingleServer().setAddress("redis://127.0.0.1:6379");
         this.redisson = Redisson.create(config);
-        RTopic topic = redisson.getTopic("topic");
-        topic.addListener(LockMetadata.class, new MessageListener<LockMetadata>() {
+
+        RTopic topic = redisson.getTopic(redisIpcTopic);
+        topic.addListener(String.class, new MessageListener<String>() {
             @Override
-            public void onMessage(CharSequence channel, LockMetadata lockMetadata) {
-                System.out.println("debug to be removed " + channel.toString());
-                receiveEvictMessage(lockMetadata);
+            public void onMessage(CharSequence channel, String redisTopicMessage) {
+                int x = 3;
+                try {
+                    receiveEvictMessage(redisson, null, serverName);
+                } catch(Exception e) {
+                    // TODO: Handle
+                }
+
             }
         });
-        System.out.println("debug to be removed");
     }
 
     @Override
@@ -50,66 +59,162 @@ public class FormplayerRedisLockRegistry implements LockRegistry {
     }
 
     public Lock obtain(Object lockKey, boolean writeLock) {
-        ReadWriteLock rwLock = this.redisson.getReadWriteLock(lockKey.toString());
+        // TODO: Check lockKey type string
+        ReadWriteLock rwLock = this.redisson.getReadWriteLock((String) lockKey);
+        LockMetadata lockMetadata = new LockMetadata(lockKey.toString(),
+                                                     this.serverName,
+                                                     Thread.currentThread().getId());
         if (writeLock) {
-            return rwLock.writeLock();
+            return new FormplayerRedisLock(rwLock.writeLock(), lockMetadata, this.redisson, REDIS_TOPIC_EVICT,
+                    this.tryLockDurationInSeconds, this.nonEvictionDurationInSeconds);
         }
-        return rwLock.readLock();
+        return new FormplayerRedisLock(rwLock.readLock(), lockMetadata, this.redisson, REDIS_TOPIC_EVICT,
+                this.tryLockDurationInSeconds, this.nonEvictionDurationInSeconds);
     }
 
-    public boolean obtainAndLock(Object lockKey, boolean writeLock) {
-        String lockKeyString = lockKey.toString();
-        Lock lock = this.obtain(lockKeyString, writeLock);
+    private static void sendEvictMessage(RedissonClient redisson, LockMetadata lockMetadata, String redisIpcTopic) {
+        RTopic topic = redisson.getTopic(redisIpcTopic);
+        topic.publish(new RedisTopicMessage(redisIpcTopic, lockMetadata));
+    }
 
-        boolean didLock = false;
-        for (int i = 0; i < 3; i++) {
-            try {
-                didLock = lock.tryLock(5, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+    private static void receiveEvictMessage(RedissonClient redisson, RedisTopicMessage msg, String serverName) {
+        if (msg.action != REDIS_TOPIC_EVICT) return;
 
-            RBucket<LockMetadata> bucket = redisson.getBucket(lockKeyString);
-            if (didLock) {
-                // TODO: Check if there is something in bucket already
-                bucket.set(new LockMetadata(lockKeyString), 100, TimeUnit.SECONDS);
-                return didLock;
-            } else {
-                LockMetadata lockMetadata = bucket.get();
-                if (lockMetadata != null) {
-                    // TODO: set time check
-                    if (true) {
-                        throw new Error("Lock currently held within lease time");
-                    } else {
-                        sendEvictMessage(lockMetadata);
+        LockMetadata lockMetadata = msg.lockMetadata;
+        if (lockMetadata != null && lockMetadata.serverName == serverName) {
+            for (Thread t : Thread.getAllStackTraces().keySet()) {
+                if (t.getId() == lockMetadata.serverThreadId) {
+                    if (redisson.getLock(lockMetadata.lockId).isHeldByThread(t.getId())
+                            && t.isAlive()) {
+                        t.interrupt();
                     }
                 }
             }
         }
-
-        return didLock;
     }
 
+    public static class LockMetadata implements Serializable {
+        public final String lockId;
+        public final String serverName;
+        public final long serverThreadId;
+        private volatile long lockedAt;
 
+        public LockMetadata(String lockId, String serverName, long serverThreadId) {
+            this.lockId = lockId;
+            this.serverName = serverName;
+            this.serverThreadId = serverThreadId;
+        }
 
-    private void sendEvictMessage(LockMetadata lockMetadata) {
-        RTopic topic = redisson.getTopic("topic");
-        topic.publish(lockMetadata);
-    }
-
-    private void receiveEvictMessage(LockMetadata lockMetadata) {
-        // TODO: Check if severname is this server
-        for (Thread t : Thread.getAllStackTraces().keySet()) {
-            if (t.getId() == lockMetadata.serverThreadId) {
-                if (redisson.getLock(lockMetadata.lockId).isHeldByThread(t.getId())
-                        && t.isAlive()) {
-                    t.interrupt();
-                }
-            }
+        public void setLockedAt(long lockedAt) {
+            this.lockedAt = lockedAt;
         }
     }
 
+    public static class RedisTopicMessage implements Serializable {
+        public final String action;
+        public final LockMetadata lockMetadata;
 
+        public RedisTopicMessage(String action, LockMetadata lockMetadata) {
+            this.action = action;
+            this.lockMetadata = lockMetadata;
+        }
+    }
+
+    public static class FormplayerRedisLock implements Lock {
+
+        public final Lock lock;
+        private final LockMetadata lockMetadata;
+        private final RedissonClient redisson;
+        private final String redisIpcTopic;
+
+        private final int tryLockDurationInSeconds;
+        private final int nonEvictionDurationInSeconds;
+        private final int lockTryTimes = 3;
+
+        public FormplayerRedisLock(Lock lock,
+                                   LockMetadata lockMetadata,
+                                   RedissonClient redisson,
+                                   String redisIpcTopic,
+                                   int tryLockDurationInSeconds,
+                                   int nonEvictionDurationInSeconds) {
+            this.lock = lock;
+            this.lockMetadata = lockMetadata;
+            this.redisson = redisson;
+            this.redisIpcTopic = redisIpcTopic;
+            this.tryLockDurationInSeconds = tryLockDurationInSeconds;
+            this.nonEvictionDurationInSeconds = nonEvictionDurationInSeconds;
+        }
+
+        @Override
+        public void lock() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void lockInterruptibly() throws InterruptedException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tryLock() {
+            try {
+                return tryLock(tryLockDurationInSeconds, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return false;
+        }
+
+        @Override
+        public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+            boolean didLock = false;
+            for (int i = 0; i < this.lockTryTimes; i++) {
+                try {
+                    didLock = this.lock.tryLock(time, unit);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+
+                RBucket<LockMetadata> bucket = this.redisson.getBucket(lockMetadata.lockId);
+                if (didLock) {
+                    // TODO: Check if there is something in bucket already
+                    this.lockMetadata.setLockedAt(System.currentTimeMillis());
+                    bucket.set(this.lockMetadata, this.nonEvictionDurationInSeconds, TimeUnit.SECONDS);
+                    return didLock;
+                } else {
+                    LockMetadata retrievedlockMetadata = bucket.get();
+                    if (retrievedlockMetadata != null) {
+                        long lockedAt = retrievedlockMetadata.lockedAt;
+                        long currentTime = System.currentTimeMillis();
+                        if ((currentTime - lockedAt) <= this.nonEvictionDurationInSeconds) {
+                            throw new Error("Lock currently held within lease time");
+                        } else {
+                            sendEvictMessage(this.redisson, retrievedlockMetadata, this.redisIpcTopic);
+                        }
+                    }
+                }
+            }
+            return didLock;
+        }
+
+        @Override
+        public void unlock() {
+            // Use a freshly acquired RLock to check if it's held (`isHeldByCurrentThread` not a method
+            // of redis read and write locks)
+            RLock rLock = this.redisson.getLock(this.lockMetadata.lockId);
+            if (rLock.isHeldByCurrentThread()) {
+                RBucket<LockMetadata> bucket = this.redisson.getBucket(this.lockMetadata.lockId);
+                LockMetadata retrievedlockMetadata = bucket.getAndDelete();
+                // TODO: log
+                rLock.unlock();
+            }
+        }
+
+        @Override
+        public Condition newCondition() {
+            throw new UnsupportedOperationException();
+        }
+    }
 
 
 }

--- a/src/main/java/org/commcare/formplayer/services/FormplayerRedisLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerRedisLockRegistry.java
@@ -238,7 +238,8 @@ public class FormplayerRedisLockRegistry implements LockRegistry {
         @Override
         public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
             boolean didLock = false;
-            for (int i = 0; i < this.lockTryTimes; i++) {
+            int lockTryTimes = 1;
+            for (int i = 0; i < /*this.*/lockTryTimes; i++) {
                 try {
                     // TODO: This is in a for loop so consider adjusting lock duration.
                     didLock = this.lock.tryLock(time, unit);

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -98,7 +98,7 @@ public class Constants {
     public static final String POSTGRES_DJANGO_SESSION_ID = "sessionid";
     public static final String COMMCARE_USER_SUFFIX = "commcarehq.org";
 
-    public static final int USER_LOCK_TIMEOUT = 21;
+    public static final int USER_LOCK_TIMEOUT = 1;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;
     public static final int CONNECT_TIMEOUT = 60 * 1000;

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerRedisLockRegistryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerRedisLockRegistryTest.java
@@ -1,0 +1,15 @@
+package org.commcare.formplayer.tests;
+
+import org.commcare.formplayer.services.FormplayerRedisLockRegistry;
+import org.junit.jupiter.api.Test;
+
+public class FormplayerRedisLockRegistryTest {
+
+    @Test
+    public void testStuff() {
+        FormplayerRedisLockRegistry registry = new FormplayerRedisLockRegistry();
+        registry.obtain("");
+        int x = 3;
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerRedisLockRegistryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerRedisLockRegistryTest.java
@@ -1,15 +1,88 @@
 package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.services.FormplayerRedisLockRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RBucket;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 
 public class FormplayerRedisLockRegistryTest {
 
+    private FormplayerRedisLockRegistry registry;
+    private RedissonClient redisson;
+
+    private static final String SERVER_NAME = "s";
+    private static final String REDIS_KEY_PREFIX = "TEST_PREFIX_";
+    private static final String REDIS_IPC_TOPIC = REDIS_KEY_PREFIX + "topic";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        this.registry = new FormplayerRedisLockRegistry(SERVER_NAME, REDIS_IPC_TOPIC, 1, 100);
+
+        final Config config = new Config();
+        config.useSingleServer().setAddress("redis://127.0.0.1:6379");
+        this.redisson = Redisson.create(config);
+
+        this.redisson.getKeys().deleteByPattern(REDIS_KEY_PREFIX + "*");
+    }
+
     @Test
-    public void testStuff() {
-        FormplayerRedisLockRegistry registry = new FormplayerRedisLockRegistry();
-        registry.obtain("");
-        int x = 3;
+    public void testSingleThreadLockUnlock() throws InterruptedException {
+        final CountDownLatch waitForThread = new CountDownLatch(1);
+        final CountDownLatch waitForCheck = new CountDownLatch(1);
+
+        final String lockName = REDIS_KEY_PREFIX + "lock1";
+
+        Thread t = new Thread() {
+            public void run() {
+                Lock lock = registry.obtain(lockName);
+
+                try {
+                    assert(lock.tryLock(1, TimeUnit.SECONDS));
+                    waitForThread.countDown();
+
+                    waitForCheck.await();
+                    lock.unlock();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+
+
+            };
+        };
+
+        t.start();
+        redisson.getTopic(REDIS_IPC_TOPIC).publish("hello");
+
+        waitForThread.await();
+
+
+//        // Check that lock is locked.
+//        RLock lock = this.redisson.getLock(lockName);
+//        assert(lock.isLocked());
+//        assert(lock.isHeldByThread((t.getId())));
+//        RBucket<FormplayerRedisLockRegistry.LockMetadata> bucket = this.redisson.getBucket(lockName);
+//        FormplayerRedisLockRegistry.LockMetadata lockMetadata = bucket.get();
+//        assert(lockMetadata.lockId == lockName &&
+//                lockMetadata.serverName == SERVER_NAME &&
+//                lockMetadata.serverThreadId == t.getId());
+//
+//        waitForCheck.countDown();
+//
+//        t.join();
+//
+//        // Check that lock is unlocked.
+//        lock = this.redisson.getLock(lockName);
+//        assert(!lock.isLocked());
+//        lockMetadata = bucket.get();
+//        assert(lockMetadata == null);
     }
 
 }

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerRedisLockRegistryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerRedisLockRegistryTest.java
@@ -6,25 +6,32 @@ import org.junit.jupiter.api.Test;
 import org.redisson.Redisson;
 import org.redisson.api.RBucket;
 import org.redisson.api.RLock;
+import org.redisson.api.RTopic;
 import org.redisson.api.RedissonClient;
+import org.redisson.api.listener.MessageListener;
 import org.redisson.config.Config;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
+
+import static org.commcare.formplayer.services.FormplayerRedisLockRegistry.REDIS_TOPIC_EVICT;
 
 public class FormplayerRedisLockRegistryTest {
 
     private FormplayerRedisLockRegistry registry;
     private RedissonClient redisson;
 
-    private static final String SERVER_NAME = "s";
+    private static final String SERVER_NAME = "S";
     private static final String REDIS_KEY_PREFIX = "TEST_PREFIX_";
-    private static final String REDIS_IPC_TOPIC = REDIS_KEY_PREFIX + "topic";
+    private static final String REDIS_IPC_TOPIC = "topic_";
 
     @BeforeEach
     public void setUp() throws Exception {
-        this.registry = new FormplayerRedisLockRegistry(SERVER_NAME, REDIS_IPC_TOPIC, 1, 100);
+        this.registry = new FormplayerRedisLockRegistry(SERVER_NAME, REDIS_KEY_PREFIX, REDIS_IPC_TOPIC, 1, 100);
 
         final Config config = new Config();
         config.useSingleServer().setAddress("redis://127.0.0.1:6379");
@@ -33,75 +40,23 @@ public class FormplayerRedisLockRegistryTest {
         this.redisson.getKeys().deleteByPattern(REDIS_KEY_PREFIX + "*");
     }
 
-    public void testSingleThreadLockUnlock1() throws InterruptedException {
-        final CountDownLatch waitForThread = new CountDownLatch(1);
-        final CountDownLatch waitForCheck = new CountDownLatch(1);
-
-        final String lockName = REDIS_KEY_PREFIX + "lock1";
-
-        Thread t = new Thread() {
-            public void run() {
-                Lock lock = registry.obtain(lockName);
-
-                try {
-                    assert(lock.tryLock(1, TimeUnit.SECONDS));
-                    waitForThread.countDown();
-
-                    waitForCheck.await();
-                    lock.unlock();
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-
-
-            };
-        };
-
-        t.start();
-        redisson.getTopic(REDIS_IPC_TOPIC).publish("hello");
-
-        waitForThread.await();
-
-
-//        // Check that lock is locked.
-//        RLock lock = this.redisson.getLock(lockName);
-//        assert(lock.isLocked());
-//        assert(lock.isHeldByThread((t.getId())));
-//        RBucket<FormplayerRedisLockRegistry.LockMetadata> bucket = this.redisson.getBucket(lockName);
-//        FormplayerRedisLockRegistry.LockMetadata lockMetadata = bucket.get();
-//        assert(lockMetadata.lockId == lockName &&
-//                lockMetadata.serverName == SERVER_NAME &&
-//                lockMetadata.serverThreadId == t.getId());
-//
-//        waitForCheck.countDown();
-//
-//        t.join();
-//
-//        // Check that lock is unlocked.
-//        lock = this.redisson.getLock(lockName);
-//        assert(!lock.isLocked());
-//        lockMetadata = bucket.get();
-//        assert(lockMetadata == null);
-    }
-
     @Test
     public void testSingleThreadLockUnlock() throws InterruptedException {
         final CountDownLatch waitForThread = new CountDownLatch(1);
         final CountDownLatch waitForCheck = new CountDownLatch(1);
 
-        final String lockName = REDIS_KEY_PREFIX + "lock1";
+        final String lockName = "lock1";
 
         FormplayerRedisLockRegistry.FormplayerRedisLock formplayerRedisLock = registry.obtain(lockName);
 
-        RLock finalLock = formplayerRedisLock.getRLock();
         Thread t = new Thread() {
             public void run() {
                 try {
-                    assert(finalLock.tryLock(1, TimeUnit.SECONDS));
+                    assert(formplayerRedisLock.tryLock(1, TimeUnit.SECONDS));
                     waitForThread.countDown();
-
+                    // Wait for main thread to run checks on the lock.
                     waitForCheck.await();
-                    finalLock.unlock();
+                    formplayerRedisLock.unlock();
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
@@ -118,21 +73,190 @@ public class FormplayerRedisLockRegistryTest {
         // Check that lock is locked.
         assert(formplayerRedisLock.getRLock().isLocked());
         assert(rLock.isHeldByThread((t.getId())));
-
-        RBucket<FormplayerRedisLockRegistry.LockMetadata> bucket = this.redisson.getBucket(lockName);
+        // Check that bucket has entries.
+        RBucket<FormplayerRedisLockRegistry.LockMetadata> bucket = this.redisson.getBucket(this.registry.lockNameToRedisBucketKey(lockName));
         FormplayerRedisLockRegistry.LockMetadata lockMetadata = bucket.get();
-        assert(lockMetadata.lockId == lockName &&
-                lockMetadata.serverName == SERVER_NAME &&
+        assert(lockMetadata.lockId.equals(lockName) &&
+                lockMetadata.serverName.equals(SERVER_NAME) &&
                 lockMetadata.serverThreadId == t.getId());
 
         waitForCheck.countDown();
 
+        // Unlocking happens here.
         t.join();
-
+        // Check that it is unlocked and bucket is empty.
         assert(!rLock.isLocked());
         lockMetadata = bucket.get();
         assert(lockMetadata == null);
+    }
 
+    @Test
+    public void testTwoThreadsMutualExclusionUseDifferentRegistries() throws InterruptedException {
+        testTwoThreadsMutualExclusion(true);
+    }
+
+    @Test
+    public void testTwoThreadsMutualExclusionUseSameRegistries() throws InterruptedException {
+        testTwoThreadsMutualExclusion(false);
+    }
+
+    private void testTwoThreadsMutualExclusion(boolean newRegistry) throws InterruptedException {
+        final String lockName = "lock1";
+        final long DURATION_BETWEEN_THREADS = 1000;
+
+        List<Entry> entries = Collections.synchronizedList(new ArrayList<Entry>());
+
+        final CountDownLatch waitForT1 = new CountDownLatch(1);
+
+        Thread t1 = new Thread() {
+            public void run() {
+                FormplayerRedisLockRegistry threadRegistry = (newRegistry) ?
+                        new FormplayerRedisLockRegistry("S1", REDIS_KEY_PREFIX, REDIS_IPC_TOPIC, 1, 100) :
+                        registry;
+                Lock lock = threadRegistry.obtain(lockName);
+                try {
+                    assert(lock.tryLock());
+
+                    // Allow T2 to run after we've acquired the lock
+                    waitForT1.countDown();
+                    Thread.sleep(DURATION_BETWEEN_THREADS/3);
+                    entries.add(new Entry("T1", System.currentTimeMillis()));
+                    Thread.sleep(DURATION_BETWEEN_THREADS);
+
+                } catch (InterruptedException e) {
+                } finally {
+                    lock.unlock();
+                }
+
+            };
+        };
+
+        Thread t2 = new Thread() {
+            public void run() {
+                FormplayerRedisLockRegistry threadRegistry = (newRegistry) ?
+                        new FormplayerRedisLockRegistry("S2", REDIS_KEY_PREFIX, REDIS_IPC_TOPIC, 1, 100) :
+                        registry;
+                Lock lock = threadRegistry.obtain(lockName);
+                try {
+                    // Wait for T1 to acquire the lock
+                    waitForT1.await();
+
+                    assert(lock.tryLock((long) (DURATION_BETWEEN_THREADS * 1.5), TimeUnit.MILLISECONDS));
+
+                    entries.add(new Entry("T2", System.currentTimeMillis()));
+                } catch (InterruptedException e) {
+                } finally {
+                    lock.unlock();
+                }
+            };
+        };
+
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        Entry e1 = entries.get(0);
+        Entry e2 = entries.get(1);
+        assert(e1.name == "T1");
+        assert(e2.name == "T2");
+        assert((e2.timestamp - e1.timestamp) >= DURATION_BETWEEN_THREADS);
+    }
+
+    @Test
+    public void testEviction() throws InterruptedException {
+        final String lockName = "lock1";
+        final long NON_EVICTION_DURATION = 1000;
+
+        // shouldBeTrue needs to be flipped during running
+        final boolean[] shouldBeTrue = {false, false};
+        // Listen to the eviction channel and make sure we see an eviction message.
+        RTopic topic = redisson.getTopic(REDIS_KEY_PREFIX + REDIS_IPC_TOPIC);
+        topic.addListener(FormplayerRedisLockRegistry.RedisTopicMessage.class, new MessageListener<FormplayerRedisLockRegistry.RedisTopicMessage>() {
+            @Override
+            public void onMessage(CharSequence channel, FormplayerRedisLockRegistry.RedisTopicMessage redisTopicMessage) {
+                FormplayerRedisLockRegistry.LockMetadata lockMetadata = redisTopicMessage.lockMetadata;
+                // eviction message received, flip the first bool
+                if (redisTopicMessage.action.equals(REDIS_TOPIC_EVICT) && lockMetadata.lockId.equals(lockName) &&
+                        lockMetadata.serverName.equals("S1")) {
+                    shouldBeTrue[0] = true;
+                }
+            }
+        });
+
+        List<Entry> entries = Collections.synchronizedList(new ArrayList<Entry>());
+        final CountDownLatch waitForT1 = new CountDownLatch(1);
+        final CountDownLatch waitForT2 = new CountDownLatch(1);
+
+        Thread t1 = new Thread() {
+            public void run() {
+                FormplayerRedisLockRegistry threadRegistry =
+                        new FormplayerRedisLockRegistry("S1", REDIS_KEY_PREFIX, REDIS_IPC_TOPIC, 1, (int) (NON_EVICTION_DURATION/1000));
+                Lock lock = threadRegistry.obtain(lockName);
+                try {
+
+                    assert(lock.tryLock());
+
+                    waitForT1.countDown();
+                    entries.add(new Entry("T1", System.currentTimeMillis()));
+
+                    // We should be interrupted here and the rest should not run.
+                    waitForT2.await();
+                    entries.add(new Entry("SHOULD NOT BE ADDED", System.currentTimeMillis()));
+                    lock.unlock();
+                } catch (InterruptedException e) {
+                    // needs to be interrupted
+                    shouldBeTrue[1] = true;
+                } finally {
+                    lock.unlock();
+                }
+
+            };
+        };
+
+        Thread t2 = new Thread() {
+            public void run() {
+                FormplayerRedisLockRegistry threadRegistry =
+                        new FormplayerRedisLockRegistry("S2", REDIS_KEY_PREFIX, REDIS_IPC_TOPIC, 1, 100);
+                Lock lock = threadRegistry.obtain(lockName);
+                try {
+                    waitForT1.await();
+
+                    // Sleep for the non eviction duration which ensures we will evict when we try to lock
+                    Thread.sleep((long) (NON_EVICTION_DURATION));
+                    assert(lock.tryLock());
+
+                    entries.add(new Entry("T2", System.currentTimeMillis()));
+                } catch (InterruptedException e) {
+                } finally {
+                    lock.unlock();
+                }
+            };
+        };
+
+        t1.start();
+        t2.start();
+
+        t1.join();
+        t2.join();
+
+        Entry e1 = entries.get(0);
+        Entry e2 = entries.get(1);
+        assert(e1.name == "T1");
+        assert(e2.name == "T2");
+        assert(entries.size() == 2);
+        assert(shouldBeTrue[0] && shouldBeTrue[1]);
+    }
+
+    class Entry {
+        public final String name;
+        public final long timestamp;
+
+        public Entry(String name, long timestamp) {
+            this.name = name;
+            this.timestamp = timestamp;
+        }
     }
 
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11764 

More design [here](https://docs.google.com/document/d/1wC0fDcE8KppQpxCNqmhvm-IutiLipqFCVdw5v8uaWcY/edit#heading=h.nd5tnxybckzo)

This is a **very rough draft** with a few base case tests, but more edge cases will be needed because of this distributed design. 

Notably, per our [conversation](https://docs.google.com/document/d/1wC0fDcE8KppQpxCNqmhvm-IutiLipqFCVdw5v8uaWcY/edit?disco=AAAALVMNuzo)  I had initially tried to avoid keeping the locks in memory in this [commit](https://github.com/dimagi/formplayer/commit/f3bfe6b818fd98c370ab15f1b4b4f69ef3c8e5e7#diff-23ffd79a2d22daa6ab581b8a54813126d2fb4810448e962fb99539a2f00aa9f6R80-R93) by grabbing a new redis lock and looping over all threads to call `isHeldByThread(long id)`. However, this can only be called on the locked instance. Thus, I had to resort to maintaining a locks data structure.

## Design

### Redis Distributed Lock
Used for distributed lock

### Redis Key Value Store
Used to store the lock metadata (lock id, server name, server thread id, locked at time). This is referenced to check if the lock is available to be evicted.

### Redis Pub Sub
Used as a communication channel to announce eviction

### Interface
I looked at how the registry was used in the [LockAspect](https://github.com/dimagi/formplayer/blob/5693c6620229f3528ef648314895fb47d92f3e90/src/main/java/org/commcare/formplayer/aspects/LockAspect.java#L158) and tried to build around that. Thus, many lock operations are not supported.

### Read Write Lock Option 
Option to obtain a [read or write lock](https://github.com/dimagi/formplayer/commit/cfaca18f3d0c6fb1685bdb34d70ae0b7394f6e81#diff-23ffd79a2d22daa6ab581b8a54813126d2fb4810448e962fb99539a2f00aa9f6R67). I just realized that there is a bug where if a lock by that id already exists in the map, it will return that instead of instantiated with the type of lock requested. 

## Implementation

### FormplayerRedisLock
A new class was created to expose the simple lock interface. It also stores the lock metadata.

### Concurrent Map of locks
Each formplayer machine keeps track of a map from lock id to lock.

### States

#### LOCKED
- Redis Lock should be locked
- Machine that locked should have lock in locks map
- Redis store should have lock metadata entry

#### UNLOCKED
- Redis lock should be unlocked
- Ideally the lock should be removed from the locks map and the redis store should not have the lock metadata entry, but I don't think this is a requirement since the next thread that acquires it will just overwrite it

As you can see, there is state stored on redis which ideally would be mirrored on certain servers. It's difficult to keep these things in sync since errors happen, and we have to think through the scenarios. 

Namely, if the lock metadata on redis or the local locks map is deleted while the lock is still locked, we cannot evict. 

## Testing
Basic unit tests were created, but more exhausted ones are needed. This PR is mainly to get feedback on the approach and any glaring issues.

## TODO
- forceUnlock logic
- More tests and cases
