### PR TITLE
Bug Fix: Search prompts getting skipped from case search 

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.services;
 
 import io.sentry.Sentry;
+
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.NotificationMessage;
 import org.commcare.formplayer.beans.menus.*;
@@ -241,9 +242,8 @@ public class MenuSessionRunnerService {
 
             // Advance the session in case auto launch is set
             nextScreen = handleAutoLaunch(nextScreen, menuSession, selection, needsDetail, confirmed);
-            boolean forceSearch = i < selections.length;
-            boolean disallowSearch = forceManualAction && !forceSearch;
-            notificationMessage = handleQueryScreen(nextScreen, menuSession, queryData, forceSearch, disallowSearch);
+            boolean replay = i < selections.length;
+            notificationMessage = handleQueryScreen(nextScreen, menuSession, queryData, replay, forceManualAction);
             if (nextScreen instanceof FormplayerSyncScreen) {
                 BaseResponseBean syncResponse = doSyncGetNext(
                         (FormplayerSyncScreen)nextScreen,
@@ -292,19 +292,19 @@ public class MenuSessionRunnerService {
     }
 
     private NotificationMessage handleQueryScreen(Screen nextScreen, MenuSession menuSession, QueryData queryData,
-                                                  boolean forceSearch, boolean disallowSearch)
+                                                  boolean replay, boolean forceManualAction)
             throws CommCareSessionException {
         if (nextScreen instanceof FormplayerQueryScreen) {
             FormplayerQueryScreen formplayerQueryScreen = ((FormplayerQueryScreen)nextScreen);
             formplayerQueryScreen.refreshItemSetChoices();
-            boolean autoSearch = forceSearch || (formplayerQueryScreen.doDefaultSearch() && !disallowSearch);
+            boolean autoSearch = replay || (formplayerQueryScreen.doDefaultSearch() && !forceManualAction);
             String queryKey = menuSession.getSessionWrapper().getCommand();
             if ((queryData != null && queryData.getExecute(queryKey)) || autoSearch) {
                 return doQuery(
                         (FormplayerQueryScreen)nextScreen,
                         menuSession,
                         queryData == null ? null : queryData.getInputs(queryKey),
-                        formplayerQueryScreen.doDefaultSearch()
+                        formplayerQueryScreen.doDefaultSearch() && !forceManualAction
                 );
             } else if (queryData != null) {
                 answerQueryPrompts((FormplayerQueryScreen)nextScreen,


### PR DESCRIPTION
When we do a search again for a query definition with default search on, the user entered query prompts doesn't get incorporated in the case search uri resulting in case search results with default definition. 

Introduced in https://github.com/dimagi/formplayer/pull/921/