### PR TITLE
add translations attr in form response

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
@@ -4,6 +4,8 @@ import org.commcare.formplayer.beans.NotificationMessage;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.formplayer.util.SessionUtils;
 
+import java.util.HashMap;
+
 /**
  * Base class for responses being sent to the front end. Params are:
  * title - self explanatory
@@ -20,6 +22,7 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
     private String appId;
     private String appVersion;
     private String[] selections;
+    private HashMap<String, String> translations;
 
     public BaseResponseBean() {}
 
@@ -97,5 +100,20 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     public void setSelections(String[] selections) {
         this.selections = selections;
+    }
+
+    public HashMap<String, String> getTranslations() {
+        return translations;
+    }
+
+    public void setTranslations(HashMap<String, String> translations) {
+        this.translations = translations;
+    }
+
+    public void addToTranslation(String key, String value) {
+        if (this.translations == null) {
+            this.translations = new HashMap<String, String>();
+        }
+        this.translations.put(key, value);
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -10,6 +10,7 @@ import org.commcare.formplayer.util.Constants;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.xform.util.XFormUtils;
+import org.javarosa.core.services.locale.Localization;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -97,11 +98,21 @@ public class NewFormResponseFactory {
 
         SerializableFormSession serializedSession = formEntrySession.serialize();
         formSessionService.saveSession(serializedSession);
-        return new NewFormResponse(
+        NewFormResponse response = new NewFormResponse(
                 formTreeJson, formEntrySession.getLanguages(), serializedSession.getTitle(),
                 serializedSession.getId(), serializedSession.getSequenceId(),
                 serializedSession.getInstanceXml()
         );
+
+        String[] translationKey = {"repeat.dialog.add.new"};
+        for (String key : translationKey) {
+            String translation = Localization.getWithDefault(key, null);
+            if (translation != null) {
+                response.addToTranslation(key, translation);
+            }
+        }
+
+        return response;
     }
 
     public NewFormResponse getResponse(SerializableFormSession session) throws Exception {


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11642 
Corresonding cchq PR: https://github.com/dimagi/commcare-hq/pull/29279

A client has asked that we support translations for `repeat.dialog.add.new` which correspond to the `Add new repeat` button.

## Design

I believe we handle App UI Translations by having formplayer translate the text and put it in a specific section in the response json. This is a CC UI translations, which we have very little of. Since these are statically defined key names, instead of following the same approach of inserting the translation into a specific portion of the json response (which gets pretty hairy since translations can be nested in there), I created a top level `translations` attribute to the base response class where certain endpoints can append translations that they think would be needed for the webapp and the frontend can access it.

For this translation it is added for from any new form response.

Requests that need it:
<img width="508" alt="Screen Shot 2021-03-02 at 5 01 13 PM" src="https://user-images.githubusercontent.com/615126/109724026-e7cc0200-7b7c-11eb-9562-72c50a4b4544.png">

Requests that don't:
<img width="271" alt="Screen Shot 2021-03-02 at 5 01 46 PM" src="https://user-images.githubusercontent.com/615126/109724044-ef8ba680-7b7c-11eb-9d2d-171cd557747d.png">

## Testing

Tested locally, will deploy to staging soon. 

<img width="268" alt="Screen Shot 2021-03-02 at 5 41 24 PM" src="https://user-images.githubusercontent.com/615126/109725036-8c027880-7b7e-11eb-832f-2cbf91082e06.png">
