### PR TITLE
csrf protection

### DIFF
--- a/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
+++ b/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
 
@@ -49,6 +50,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.authorizeRequests().antMatchers("/**").authenticated();
         http.addFilterAt(getHmacAuthFilter(), UsernamePasswordAuthenticationFilter.class);
         http.addFilterAfter(sessionAuthFilter(), HmacAuthFilter.class);
+        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
         http.cors();
     }
 
@@ -60,7 +62,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     private void disableDefaults(HttpSecurity http) throws Exception {
-        http.csrf().disable();
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.requestCache().disable();  // only needed for login workflow
         http.logout().disable();

--- a/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
+++ b/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import org.commcare.formplayer.auth.CommCareSessionAuthFilter;
 import org.commcare.formplayer.auth.HmacAuthFilter;
 import org.commcare.formplayer.services.FormSessionService;
 import org.commcare.formplayer.services.HqUserDetailsService;
+import org.commcare.formplayer.util.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
+import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -50,7 +52,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.authorizeRequests().antMatchers("/**").authenticated();
         http.addFilterAt(getHmacAuthFilter(), UsernamePasswordAuthenticationFilter.class);
         http.addFilterAfter(sessionAuthFilter(), HmacAuthFilter.class);
-        http.csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+        http.csrf()
+            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+            .ignoringRequestMatchers(new RequestHeaderRequestMatcher(Constants.HMAC_HEADER));
         http.cors();
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/CsrfIntegrationTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CsrfIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.FilterChainProxy;
@@ -36,9 +37,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/**
- * @author $|-|!˅@M
- */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CsrfIntegrationTest {
     @Value("${commcarehq.host}")
@@ -137,6 +135,6 @@ public class CsrfIntegrationTest {
                 "http://localhost:" + port + "/" + Constants.URL_DELETE_APPLICATION_DBS,
                 HttpMethod.POST, entity, String.class);
 
-        System.err.println(response.getStatusCode());
+        assert response.getStatusCode() == HttpStatus.OK;
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/CsrfIntegrationTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CsrfIntegrationTest.java
@@ -1,0 +1,116 @@
+package org.commcare.formplayer.tests;
+
+import org.commcare.formplayer.configuration.WebSecurityConfig;
+import org.commcare.formplayer.services.HqUserDetailsService;
+import org.commcare.formplayer.util.Constants;
+import org.commcare.formplayer.utils.FileUtils;
+import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.http.Cookie;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author $|-|!˅@M
+ */
+@ExtendWith(SpringExtension.class)
+@WebMvcTest
+@ContextConfiguration(classes = { TestContext.class, FilterChainProxy.class, HqUserDetailsService.class, WebSecurityConfig.class })
+public class CsrfIntegrationTest extends BaseTestClass {
+    @Value("${commcarehq.host}")
+    private String host;
+
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        mockUserDetailResponse();
+        mockUtilController = MockMvcBuilders
+                .standaloneSetup(utilController)
+                .apply(springSecurity(springSecurityFilterChain))
+                .build();
+    }
+
+    private void mockUserDetailResponse() {
+        String detailsString = "{" +
+                "\"domains\":[\"casetestdomain\"]," +
+                "\"djangoUserId\":1," +
+                "\"username\":\"casetestuser\"," +
+                "\"superUser\":false" +
+                "}";
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServer.expect(requestTo(host + Constants.SESSION_DETAILS_VIEW))
+                .andExpect(jsonPath("$.sessionId").value("derp"))
+                .andExpect(header("X-MAC-DIGEST", "fOvC0ttB/nSI4CkRc5quDvNlDBuA2aXGZWgZLgMorbg="))
+                .andExpect(jsonPath("$.domain").value("casetestdomain"))
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    public void postApiCall_withCsrf_succeeds() throws Exception {
+        String payload = FileUtils.getFile(this.getClass(), "requests/delete_db/delete_db.json");
+        mockUtilController.perform(
+            post("/" + Constants.URL_DELETE_APPLICATION_DBS)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(payload)
+                    .with(testUser())
+                    .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+                    .with(csrf())
+        ).andExpect(status().isOk());
+    }
+
+    private RequestPostProcessor testUser() {
+        return user("user1").password("user1Pass").roles("USER");
+    }
+
+    @Test
+    public void postApiCall_withoutCsrf_fails() throws Exception {
+        String payload = FileUtils.getFile(this.getClass(), "requests/delete_db/delete_db.json");
+        mockUtilController.perform(
+                post("/" + Constants.URL_DELETE_APPLICATION_DBS)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+                        .content(payload)
+        ).andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void getApiCall_withoutCsrf_succeeds() throws Exception {
+        mockUtilController.perform(
+                get("/" + Constants.URL_SERVER_UP)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+        ).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/SAAS-11750

Using `CookieCsrfTokenRepository` to manage the csrf token generation. It persists the CSRF token in a cookie named "XSRF-TOKEN" and then reads from the header "X-XSRF-TOKEN"

Corresponding HQ PR: https://github.com/dimagi/commcare-hq/pull/29954

In case of 403s this PR should be reverted first and then the HQ PR can be reverted. 

## **Deploy instructions**:: 
First the HQ PR should be deployed https://github.com/dimagi/commcare-hq/pull/29954. 
Once that is successful, we can deploy this PR. 