### PR TITLE
Set locale before running tests

### DIFF
--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -22,6 +22,7 @@ import org.commcare.modern.util.Pair;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.TimezoneProvider;
 import org.javarosa.core.services.locale.LocalizerManager;
+import org.javarosa.core.services.locale.Localization;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -181,6 +182,8 @@ public class BaseTestClass {
         restoreFactoryMock.getSQLiteDB().closeConnection();
         PrototypeUtils.setupThreadLocalPrototypes();
         LocalizerManager.setUseThreadLocalStrategy(true);
+        LocalizerManager.getGlobalLocalizer().addAvailableLocale("default");
+        Localization.setLocale("default");
         new SQLiteProperties().setDataDir(getDatabaseFolderRoot());
         MockTimezoneProvider tzProvider = new MockTimezoneProvider();
         DateUtils.setTimezoneProvider(tzProvider);


### PR DESCRIPTION
For some context, this was initially brought up in [this PR](https://github.com/dimagi/formplayer/pull/974#discussion_r651705071). That PR was eventually reverted, with no intention of re-merging in the near future. 

I think only some devs have experienced this issue, and don't have a good explanation for why that is.