### PR TITLE
Sends question_id to webapps

### DIFF
--- a/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
+++ b/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
@@ -35,6 +35,7 @@ public class PromptToJson {
         parseCaption(prompt, questionJson);
         questionJson.put("help", jsonNullIfNull(prompt.getHelpText()));
         questionJson.put("binding", jsonNullIfNull(prompt.getQuestion().getBind().getReference().toString()));
+        questionJson.put("question_id", jsonNullIfNull(prompt.getQuestion().getBind().getReference().getNameLast()));
         questionJson.put("datatype", jsonNullIfNull(parseDataType(prompt)));
         questionJson.put("control", jsonNullIfNull(prompt.getControlType()));
         questionJson.put("required", prompt.isRequired() ? 1 : 0);

--- a/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
+++ b/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
@@ -6,6 +6,7 @@ import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.*;
 import org.javarosa.core.model.data.helper.Selection;
+import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
@@ -34,8 +35,9 @@ public class PromptToJson {
     public static void parseQuestion(FormEntryPrompt prompt, JSONObject questionJson) {
         parseCaption(prompt, questionJson);
         questionJson.put("help", jsonNullIfNull(prompt.getHelpText()));
-        questionJson.put("binding", jsonNullIfNull(prompt.getQuestion().getBind().getReference().toString()));
-        questionJson.put("question_id", jsonNullIfNull(prompt.getQuestion().getBind().getReference().getNameLast()));
+        TreeReference questionRef = prompt.getQuestion().getBind().getReference();
+        questionJson.put("binding", jsonNullIfNull(questionRef.toString()));
+        questionJson.put("question_id", jsonNullIfNull(questionRef.getNameLast()));
         questionJson.put("datatype", jsonNullIfNull(parseDataType(prompt)));
         questionJson.put("control", jsonNullIfNull(prompt.getControlType()));
         questionJson.put("required", prompt.isRequired() ? 1 : 0);

--- a/src/main/java/org/commcare/formplayer/beans/QuestionBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/QuestionBean.java
@@ -20,6 +20,7 @@ public class QuestionBean {
     private String caption;
 
     private String binding;
+    private String question_id;
     private int required;
     private int relevant;
     private Object answer;
@@ -246,5 +247,13 @@ public class QuestionBean {
 
     public String getOutput() {
         return output;
+    }
+
+    public String getQuestion_id() {
+        return question_id;
+    }
+
+    public void setQuestion_id(String question_id) {
+        this.question_id = question_id;
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryTest.java
@@ -28,6 +28,8 @@ public class FormEntryTest extends BaseTestClass{
         configureRestoreFactory("test", "test");
 
         NewFormResponse newSessionResponse = startNewForm("requests/new_form/new_form_2.json", "xforms/question_types.xml");
+        QuestionBean[] questions = newSessionResponse.getTree();
+        assertEquals("intro", questions[0].getQuestion_id());
 
         String sessionId = newSessionResponse.getSessionId();
 


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1070

We want to show the `question_id` in the web apps errored questions text whenever question text is missing. 

HQ PR - https://github.com/dimagi/commcare-hq/pull/30259