### PR TITLE
pass down templateforms list in getDetails for markdown

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -59,7 +59,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
                         detailList[i],
                         subContext,
                         titles);
-                EntityDetailResponse response = new EntityDetailResponse(subscreen, titles[i]);
+                EntityDetailResponse response = new EntityDetailResponse(subscreen, titles[i], detailList[i]);
                 accumulator.add(response);
             } else {
                 TreeReference contextualizedNodeset = detailList[i].getNodeset().contextualize(ref);

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
@@ -25,6 +25,7 @@ public class EntityDetailResponse {
     private EntityBean[] entities;
     protected Style[] styles;
     protected String[] headers;
+    protected String[] templateForms;
     protected String title;
     protected boolean isUseNodeset;
 
@@ -39,12 +40,12 @@ public class EntityDetailResponse {
     public EntityDetailResponse() {
     }
 
-    public EntityDetailResponse(EntityDetailSubscreen entityScreen, String title) {
+    public EntityDetailResponse(EntityDetailSubscreen entityScreen, String title, Detail detail) {
         this.title = title;
         this.details = processDetails(entityScreen.getData());
         this.headers = entityScreen.getHeaders();
         this.styles = entityScreen.getStyles();
-
+        this.templateForms = detail.getTemplateForms();
     }
 
     private static Object[] processDetails(Object[] data) {
@@ -65,7 +66,7 @@ public class EntityDetailResponse {
 
     // Constructor used for persistent case tile
     public EntityDetailResponse(Detail detail, EvaluationContext ec) {
-        this(new EntityDetailSubscreen(0, detail, ec, new String[]{}), "Details");
+        this(new EntityDetailSubscreen(0, detail, ec, new String[]{}), "Details", detail);
         processCaseTiles(detail);
         processStyles(detail);
     }
@@ -141,6 +142,14 @@ public class EntityDetailResponse {
 
     public void setHeaders(String[] headers) {
         this.headers = headers;
+    }
+
+    public String[] getTemplateForms() {
+        return templateForms;
+    }
+
+    public void setTemplateForms(String[] templateForms) {
+        this.templateForms = templateForms;
     }
 
     @Override


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11685
and QA https://dimagi-dev.atlassian.net/browse/QA-2976?focusedCommentId=141272

Needs to pass down the list of case list property format. In the code this is called `templateForms` so I used that naming, but should we name it to something else that is more understandable for the frontend? 

Tested locally:

<img width="450" alt="Screen Shot 2021-05-06 at 6 19 16 PM" src="https://user-images.githubusercontent.com/615126/117372801-1fff0200-ae98-11eb-87fd-42b2e69905c6.png">

