### PR TITLE
Replace detailed tagging properties value with feature flag check

### DIFF
--- a/config/application.example.properties
+++ b/config/application.example.properties
@@ -29,5 +29,4 @@ touchforms.password=123
 # logging.level.org.commcare=TRACE
 
 # Metrics collection
-detailed_tagging.domains=
 detailed_tagging.tag_names=

--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -73,9 +73,6 @@ public class WebAppContext implements WebMvcConfigurer {
     @Value("${redis.password:#{null}}")
     private String redisPassword;
 
-    @Value("${detailed_tagging.domains:}")
-    private List<String> domainsWithDetailedTagging;
-
     @Value("${detailed_tagging.tag_names:}")
     private List<String> detailedTagNames;
 
@@ -162,7 +159,7 @@ public class WebAppContext implements WebMvcConfigurer {
     @Bean
     @Scope(value= "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
     public FormplayerDatadog datadog() {
-        FormplayerDatadog datadog = new FormplayerDatadog(datadogStatsDClient(), domainsWithDetailedTagging, detailedTagNames);
+        FormplayerDatadog datadog = new FormplayerDatadog(datadogStatsDClient(), detailedTagNames);
         return datadog;
     }
 

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -68,7 +68,6 @@ public class MetricsAspect {
         if (args != null && args.length > 0 && args[0] instanceof AuthenticatedRequestBean) {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
-            datadog.setDomain(domain);
         }
 
         SimpleTimer timer = new SimpleTimer();

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -164,4 +164,9 @@ public class Constants {
     // End Datadog metrics
 
     public static final String SCHEDULED_TASKS_PURGE = "scheduled_tasks.purge";
+
+    // Feature Flags/Toggles
+
+    // https://.commcarehq.org/hq/flags/edit/detailed_tagging/
+    public static final String TOGGLE_DETAILED_TAGGING = "DETAILED_TAGGING";
 }

--- a/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
@@ -145,14 +145,13 @@ public class FormplayerDatadog {
      * @return String representing tag to send
      */
     private String getTagValueToSend(String tagName, String tagValue) {
-        // if a domain is ineligible for detailed tags, instead of sending an empty tag value, send "_other"
+        // if a domain does not have the detailed tagging feature flag enabled, instead of sending an empty tag value, send "_other"
         // this differentiates between intentionally and unintentionally empty tag values ("_other" vs "N/A", respectively)
-        String defaultValue = "_other";
         if (getDetailedTagNames().contains(tagName)) {
             if (FeatureFlagChecker.isToggleEnabled("detailed_tagging")) {
                 return tagValue;
             } else {
-                return defaultValue;
+                return "_other";
             }
         } else {
             return tagValue;

--- a/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
@@ -67,7 +67,7 @@ public class FormplayerDatadog {
      */
     public void addRequestScopedTag(String name, String value) {
         // get correct value to send (only send unique tag value if domain is eligible)
-        String valueToSend = getTagValueToSend(name, value, FeatureFlagChecker.isToggleEnabled("detailed_tagging"));
+        String valueToSend = getTagValueToSend(name, value);
         Tag tag = new Tag(name, valueToSend);
         requestScopedTags.put(name, tag);
     }
@@ -120,7 +120,7 @@ public class FormplayerDatadog {
         HashSet<String> transientKeys = new HashSet<String>();
         
         for (Tag tag : transientTags) {
-            String tagValueToSend = getTagValueToSend(tag.name, tag.value, FeatureFlagChecker.isToggleEnabled("detailed_tagging"));
+            String tagValueToSend = getTagValueToSend(tag.name, tag.value);
             Tag tempTag = new Tag(tag.name, tagValueToSend);
             formattedTags.add(tempTag.formatted());
             // keep track of transient tag names
@@ -144,12 +144,12 @@ public class FormplayerDatadog {
      * @param tagValue - tag value
      * @return String representing tag to send
      */
-    private String getTagValueToSend(String tagName, String tagValue, Boolean isDetailedTaggingEnabled) {
+    private String getTagValueToSend(String tagName, String tagValue) {
         // if a domain is ineligible for detailed tags, instead of sending an empty tag value, send "_other"
         // this differentiates between intentionally and unintentionally empty tag values ("_other" vs "N/A", respectively)
         String defaultValue = "_other";
         if (getDetailedTagNames().contains(tagName)) {
-            if (isDetailedTaggingEnabled) {
+            if (FeatureFlagChecker.isToggleEnabled("detailed_tagging")) {
                 return tagValue;
             } else {
                 return defaultValue;

--- a/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
@@ -6,6 +6,8 @@ import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 
 import java.util.*;
 
+import static org.commcare.formplayer.util.Constants.TOGGLE_DETAILED_TAGGING;
+
 /**
  * Wrapper for the Datadog Java client
  * Provides the ability to set tags throughout the request that will be appended to every datadog request
@@ -148,7 +150,7 @@ public class FormplayerDatadog {
         // if a domain does not have the detailed tagging feature flag enabled, instead of sending an empty tag value, send "_other"
         // this differentiates between intentionally and unintentionally empty tag values ("_other" vs "N/A", respectively)
         if (getDetailedTagNames().contains(tagName)) {
-            if (FeatureFlagChecker.isToggleEnabled("detailed_tagging")) {
+            if (FeatureFlagChecker.isToggleEnabled(TOGGLE_DETAILED_TAGGING)) {
                 return tagValue;
             } else {
                 return "_other";

--- a/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
@@ -57,10 +57,6 @@ public class FormplayerDatadog {
         return this.detailedTagNames;
     }
 
-    public void setDomain(String domain) {
-        this.domain = domain;
-    }
-
     // Tag Management Methods
 
     /**
@@ -153,7 +149,7 @@ public class FormplayerDatadog {
         // this differentiates between intentionally and unintentionally empty tag values ("_other" vs "N/A", respectively)
         String defaultValue = "_other";
         if (getDetailedTagNames().contains(tagName)) {
-            if (domain != null && isDetailedTaggingEnabled) {
+            if (isDetailedTaggingEnabled) {
                 return tagValue;
             } else {
                 return defaultValue;

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
@@ -11,6 +11,7 @@ import org.commcare.formplayer.utils.TestContext;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 
+import static org.commcare.formplayer.util.Constants.TOGGLE_DETAILED_TAGGING;
 import static org.mockito.Mockito.*;
 
 import java.util.*;
@@ -101,7 +102,7 @@ public class FormplayerDatadogTests {
     }
 
     @Test
-    @WithHqUser(enabledToggles = {"detailed_tagging"})
+    @WithHqUser(enabledToggles = {TOGGLE_DETAILED_TAGGING})
     public void testAddRequestScopedDetailedTagForEligibleDomain() {
         // detailed_tag was added to FormplayerDatadog in beforeTest
         datadog.addRequestScopedTag("detailed_tag", "test_value");
@@ -123,7 +124,7 @@ public class FormplayerDatadogTests {
     }
 
     @Test
-    @WithHqUser(enabledToggles = {"detailed_tagging"})
+    @WithHqUser(enabledToggles = {TOGGLE_DETAILED_TAGGING})
     public void testAddTransientDetailedTagForEligibleDomain() {
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
         // detailed_tag was added to FormplayerDatadog in beforeTest

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
@@ -2,12 +2,10 @@ package org.commcare.formplayer.tests;
 
 import com.timgroup.statsd.StatsDClient;
 
-import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.utils.WithHqUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.utils.TestContext;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,12 +13,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 import static org.mockito.Mockito.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @WebMvcTest
 @ContextConfiguration(classes = TestContext.class)
@@ -31,7 +24,7 @@ public class FormplayerDatadogTests {
     @BeforeEach
     public void setUp() throws Exception {
         mockDatadogClient = mock(StatsDClient.class);
-        List<String> detailedTagNames = Arrays.asList("detailed_tag");
+        List<String> detailedTagNames = Collections.singletonList("detailed_tag");
         datadog = new FormplayerDatadog(mockDatadogClient, detailedTagNames);
     }
 
@@ -108,9 +101,9 @@ public class FormplayerDatadogTests {
     }
 
     @Test
+    @WithHqUser(enabledToggles = {"detailed_tagging"})
     public void testAddRequestScopedDetailedTagForEligibleDomain() {
-        String domain = "eligible_domain";
-        datadog.setDomain(domain);
+        // detailed_tag was added to FormplayerDatadog in beforeTest
         datadog.addRequestScopedTag("detailed_tag", "test_value");
         datadog.recordExecutionTime("requests", 100, Collections.emptyList());
         String expectedTag = "detailed_tag:test_value";
@@ -119,9 +112,9 @@ public class FormplayerDatadogTests {
     }
 
     @Test
+    @WithHqUser(enabledToggles = {})
     public void testAddRequestScopedDetailedTagForIneligibleDomain() {
-        String domain = "ineligible_domain";
-        datadog.setDomain(domain);
+        // detailed_tag was added to FormplayerDatadog in beforeTest
         datadog.addRequestScopedTag("detailed_tag", "test_value");
         datadog.recordExecutionTime("requests", 100, Collections.emptyList());
         String expectedTag = "detailed_tag:_other";
@@ -130,19 +123,10 @@ public class FormplayerDatadogTests {
     }
 
     @Test
-    public void testAddRequestScopedDetailedTagForNullDomain() {
-        datadog.addRequestScopedTag("detailed_tag", "test_value");
-        datadog.recordExecutionTime("requests", 100, Collections.emptyList());
-        String expectedTag = "detailed_tag:_other";
-        String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
-    }
-
-    @Test
+    @WithHqUser(enabledToggles = {"detailed_tagging"})
     public void testAddTransientDetailedTagForEligibleDomain() {
-        String domain = "eligible_domain";
-        datadog.setDomain(domain);
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
+        // detailed_tag was added to FormplayerDatadog in beforeTest
         transientTags.add(new FormplayerDatadog.Tag("detailed_tag", "test_value"));
         datadog.recordExecutionTime("requests", 100, transientTags);
         String expectedTag = "detailed_tag:test_value";
@@ -151,21 +135,10 @@ public class FormplayerDatadogTests {
     }
 
     @Test
+    @WithHqUser(enabledToggles = {})
     public void testAddTransientDetailedTagForIneligibleDomain() {
-        // detailed tags should not be added if domain is ineligible
-        String domain = "ineligible_domain";
-        datadog.setDomain(domain);
         List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
-        transientTags.add(new FormplayerDatadog.Tag("detailed_tag", "test_value"));
-        datadog.recordExecutionTime("requests", 100, transientTags);
-        String expectedTag = "detailed_tag:_other";
-        String[] args = {expectedTag};
-        verify(mockDatadogClient).recordExecutionTime("requests", 100, args);
-    }
-
-    @Test
-    public void testAddTransientDetailedTagForNullDomain() {
-        List<FormplayerDatadog.Tag> transientTags = new ArrayList<>();
+        // detailed_tag was added to FormplayerDatadog in beforeTest
         transientTags.add(new FormplayerDatadog.Tag("detailed_tag", "test_value"));
         datadog.recordExecutionTime("requests", 100, transientTags);
         String expectedTag = "detailed_tag:_other";

--- a/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormplayerDatadogTests.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.tests;
 
 import com.timgroup.statsd.StatsDClient;
 
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,9 +31,8 @@ public class FormplayerDatadogTests {
     @BeforeEach
     public void setUp() throws Exception {
         mockDatadogClient = mock(StatsDClient.class);
-        List<String> eligibleDomainsForDetailedTagging = Arrays.asList("eligible_domain");
         List<String> detailedTagNames = Arrays.asList("detailed_tag");
-        datadog = new FormplayerDatadog(mockDatadogClient, eligibleDomainsForDetailedTagging, detailedTagNames);
+        datadog = new FormplayerDatadog(mockDatadogClient, detailedTagNames);
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -113,7 +113,7 @@ public class TestContext {
 
     @Bean
     public FormplayerDatadog datadog() {
-        return Mockito.spy(new FormplayerDatadog(datadogStatsDClient(), new ArrayList<String>(), new ArrayList<String>()));
+        return Mockito.spy(new FormplayerDatadog(datadogStatsDClient(), new ArrayList<String>()));
     }
 
     @Bean


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12284

Now that feature flags are available in formplayer, this should be implement asap. There are a few things I'm having trouble with:

- testing locally I can't seem to get enabled toggles on the user bean even though I know I enabled some on the HQ side. Are there any additional steps to take to enable feature flags on formplayer?

- the automated test should mock the FeatureFlagChecker to return true or false when necessary. Need some help with that since it doesn't appear that mockito can mock static methods? Could be wrong.

HQ PR: https://github.com/dimagi/commcare-hq/pull/29815