### PR TITLE
Smart linking in web apps

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -61,7 +61,8 @@ public class MenuController extends AbstractBaseController {
                     sessionNavigationBean.getSearchText(),
                     sessionNavigationBean.getSortIndex(),
                     sessionNavigationBean.isForceManualAction(),
-                    sessionNavigationBean.getCasesPerPage()
+                    sessionNavigationBean.getCasesPerPage(),
+                    sessionNavigationBean.getSmartLink()
             );
             logNotification(baseResponseBean.getNotification(),request);
             // See if we have a persistent case tile to expand
@@ -86,7 +87,8 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.isForceManualAction(),
-                sessionNavigationBean.getCasesPerPage()
+                sessionNavigationBean.getCasesPerPage(),
+                sessionNavigationBean.getSmartLink()
         );
         logNotification(baseResponseBean.getNotification(),request);
 
@@ -143,7 +145,8 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.isForceManualAction(),
-                sessionNavigationBean.getCasesPerPage()
+                sessionNavigationBean.getCasesPerPage(),
+                sessionNavigationBean.getSmartLink()
         );
         logNotification(response.getNotification(), request);
         return setLocationNeeds(response, menuSession);

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -62,7 +62,7 @@ public class MenuController extends AbstractBaseController {
                     sessionNavigationBean.getSortIndex(),
                     sessionNavigationBean.isForceManualAction(),
                     sessionNavigationBean.getCasesPerPage(),
-                    sessionNavigationBean.getSmartLinkParams()
+                    sessionNavigationBean.getSmartLinkTemplate()
             );
             logNotification(baseResponseBean.getNotification(),request);
             // See if we have a persistent case tile to expand
@@ -88,7 +88,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.isForceManualAction(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSmartLinkParams()
+                sessionNavigationBean.getSmartLinkTemplate()
         );
         logNotification(baseResponseBean.getNotification(),request);
 
@@ -146,7 +146,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.isForceManualAction(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSmartLinkParams()
+                sessionNavigationBean.getSmartLinkTemplate()
         );
         logNotification(response.getNotification(), request);
         return setLocationNeeds(response, menuSession);

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -62,7 +62,7 @@ public class MenuController extends AbstractBaseController {
                     sessionNavigationBean.getSortIndex(),
                     sessionNavigationBean.isForceManualAction(),
                     sessionNavigationBean.getCasesPerPage(),
-                    sessionNavigationBean.getSmartLink()
+                    sessionNavigationBean.getSmartLinkParams()
             );
             logNotification(baseResponseBean.getNotification(),request);
             // See if we have a persistent case tile to expand
@@ -88,7 +88,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.isForceManualAction(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSmartLink()
+                sessionNavigationBean.getSmartLinkParams()
         );
         logNotification(baseResponseBean.getNotification(),request);
 
@@ -146,7 +146,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.isForceManualAction(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSmartLink()
+                sessionNavigationBean.getSmartLinkParams()
         );
         logNotification(response.getNotification(), request);
         return setLocationNeeds(response, menuSession);

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -25,7 +25,7 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int sortIndex;
     private boolean forceManualSearch;
     private int casesPerPage;
-    private String[] smartLinkParams;
+    private String smartLinkTemplate;
 
     public String[] getSelections() {
         return selections;
@@ -110,14 +110,14 @@ public class SessionNavigationBean extends InstallRequestBean {
         isPersistent = persistent;
     }
 
-    @JsonGetter(value = "smart_link_params")
-    public String[] getSmartLinkParams() {
-        return smartLinkParams;
+    @JsonGetter(value = "smart_link_template")
+    public String getSmartLinkTemplate() {
+        return smartLinkTemplate;
     }
 
-    @JsonSetter(value = "smart_link_params")
-    public void setSmartLinkParams(String[] smartLinkParams) {
-        this.smartLinkParams = smartLinkParams;
+    @JsonSetter(value = "smart_link_template")
+    public void setSmartLinkTemplate(String smartLinkTemplate) {
+        this.smartLinkTemplate = smartLinkTemplate;
     }
 
     public int getSortIndex() {

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -25,7 +25,7 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int sortIndex;
     private boolean forceManualSearch;
     private int casesPerPage;
-    private String smartLink;
+    private String[] smartLinkParams;
 
     public String[] getSelections() {
         return selections;
@@ -110,14 +110,14 @@ public class SessionNavigationBean extends InstallRequestBean {
         isPersistent = persistent;
     }
 
-    @JsonGetter(value = "smart_link")
-    public String getSmartLink() {
-        return smartLink;
+    @JsonGetter(value = "smart_link_params")
+    public String[] getSmartLinkParams() {
+        return smartLinkParams;
     }
 
-    @JsonSetter(value = "smart_link")
-    public void setSmartLink(String wantSmartLink) {
-        smartLink = wantSmartLink;
+    @JsonSetter(value = "smart_link_params")
+    public void setSmartLinkParams(String[] smartLinkParams) {
+        this.smartLinkParams = smartLinkParams;
     }
 
     public int getSortIndex() {

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -25,6 +25,7 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int sortIndex;
     private boolean forceManualSearch;
     private int casesPerPage;
+    private String smartLink;
 
     public String[] getSelections() {
         return selections;
@@ -107,6 +108,16 @@ public class SessionNavigationBean extends InstallRequestBean {
 
     public void setIsPersistent(boolean persistent) {
         isPersistent = persistent;
+    }
+
+    @JsonGetter(value = "smart_link")
+    public String getSmartLink() {
+        return smartLink;
+    }
+
+    @JsonSetter(value = "smart_link")
+    public void setSmartLink(String wantSmartLink) {
+        smartLink = wantSmartLink;
     }
 
     public int getSortIndex() {

--- a/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
@@ -23,6 +23,7 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
     private String appVersion;
     private String[] selections;
     private HashMap<String, String> translations;
+    private String smartLinkRedirect;
 
     public BaseResponseBean() {}
 
@@ -43,6 +44,14 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getSmartLinkRedirect() {
+        return smartLinkRedirect;
+    }
+
+    public void setSmartLinkRedirect(String smartLinkRedirect) {
+        this.smartLinkRedirect = smartLinkRedirect;
     }
 
     public NotificationMessage getNotification() {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -7,6 +7,10 @@ import org.commcare.util.screen.EntityDetailSubscreen;
 import org.commcare.util.screen.EntityScreen;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.xpath.XPathParseTool;
+import org.javarosa.xpath.expr.XPathExpression;
+import org.javarosa.xpath.XPathNodeset;
+import org.javarosa.xpath.parser.XPathSyntaxException;
 
 import java.util.ArrayList;
 
@@ -17,6 +21,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
 
     private EntityDetailResponse[] entityDetailList;
     private boolean isPersistentDetail;
+    private String[] smartLinkParams;
 
     public EntityDetailListResponse() {}
 
@@ -52,6 +57,8 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
         }
 
         EvaluationContext subContext = new EvaluationContext(ec, ref);
+        setSmartLinkParams(subContext);
+
         ArrayList<Object> accumulator = new ArrayList<>();
         for (int i = 0; i < detailList.length; i++) {
             if (detailList[i].getNodeset() == null) {
@@ -76,6 +83,20 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
         return ret;
     }
 
+    private void setSmartLinkParams(EvaluationContext ec) {
+        try {
+            XPathExpression paramExpr = XPathParseTool.parseXPath("commcare_project");
+            String commcare_project = (String) ((XPathNodeset) paramExpr.eval(ec)).unpack();
+            if (!commcare_project.equals("")) {
+                String[] params = new String[1];
+                params[0] = commcare_project;
+                this.setSmartLinkParams(params);
+            }
+        } catch (XPathSyntaxException e) {
+            // nothing to do here
+        }
+    }
+
     @JsonGetter(value = "details")
     public EntityDetailResponse[] getEntityDetailList() {
         return entityDetailList;
@@ -94,5 +115,15 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     @JsonSetter(value = "isPersistentDetail")
     public void setPersistentDetail(boolean persistentDetail) {
         this.isPersistentDetail = persistentDetail;
+    }
+
+    @JsonGetter(value = "smartLinkParams")
+    public String[] getSmartLinkParams() {
+        return smartLinkParams;
+    }
+
+    @JsonSetter(value = "smartLinkParams")
+    public void setSmartLinkParams(String[] params) {
+        this.smartLinkParams = params;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -13,6 +13,7 @@ import org.javarosa.xpath.XPathNodeset;
 import org.javarosa.xpath.parser.XPathSyntaxException;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * Created by willpride on 1/4/17.
@@ -21,7 +22,7 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
 
     private EntityDetailResponse[] entityDetailList;
     private boolean isPersistentDetail;
-    private String[] smartLinkParams;
+    private HashMap<String, String> smartLinkParams;
 
     public EntityDetailListResponse() {}
 
@@ -88,8 +89,8 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
             XPathExpression paramExpr = XPathParseTool.parseXPath("commcare_project");
             String commcare_project = (String) ((XPathNodeset) paramExpr.eval(ec)).unpack();
             if (!commcare_project.equals("")) {
-                String[] params = new String[1];
-                params[0] = commcare_project;
+                HashMap<String, String> params = new HashMap<>();
+                params.put("domain", commcare_project);
                 this.setSmartLinkParams(params);
             }
         } catch (XPathSyntaxException e) {
@@ -118,12 +119,12 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     }
 
     @JsonGetter(value = "smartLinkParams")
-    public String[] getSmartLinkParams() {
+    public HashMap<String, String> getSmartLinkParams() {
         return smartLinkParams;
     }
 
     @JsonSetter(value = "smartLinkParams")
-    public void setSmartLinkParams(String[] params) {
+    public void setSmartLinkParams(HashMap<String, String> params) {
         this.smartLinkParams = params;
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -200,7 +200,8 @@ public class MenuSessionRunnerService {
         if (command != null) {
             Endpoint endpoint = menuSession.getEndpointByCommand(command);
             if (endpoint != null) {
-                template = template.replace("---", endpoint.getId());
+                Hashtable<String, String> urlArgs = new Hashtable<String, String>();
+                urlArgs.put("endpoint", endpoint.getId());
                 HttpUrl.Builder urlBuilder = HttpUrl.parse(template).newBuilder();
                 OrderedHashtable<String, String> data = session.getData();
                 for (String key : data.keySet()) {
@@ -208,7 +209,7 @@ public class MenuSessionRunnerService {
                         urlBuilder.addQueryParameter(key, data.get(key));
                     }
                 }
-                String finalUrl = urlBuilder.build().toString();
+                String finalUrl = urlBuilder.build(urlArgs).toString();
                 BaseResponseBean responseBean = new BaseResponseBean(null, null, true);
                 System.out.println("final url => " + finalUrl);
                 responseBean.setSmartLinkRedirect(finalUrl);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -202,7 +202,7 @@ public class MenuSessionRunnerService {
             Endpoint endpoint = menuSession.getEndpointByCommand(command);
             if (endpoint != null) {
                 HashMap<String, String> urlArgs = new HashMap<>();
-                urlArgs.put("endpoint", endpoint.getId());
+                urlArgs.put("endpoint_id", endpoint.getId());
                 UriComponentsBuilder urlBuilder = UriComponentsBuilder.fromUriString(template);
                 OrderedHashtable<String, String> data = session.getData();
                 for (String key : data.keySet()) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -118,6 +118,11 @@ public class MenuSessionRunnerService {
                                          int casesPerPage,
                                          String[] smartLinkParams) throws Exception {
         Screen nextScreen = menuSession.getNextScreen();
+        BaseResponseBean smartResponse = getSmartResponse(menuSession, smartLinkParams);
+        if (smartResponse != null) {
+            return smartResponse;
+        }
+
         // No next menu screen? Start form entry!
         if (nextScreen == null) {
             String assertionFailure = getAssertionFailure(menuSession);
@@ -127,20 +132,12 @@ public class MenuSessionRunnerService {
                         true);
                 return responseBean;
             }
-            BaseResponseBean smartResponse = getSmartResponse(menuSession, smartLinkRedirect);
-            if (smartResponse != null) {
-                return smartResponse;
-            }
             return startFormEntry(menuSession);
         }
 
         MenuBean menuResponseBean;
         // We're looking at a module or form menu
         if (nextScreen instanceof MenuScreen) {
-            BaseResponseBean smartResponse = getSmartResponse(menuSession, smartLinkRedirect);
-            if (smartResponse != null) {
-                return smartResponse;
-            }
             menuResponseBean = new CommandListResponseBean(
                     (MenuScreen)nextScreen,
                     menuSession.getSessionWrapper(),

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -34,6 +34,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import org.commcare.formplayer.objects.FormVolatilityRecord;
 import org.commcare.formplayer.repo.MenuSessionRepo;
@@ -200,13 +201,13 @@ public class MenuSessionRunnerService {
         if (command != null) {
             Endpoint endpoint = menuSession.getEndpointByCommand(command);
             if (endpoint != null) {
-                Hashtable<String, String> urlArgs = new Hashtable<String, String>();
+                HashMap<String, String> urlArgs = new HashMap<>();
                 urlArgs.put("endpoint", endpoint.getId());
-                HttpUrl.Builder urlBuilder = HttpUrl.parse(template).newBuilder();
+                UriComponentsBuilder urlBuilder = UriComponentsBuilder.fromUriString(template);
                 OrderedHashtable<String, String> data = session.getData();
                 for (String key : data.keySet()) {
                     if (endpoint.getArguments().contains(key)) {
-                        urlBuilder.addQueryParameter(key, data.get(key));
+                        urlBuilder.queryParam(key, data.get(key));
                     }
                 }
                 String finalUrl = urlBuilder.build(urlArgs).toString();

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -103,7 +103,7 @@ public class MenuSessionRunnerService {
     private static final Log log = LogFactory.getLog(MenuSessionRunnerService.class);
 
     public BaseResponseBean getNextMenu(MenuSession menuSession) throws Exception {
-        return getNextMenu(menuSession, null, 0, "", 0, null, 0);
+        return getNextMenu(menuSession, null, 0, "", 0, null, 0, null);
     }
 
     private BaseResponseBean getNextMenu(MenuSession menuSession,
@@ -112,7 +112,8 @@ public class MenuSessionRunnerService {
                                          String searchText,
                                          int sortIndex,
                                          QueryData queryData,
-                                         int casesPerPage) throws Exception {
+                                         int casesPerPage,
+                                         String smartLinkRedirect) throws Exception {
         Screen nextScreen = menuSession.getNextScreen();
         // No next menu screen? Start form entry!
         if (nextScreen == null) {
@@ -123,12 +124,20 @@ public class MenuSessionRunnerService {
                         true);
                 return responseBean;
             }
+            BaseResponseBean smartResponse = getSmartResponse(menuSession, smartLinkRedirect);
+            if (smartResponse != null) {
+                return smartResponse;
+            }
             return startFormEntry(menuSession);
         }
 
         MenuBean menuResponseBean;
         // We're looking at a module or form menu
         if (nextScreen instanceof MenuScreen) {
+            BaseResponseBean smartResponse = getSmartResponse(menuSession, smartLinkRedirect);
+            if (smartResponse != null) {
+                return smartResponse;
+            }
             menuResponseBean = new CommandListResponseBean(
                     (MenuScreen)nextScreen,
                     menuSession.getSessionWrapper(),
@@ -140,7 +149,7 @@ public class MenuSessionRunnerService {
             // We're looking at a case list or detail screen
             nextScreen.init(menuSession.getSessionWrapper());
             if (nextScreen.shouldBeSkipped()) {
-                return getNextMenu(menuSession, detailSelection, offset, searchText, sortIndex, queryData, casesPerPage);
+                return getNextMenu(menuSession, detailSelection, offset, searchText, sortIndex, queryData, casesPerPage, smartLinkRedirect);
             }
             addHereFuncHandler((EntityScreen)nextScreen, menuSession);
             menuResponseBean = new EntityListResponse(
@@ -181,6 +190,11 @@ public class MenuSessionRunnerService {
         return menuResponseBean;
     }
 
+    private BaseResponseBean getSmartResponse(MenuSession menuSession, String smartLinkRedirect) {
+        // TODO
+        return null;
+    }
+
     private void addHereFuncHandler(EntityScreen nextScreen, MenuSession menuSession) {
         EvaluationContext ec = nextScreen.getEvalContext();
         ec.addFunctionHandler(new FormplayerHereFunctionHandler(menuSession, menuSession.getCurrentBrowserLocation()));
@@ -189,7 +203,7 @@ public class MenuSessionRunnerService {
     public BaseResponseBean advanceSessionWithSelections(MenuSession menuSession,
                                                          String[] selections) throws Exception {
         return advanceSessionWithSelections(menuSession, selections, null, null,
-                0, null, 0, false, 0);
+                0, null, 0, false, 0, null);
     }
 
     /**
@@ -213,7 +227,8 @@ public class MenuSessionRunnerService {
                                                          String searchText,
                                                          int sortIndex,
                                                          boolean forceManualAction,
-                                                         int casesPerPage) throws Exception {
+                                                         int casesPerPage,
+                                                         String smartLinkRedirect) throws Exception {
         BaseResponseBean nextResponse;
         boolean needsDetail;
         // If we have no selections, we're are the root screen.
@@ -225,7 +240,8 @@ public class MenuSessionRunnerService {
                     searchText,
                     sortIndex,
                     queryData,
-                    casesPerPage
+                    casesPerPage,
+                    smartLinkRedirect
             );
         }
         NotificationMessage notificationMessage = null;
@@ -278,7 +294,8 @@ public class MenuSessionRunnerService {
                 searchText,
                 sortIndex,
                 queryData,
-                casesPerPage
+                casesPerPage,
+                smartLinkRedirect
         );
         restoreFactory.cacheSessionSelections(selections);
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -210,7 +210,9 @@ public class MenuSessionRunnerService {
                     HttpUrl.Builder urlBuilder = HttpUrl.parse(template).newBuilder();
                     OrderedHashtable<String, String> data = session.getData();
                     for (String key : data.keySet()) {
-                        urlBuilder.addQueryParameter(key, data.get(key));
+                        if (endpoint.getArguments().contains(key)) {
+                            urlBuilder.addQueryParameter(key, data.get(key));
+                        }
                     }
                     template = urlBuilder.build().toString();
                     BaseResponseBean responseBean = new BaseResponseBean(null, null, true);

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -345,6 +345,10 @@ public class MenuSession implements HereFunctionHandlerListener {
         return engine.getPlatform().getAllEndpoints().get(id);
     }
 
+    public Endpoint getEndpointByCommand(String commandId) {
+        return engine.getPlatform().getEndpointByCommand(commandId);
+    }
+
     public void setCurrentBrowserLocation(String location) {
         this.currentBrowserLocation = location;
     }

--- a/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
@@ -21,6 +21,8 @@ public class FormplayerPropertyManager extends PropertyManager {
     public static final String SKIP_FIXTURES_AFTER_SUBMIT = "cc-skip-fixtures-after-submit";
     public static final String AUTO_ADVANCE_MENU = "cc-auto-advance-menu";
 
+    public static final String SMART_LINK_TEMPLATE = "cc-smart-link-template";
+
     /**
      * Constructor for this PropertyManager
      *
@@ -61,5 +63,9 @@ public class FormplayerPropertyManager extends PropertyManager {
 
     public boolean isAutoAdvanceMenu() {
         return doesPropertyMatch(AUTO_ADVANCE_MENU, NO, YES);
+    }
+
+    public String getSmartLinkTemplate() {
+        return getSingularProperty(SMART_LINK_TEMPLATE);
     }
 }

--- a/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
@@ -21,8 +21,6 @@ public class FormplayerPropertyManager extends PropertyManager {
     public static final String SKIP_FIXTURES_AFTER_SUBMIT = "cc-skip-fixtures-after-submit";
     public static final String AUTO_ADVANCE_MENU = "cc-auto-advance-menu";
 
-    public static final String SMART_LINK_TEMPLATE = "cc-smart-link-template";
-
     /**
      * Constructor for this PropertyManager
      *
@@ -63,9 +61,5 @@ public class FormplayerPropertyManager extends PropertyManager {
 
     public boolean isAutoAdvanceMenu() {
         return doesPropertyMatch(AUTO_ADVANCE_MENU, NO, YES);
-    }
-
-    public String getSmartLinkTemplate() {
-        return getSingularProperty(SMART_LINK_TEMPLATE);
     }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/USH-1292

Opening for review on the general approach.

Depends on https://github.com/dimagi/commcare-core/pull/1046 and should be released together with https://github.com/dimagi/commcare-hq/pull/30441, although using this feature requires making app changes, so the release doesn't need to be perfect / backwards compatible.

This implements smart linking for case search workflows that have a data registry configured. How it works:
1. Case search results now include a `commcare_project` attribute, thanks to https://github.com/dimagi/commcare-hq/pull/30388
1. In formplayer, the `get_details` response when case details is requested adds the `commcare_project` to the response. It's passed in the new `smartLinkParams` attribute on `EntityDetailListResponse`
1. Web apps sees the `smart_link_params`, compares the param to the user's current domain, and if they're different, sends back the params as part of the navigation request - this is the new `smartLinkParams` attribute in the `SessionNavigationBean`. If the domain in the formplayer response is the user's current domain, web apps creates a smart link template, based on the `session_endpoint` URL, the domain, and the app id. The template looks something like `https://www.commcare.org/a/DOMAIN/app/APP_ID/---/`, where the last `---` needs to be replaced by an endpoint id.
1. Formplayer gets the smart link template in the navigation request, determines what the next screen is, and looks up the corresponding endpoint for that screen. This lookup depends on https://github.com/dimagi/commcare-core/pull/1046 adding the command id to the definition of an endpoint.
1. Formplayer adds the endpoint's id and any arguments to the URL and passes it back to web apps, using the new `smartLinkRedirect` attr on `BaseResponseBean`.
   1. Adding in the arguments isn't currently working.
1. Web apps sees the `smartLinkRedirect` attr on the response and does a hard redirect to that URL.

Open issues (also making some comments in the code):
* ~~There probably needs to be some app manager configuration to turn this on. As is, smart links will be generated for any case search config that uses a registry.~~ [USH-1307](https://dimagi-dev.atlassian.net/browse/USH-1307)
* I haven't tested or really thought much about multiple-case workflows.

[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-3592)