### PR TITLE
prune formplayer metrics to reduce cost + remove unused

### DIFF
--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -77,12 +77,9 @@ public class MetricsAspect {
         timer.end();
 
         List<FormplayerDatadog.Tag> datadogArgs = new ArrayList<>();
+        datadogArgs.add(new FormplayerDatadog.Tag(Constants.DOMAIN_TAG, domain));
         datadogArgs.add(new FormplayerDatadog.Tag(Constants.REQUEST_TAG, requestPath));
         datadogArgs.add(new FormplayerDatadog.Tag(Constants.DURATION_TAG, timer.getDurationBucket()));
-
-        if (timer.durationInSeconds() > 1) {
-            datadogArgs.add(new FormplayerDatadog.Tag(Constants.DOMAIN_TAG, domain));
-        }
 
         datadog.recordExecutionTime(Constants.DATADOG_TIMINGS, timer.durationInMs(), datadogArgs);
 

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -79,11 +79,6 @@ public class MetricsAspect {
         List<FormplayerDatadog.Tag> datadogArgs = new ArrayList<>();
         datadogArgs.add(new FormplayerDatadog.Tag(Constants.REQUEST_TAG, requestPath));
         datadogArgs.add(new FormplayerDatadog.Tag(Constants.DURATION_TAG, timer.getDurationBucket()));
-        datadogArgs.add(new FormplayerDatadog.Tag(Constants.UNBLOCKED_TIME_TAG, getUnblockedTimeBucket(timer)));
-        datadogArgs.add(new FormplayerDatadog.Tag(Constants.BLOCKED_TIME_TAG, getBlockedTimeBucket()));
-        datadogArgs.add(new FormplayerDatadog.Tag(Constants.RESTORE_BLOCKED_TIME_TAG, getRestoreBlockedTimeBucket()));
-        datadogArgs.add(new FormplayerDatadog.Tag(Constants.INSTALL_BLOCKED_TIME_TAG, getInstallBlockedTimeBucket()));
-        datadogArgs.add(new FormplayerDatadog.Tag(Constants.SUBMIT_BLOCKED_TIME_TAG, getSubmitBlockedTimeBucket()));
 
         if (timer.durationInSeconds() > 1) {
             datadogArgs.add(new FormplayerDatadog.Tag(Constants.DOMAIN_TAG, domain));
@@ -104,55 +99,6 @@ public class MetricsAspect {
         }
 
         return result;
-    }
-
-    private String getUnblockedTimeBucket(SimpleTimer timer) {
-        return Timing.getDurationBucket(timer.durationInSeconds() - getBlockedTime());
-    }
-
-    private String getBlockedTimeBucket() {
-        return Timing.getDurationBucket(getRestoreBlockedTime() +
-                getInstallBlockedTime() +
-                getSubmitBlockedTime());
-    }
-
-    private long getBlockedTime() {
-        return getRestoreBlockedTime() +
-                getInstallBlockedTime() +
-                getSubmitBlockedTime();
-    }
-
-    private String getRestoreBlockedTimeBucket() {
-        return Timing.getDurationBucket(getRestoreBlockedTime());
-    }
-
-    private long getRestoreBlockedTime() {
-        if (restoreFactory.getDownloadRestoreTimer() == null) {
-            return 0;
-        }
-        return restoreFactory.getDownloadRestoreTimer().durationInSeconds();
-    }
-
-    private String getInstallBlockedTimeBucket() {
-        return Timing.getDurationBucket(getInstallBlockedTime());
-    }
-
-    private long getInstallBlockedTime() {
-        if (installService.getInstallTimer() == null) {
-            return 0;
-        }
-        return installService.getInstallTimer().durationInSeconds();
-    }
-
-    private String getSubmitBlockedTimeBucket() {
-        return Timing.getDurationBucket(getSubmitBlockedTime());
-    }
-
-    private long getSubmitBlockedTime() {
-        if (submitService.getSubmitTimer() == null) {
-            return 0;
-        }
-        return submitService.getSubmitTimer().durationInSeconds();
     }
 
     private void sendTimingWarningToSentry(SimpleTimer timer, String category) {

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -84,7 +84,6 @@ public class MetricsAspect {
             datadogArgs.add(new FormplayerDatadog.Tag(Constants.DOMAIN_TAG, domain));
         }
 
-        datadog.increment(Constants.DATADOG_REQUESTS, datadogArgs);
         datadog.recordExecutionTime(Constants.DATADOG_TIMINGS, timer.durationInMs(), datadogArgs);
 
         FormplayerSentry.newBreadcrumb()

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -87,6 +87,12 @@ public class MetricsAspect {
         datadog.increment(Constants.DATADOG_REQUESTS, datadogArgs);
         datadog.recordExecutionTime(Constants.DATADOG_TIMINGS, timer.durationInMs(), datadogArgs);
 
+        FormplayerSentry.newBreadcrumb()
+                .setCategory("timing")
+                .setLevel(SentryLevel.WARNING)
+                .setData("duration", timer.formatDuration())
+                .record();
+
         if (timer.durationInSeconds() >= 60) {
             sendTimingWarningToSentry(timer, INTOLERABLE_REQUEST);
         } else if (tolerableRequestThresholds.containsKey(requestPath) && timer.durationInMs() >= tolerableRequestThresholds.get(requestPath)) {
@@ -102,12 +108,6 @@ public class MetricsAspect {
     }
 
     private void sendTimingWarningToSentry(SimpleTimer timer, String category) {
-        FormplayerSentry.newBreadcrumb()
-                .setCategory(category)
-                .setLevel(SentryLevel.WARNING)
-                .setData("duration", timer.formatDuration())
-                .record();
-
         String message = "N/A";
         if (sentryMessages.containsKey(category)) {
             message = sentryMessages.get(category);

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -77,8 +77,6 @@ public class CategoryTimingHelper {
     private void recordDatadogMetrics(Timing timing, String category, Map<String, String> extras) {
         List<String> datadogArgs = new ArrayList<>();
         datadogArgs.add(Constants.CATEGORY_TAG + ":" + category);
-        datadogArgs.add(Constants.REQUEST_TAG + ":" + RequestUtils.getRequestEndpoint());
-        datadogArgs.add(Constants.DURATION_TAG + ":" + timing.getDurationBucket());
         if (extras != null) {
             for (Map.Entry<String, String> entry : extras.entrySet()) {
                 datadogArgs.add(entry.getKey() + ":" + entry.getValue());

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -77,6 +77,7 @@ public class CategoryTimingHelper {
     private void recordDatadogMetrics(Timing timing, String category, Map<String, String> extras) {
         List<String> datadogArgs = new ArrayList<>();
         datadogArgs.add(Constants.CATEGORY_TAG + ":" + category);
+        datadogArgs.add(Constants.DURATION_TAG + ":" + timing.getDurationBucket());
         if (extras != null) {
             for (Map.Entry<String, String> entry : extras.entrySet()) {
                 datadogArgs.add(entry.getKey() + ":" + entry.getValue());

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -77,6 +77,7 @@ public class CategoryTimingHelper {
     private void recordDatadogMetrics(Timing timing, String category, Map<String, String> extras) {
         List<String> datadogArgs = new ArrayList<>();
         datadogArgs.add(Constants.CATEGORY_TAG + ":" + category);
+        datadogArgs.add(Constants.REQUEST_TAG + ":" + RequestUtils.getRequestEndpoint());
         datadogArgs.add(Constants.DURATION_TAG + ":" + timing.getDurationBucket());
         if (extras != null) {
             for (Map.Entry<String, String> entry : extras.entrySet()) {

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -108,7 +108,6 @@ public class Constants {
     public static String HMAC_REQUEST_ATTRIBUTE = "org.commcare.formplayer.hmacRequest";
 
     // Datadog metrics
-    public static final String DATADOG_REQUESTS = "requests";
     public static final String DATADOG_TIMINGS = "timings";
     public static final String DATADOG_GRANULAR_TIMINGS = "granular.timings";
     public static final String DATADOG_RESTORE_COUNT = "restore.count";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -121,11 +121,6 @@ public class Constants {
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";
     public static final String DURATION_TAG = "duration";
-    public static final String UNBLOCKED_TIME_TAG = "unblocked_time";
-    public static final String BLOCKED_TIME_TAG = "blocked_time";
-    public static final String RESTORE_BLOCKED_TIME_TAG = "restore_blocked_time";
-    public static final String INSTALL_BLOCKED_TIME_TAG = "install_blocked_time";
-    public static final String SUBMIT_BLOCKED_TIME_TAG = "submit_blocked_time";
 
     //.Sentry tags
     public static final String URI = "uri";

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
@@ -70,19 +70,19 @@ public class FormplayerDatadogTests {
     @Test
     public void testTagUsedForIncrement() {
         datadog.addRequestScopedTag("form", "test-form");
-        datadog.increment(Constants.DATADOG_REQUESTS, Collections.emptyList());
+        datadog.increment("requests", Collections.emptyList());
         String expectedTag = "form:test-form";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).increment(Constants.DATADOG_REQUESTS, args);
+        verify(mockDatadogClient).increment("requests", args);
     }
 
     @Test
     public void testTagUsedForRecordExecutionTime() {
         datadog.addRequestScopedTag("form", "test-form");
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, Collections.emptyList());
+        datadog.recordExecutionTime("requests", 100, Collections.emptyList());
         String expectedTag = "form:test-form";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
@@ -90,10 +90,10 @@ public class FormplayerDatadogTests {
         datadog.addRequestScopedTag("form", "test-form");
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
         transientTags.add(new FormplayerDatadog.Tag("form", "test-form-2"));
-        datadog.increment(Constants.DATADOG_REQUESTS, transientTags);
+        datadog.increment("requests", transientTags);
         String expectedTag = "form:test-form-2";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).increment(Constants.DATADOG_REQUESTS, args);
+        verify(mockDatadogClient).increment("requests", args);
     }
 
     @Test
@@ -101,10 +101,10 @@ public class FormplayerDatadogTests {
         datadog.addRequestScopedTag("form", "test-form");
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
         transientTags.add(new FormplayerDatadog.Tag("form", "test-form-2"));
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, transientTags);
+        datadog.recordExecutionTime("requests", 100, transientTags);
         String expectedTag = "form:test-form-2";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
@@ -112,10 +112,10 @@ public class FormplayerDatadogTests {
         String domain = "eligible_domain";
         datadog.setDomain(domain);
         datadog.addRequestScopedTag("detailed_tag", "test_value");
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, Collections.emptyList());
+        datadog.recordExecutionTime("requests", 100, Collections.emptyList());
         String expectedTag = "detailed_tag:test_value";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
@@ -123,19 +123,19 @@ public class FormplayerDatadogTests {
         String domain = "ineligible_domain";
         datadog.setDomain(domain);
         datadog.addRequestScopedTag("detailed_tag", "test_value");
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, Collections.emptyList());
+        datadog.recordExecutionTime("requests", 100, Collections.emptyList());
         String expectedTag = "detailed_tag:_other";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
     public void testAddRequestScopedDetailedTagForNullDomain() {
         datadog.addRequestScopedTag("detailed_tag", "test_value");
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, Collections.emptyList());
+        datadog.recordExecutionTime("requests", 100, Collections.emptyList());
         String expectedTag = "detailed_tag:_other";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
@@ -144,10 +144,10 @@ public class FormplayerDatadogTests {
         datadog.setDomain(domain);
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
         transientTags.add(new FormplayerDatadog.Tag("detailed_tag", "test_value"));
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, transientTags);
+        datadog.recordExecutionTime("requests", 100, transientTags);
         String expectedTag = "detailed_tag:test_value";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
@@ -157,20 +157,20 @@ public class FormplayerDatadogTests {
         datadog.setDomain(domain);
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
         transientTags.add(new FormplayerDatadog.Tag("detailed_tag", "test_value"));
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, transientTags);
+        datadog.recordExecutionTime("requests", 100, transientTags);
         String expectedTag = "detailed_tag:_other";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
     @Test
     public void testAddTransientDetailedTagForNullDomain() {
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
         transientTags.add(new FormplayerDatadog.Tag("detailed_tag", "test_value"));
-        datadog.recordExecutionTime(Constants.DATADOG_REQUESTS, 100, transientTags);
+        datadog.recordExecutionTime("requests", 100, transientTags);
         String expectedTag = "detailed_tag:_other";
         String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime(Constants.DATADOG_REQUESTS, 100, args);
+        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
     }
 
 }


### PR DESCRIPTION
* Remove `formplayer.metrics.requests` entirely and update all usages with `formplayer.metrics.timings.count`
* Changes to `formplayer.metrics.timings.*` tags
    * Only add the 'domain' tag to for requests > 1s
    * Drop the following tags altogether: "unblocked_time", "blocked_time", "restore_blocked_time", "install_blocked_time", "submit_blocked_time"        
        * These tags were either unused or can be replaced with the granular timings metrics.