### PR TITLE
custom JPA repository implementation to avoid 'select on update'

### DIFF
--- a/src/main/java/org/commcare/formplayer/Application.java
+++ b/src/main/java/org/commcare/formplayer/Application.java
@@ -3,32 +3,30 @@ package org.commcare.formplayer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.formplayer.application.RequestResponseLoggingFilter;
+import org.commcare.formplayer.repo.FormplayerBaseJpaRepoImpl;
+import org.commcare.formplayer.util.PrototypeUtils;
 import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.services.locale.LocalizerManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.commcare.formplayer.util.PrototypeUtils;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 
 @SpringBootApplication
-@EnableJpaRepositories(basePackages = {"org.commcare.formplayer.repo"})
+@EnableJpaRepositories(
+        basePackages = {"org.commcare.formplayer.repo"},
+        repositoryBaseClass = FormplayerBaseJpaRepoImpl.class
+)
 @EntityScan("org.commcare.formplayer.objects")
 @EnableCaching
 public class Application {

--- a/src/main/java/org/commcare/formplayer/repo/FormplayerBaseJpaRepoImpl.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormplayerBaseJpaRepoImpl.java
@@ -1,0 +1,53 @@
+package org.commcare.formplayer.repo;
+
+import org.hibernate.Session;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import javax.persistence.EntityManager;
+
+/**
+ * JPA repository implementation that uses ``Session.update`` instead of
+ * ``Session.merge`` when saving. This avoids the additional 'select' that
+ * happens when saving detached entities.
+ *
+ * Formplayer caches entities between requests to avoid having to re-fetch them
+ * from the DB on successive requests. Since the caching results in detached
+ * entities, the advantage of caching is lost when using ``Session.merge`` since
+ * the merge will re-fetch the entity from the DB on update.
+ *
+ * It is safe to skip the select before update as long as the Formplayer
+ * request routing is consistent or the caching is global across all Formplayer instances.
+ */
+public class FormplayerBaseJpaRepoImpl<T, ID>
+        extends SimpleJpaRepository<T, ID> {
+
+    private final EntityManager entityManager;
+    private final JpaEntityInformation<T, ?> entityInformation;
+
+    public FormplayerBaseJpaRepoImpl(JpaEntityInformation<T, ?> entityInformation, EntityManager entityManager) {
+        super(entityInformation, entityManager);
+        this.entityManager = entityManager;
+        this.entityInformation = entityInformation;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.data.repository.CrudRepository#save(java.lang.Object)
+     */
+    @Transactional
+    @Override
+    public <S extends T> S save(S entity) {
+        Assert.notNull(entity, "Entity must not be null.");
+
+        if (entityInformation.isNew(entity)) {
+            entityManager.persist(entity);
+            return entity;
+        } else {
+            entityManager.unwrap(Session.class).update(entity);
+            return entity;
+        }
+    }
+}


### PR DESCRIPTION
This adds a custom JPA repository implementation that uses ``Session.update`` instead of
``Session.merge`` when saving. This avoids the additional 'select' that
happens when saving detached entities.

With caching enabled Formplayer caches entities between requests to avoid having to re-fetch them
from the DB on successive requests. Since the caching results in detached
entities, the advantage of caching is lost since ``Session.merge`` re-fetch the entity from the DB on update.

It is safe to skip the "select before update" as long as the Formplayer
request routing is consistent. If we remove the consistent routing we would need
to use a global cache (instead of per machine).

Hibernate Docs:
https://docs.jboss.org/hibernate/orm/5.2/javadocs/org/hibernate/Session.html#merge-java.lang.Object-
https://docs.jboss.org/hibernate/orm/5.2/javadocs/org/hibernate/Session.html#update-java.lang.Object-

Other resources:
https://www.baeldung.com/hibernate-save-persist-update-merge-saveorupdate
https://thorben-janssen.com/persist-save-merge-saveorupdate-whats-difference-one-use/