### PR TITLE
Auto advance Menu screen with single option

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -33,6 +33,9 @@ public class MenuSessionFactory {
     @Autowired
     private InstallService installService;
 
+    @Autowired
+    protected FormplayerStorageFactory storageFactory;
+
     @Value("${commcarehq.host}")
     private String host;
 
@@ -78,7 +81,7 @@ public class MenuSessionFactory {
             if (currentStep == null) {
                 break;
             } else {
-                menuSession.handleInput(currentStep, false, true, false);
+                menuSession.handleInput(currentStep, false, true, false, storageFactory.getPropertyManager().isAutoAdvanceMenu());
                 menuSession.addSelection(currentStep);
                 screen = menuSession.getNextScreen(false);
             }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -232,7 +232,7 @@ public class MenuSessionRunnerService {
             // minimal entity screens are only safe if there will be no further selection
             // and we do not need the case detail
             needsDetail = detailSelection != null || i != selections.length;
-            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, true);
+            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, true, isAutoAdvanceMenu());
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
                         "Overflowed selections with selection " + selection + " at index " + i,
@@ -317,6 +317,10 @@ public class MenuSessionRunnerService {
         return null;
     }
 
+    private boolean isAutoAdvanceMenu() {
+        return storageFactory.getPropertyManager().isAutoAdvanceMenu();
+    }
+
     private Screen handleAutoLaunch(Screen nextScreen, MenuSession menuSession,
                                     String selection, boolean needsDetail, boolean confirmed, String nextInput)
             throws CommCareSessionException {
@@ -324,7 +328,7 @@ public class MenuSessionRunnerService {
             EntityScreen entityScreen = (EntityScreen)nextScreen;
             entityScreen.evaluateAutoLaunch(nextInput);
             if (entityScreen.getAutoLaunchAction() != null) {
-                menuSession.handleInput(selection, needsDetail, confirmed, true);
+                menuSession.handleInput(selection, needsDetail, confirmed, true, isAutoAdvanceMenu());
                 nextScreen = menuSession.getNextScreen(needsDetail);
             }
         }

--- a/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
@@ -19,6 +19,7 @@ public class FormplayerPropertyManager extends PropertyManager {
     public static final String FUZZY_SEARCH_ENABLED = "cc-fuzzy-search-enabled";
 
     public static final String SKIP_FIXTURES_AFTER_SUBMIT = "cc-skip-fixtures-after-submit";
+    public static final String AUTO_ADVANCE_MENU = "cc-auto-advance-menu";
 
     /**
      * Constructor for this PropertyManager
@@ -56,5 +57,9 @@ public class FormplayerPropertyManager extends PropertyManager {
 
     public boolean skipFixturesAfterSubmit() {
         return doesPropertyMatch(SKIP_FIXTURES_AFTER_SUBMIT, NO, YES);
+    }
+
+    public boolean isAutoAdvanceMenu() {
+        return doesPropertyMatch(AUTO_ADVANCE_MENU, NO, YES);
     }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-636

Auto advances any menu screen with a single option if the property `cc-auto-advance-menu` is enabled. 

It was hard to test this feature without fixes in `caseSearchSkip` due to which I ended up merging `caseSearchSkip` in the current branch

cross-request: https://github.com/dimagi/commcare-core/pull/993