### PR TITLE
enable caching by default

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,7 +32,7 @@ management.metrics.enable.formplayer.spring.integration=false
 management.metrics.enable.formplayer.http.client=false
 
 # caching (override type in application.properties to enable)
-spring.cache.type=none
+spring.cache.type=caffeine
 spring.cache.cache-names=form_session,case_search
 spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=300s,expireAfterWrite=300s
 


### PR DESCRIPTION
This was only enabled in some envs to allow testing but we can now do full rollout.