### PR TITLE
separate autosearch from skip default

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -305,7 +305,7 @@ public class MenuSessionRunnerService {
                         (FormplayerQueryScreen)nextScreen,
                         menuSession,
                         queryData == null ? null : queryData.getInputs(queryKey),
-                        autoSearch
+                        formplayerQueryScreen.doDefaultSearch()
                 );
             } else if (queryData != null) {
                 answerQueryPrompts((FormplayerQueryScreen)nextScreen,
@@ -386,7 +386,7 @@ public class MenuSessionRunnerService {
     private NotificationMessage doQuery(FormplayerQueryScreen screen,
                                         MenuSession menuSession,
                                         Hashtable<String, String> queryDictionary,
-                                        boolean autoSearch) throws CommCareSessionException {
+                                        boolean skipDefaultPromptValues) throws CommCareSessionException {
         log.info("Formplayer doing query with dictionary " + queryDictionary);
         NotificationMessage notificationMessage = null;
 
@@ -394,7 +394,7 @@ public class MenuSessionRunnerService {
             screen.answerPrompts(queryDictionary);
         }
 
-        String responseString = queryRequester.makeQueryRequest(screen.getUriString(autoSearch), restoreFactory.getUserHeaders());
+        String responseString = queryRequester.makeQueryRequest(screen.getUriString(skipDefaultPromptValues), restoreFactory.getUserHeaders());
         boolean success = screen.processResponse(new ByteArrayInputStream(responseString.getBytes(StandardCharsets.UTF_8)));
         if (success) {
             if (screen.getCurrentMessage() != null) {


### PR DESCRIPTION
The previous logic mixed whether to do a search with whether include user input and default values in the search. This separates those two and attempts to clear up the naming.
https://dimagi-dev.atlassian.net/jira/servicedesk/projects/SUPPORT/queues/custom/81/SUPPORT-8316

Followup for 7839d7d4e5335762333a19d63a58f4909abed19a, restores the previous `autoSearch` flag that's passed to `doQuery`, while preserving the new logic that's used to determine whether or not to call `doQuery`.