### PR TITLE
add custom exception handler

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/GlobalExceptionHandler.java
+++ b/src/main/java/org/commcare/formplayer/application/GlobalExceptionHandler.java
@@ -1,0 +1,12 @@
+package org.commcare.formplayer.application;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * Controller advice to replace the default error handling with simple responses
+ * instead of rendering error pages.
+ */
+@ControllerAdvice()
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,5 @@ logging.level.root=INFO
 logging.level.org.springframework.web=INFO
 logging.level.org.commcare=TRACE
 logging.level.org.hibernate=ERROR
+
+spring.mvc.throw-exception-if-no-handler-found=true


### PR DESCRIPTION
This has been bugging me since I started working on formplayer. All generic spring errors now return plain responses instead of attempting to render error messages which it can't find.