### PR TITLE
Smart linking MVP: claim cases on formplayer

### DIFF
--- a/src/main/java/org/commcare/formplayer/screens/FormplayerSyncScreen.java
+++ b/src/main/java/org/commcare/formplayer/screens/FormplayerSyncScreen.java
@@ -15,6 +15,12 @@ import java.util.Hashtable;
 
 /**
  * Screen to make a sync request to HQ after a case claim
+ *
+ * This ignores the OkHttpClient logic from SyncScreen.
+ * Calling handleInputAndUpdateSession directly causes okhttp3.Credentials
+ * to throw an error due to username being null. Instead of using handleInputAndUpdateSession
+ * to execute the sync request, formplayer just grabs the url from this screen and then
+ * posts is using WebClient - see MenuSessionRunnerService.doSync.
  */
 public class FormplayerSyncScreen extends SyncScreen {
 
@@ -38,7 +44,6 @@ public class FormplayerSyncScreen extends SyncScreen {
             Hashtable<String, String> params = syncPost.getEvaluatedParams(sessionWrapper.getEvaluationContext());
             queryParams = new LinkedMultiValueMap<String, String>();
             if (asUser != null) {
-
                 queryParams.add("commcare_login_as", asUser);
             }
             for (String key: params.keySet()){

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -19,6 +19,7 @@ import org.commcare.suite.model.Detail;
 import org.commcare.suite.model.Endpoint;
 import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.StackFrameStep;
+import org.commcare.suite.model.StackOperation;
 import org.commcare.suite.model.Text;
 import org.commcare.util.screen.*;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
@@ -617,7 +618,20 @@ public class MenuSessionRunnerService {
         }
 
         restoreFactory.performTimedSync(false, false, false);
-        sessionWrapper.executeStackOperations(endpoint.getStackOperations(), evalContext);
+
+        // Sync requests aren't run when executing operations, so stop and check for them after each operation
+        for (StackOperation op : endpoint.getStackOperations()) {
+            sessionWrapper.executeStackOperations(new Vector<>(Arrays.asList(op)), evalContext);
+            Screen s = menuSession.getNextScreen();
+            if (s instanceof FormplayerSyncScreen) {
+                try {
+                    s.init(sessionWrapper);
+                    doSyncGetNext((FormplayerSyncScreen) s, menuSession);
+                } catch (CommCareSessionException ccse) {
+                    throw new RuntimeException("Unable to claim case.");
+                }
+            }
+        }
         menuSessionFactory.rebuildSessionFromFrame(menuSession);
         String[] selections = menuSession.getSelections();
 


### PR DESCRIPTION
PR into https://github.com/dimagi/formplayer/pull/984

https://dimagi-dev.atlassian.net/browse/USH-1185

This uses the same design, and similar code, as https://github.com/dimagi/commcare-core/pull/1024: when executing the stack of an endpoint, pause at the end of each operation and run a sync request if needed.

Note the @ctsims has some design feedback on https://github.com/dimagi/commcare-core/pull/1024 which I haven't thought about yet, but any changes there will likely also get applied to this PR.