### PR TITLE
remove livequery options

### DIFF
--- a/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
@@ -84,7 +84,7 @@ public class UserRestoreAspect {
         }
         if (requestBean.getUsername() != null && requestBean.getDomain() != null) {
             // Normal restore path
-            restoreFactory.configure(requestBean, auth, requestBean.getUseLiveQuery());
+            restoreFactory.configure(requestBean, auth);
         } else if (requestBean instanceof SessionRequestBean){
             // SMS users don't submit username and domain with each request, so obtain from session
             String sessionId = ((SessionRequestBean) requestBean).getSessionId();

--- a/src/main/java/org/commcare/formplayer/beans/AuthenticatedRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/AuthenticatedRequestBean.java
@@ -15,7 +15,6 @@ public class AuthenticatedRequestBean {
     protected String username;
     protected String restoreAs;
     protected boolean mustRestore;
-    private boolean useLiveQuery;
 
     private String sessionId;
     private String restoreAsCaseId;
@@ -70,14 +69,6 @@ public class AuthenticatedRequestBean {
 
     public void setMustRestore(boolean mustRestore) {
         this.mustRestore = mustRestore;
-    }
-
-    public boolean getUseLiveQuery() {
-        return useLiveQuery;
-    }
-
-    public void setUseLiveQuery(boolean useLiveQuery) {
-        this.useLiveQuery = useLiveQuery;
     }
 
     @JsonGetter(value = "tz_offset_millis")

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -139,7 +139,6 @@ public class RestoreFactory {
     CategoryTimingHelper.RecordingTimer downloadRestoreTimer;
 
     private SQLiteDB sqLiteDB = new SQLiteDB(null);
-    private boolean useLiveQuery;
     private boolean hasRestored;
     private String caseId;
     private boolean configured = false;
@@ -165,21 +164,20 @@ public class RestoreFactory {
         this.configured = true;
         sqLiteDB = new UserDB(domain, scrubbedUsername, asUsername);
         log.info(String.format("configuring RestoreFactory with arguments " +
-                "username = %s, asUsername = %s, domain = %s, useLiveQuery = %s", username, asUsername, domain, useLiveQuery));
+                "username = %s, asUsername = %s, domain = %s", username, asUsername, domain));
     }
 
-    public void configure(AuthenticatedRequestBean authenticatedRequestBean, HqAuth auth, boolean useLiveQuery) {
+    public void configure(AuthenticatedRequestBean authenticatedRequestBean, HqAuth auth) {
         this.setUsername(authenticatedRequestBean.getUsername());
         this.setDomain(authenticatedRequestBean.getDomain());
         this.setAsUsername(authenticatedRequestBean.getRestoreAs());
         this.setHqAuth(auth);
-        this.setUseLiveQuery(useLiveQuery);
         this.hasRestored = false;
         this.configured = true;
         sqLiteDB = new UserDB(domain, scrubbedUsername, asUsername);
         log.info(String.format("configuring RestoreFactory from authed request with arguments " +
-                        "username = %s, asUsername = %s, domain = %s, useLiveQuery = %s",
-                username, asUsername, domain, useLiveQuery));
+                        "username = %s, asUsername = %s, domain = %s",
+                username, asUsername, domain));
     }
 
     // This function will only wipe user DBs when they have expired, otherwise will incremental sync
@@ -687,9 +685,6 @@ public class RestoreFactory {
                 builderQueryParamEncoded(builder, "since", syncToken);
             }
             builderQueryParamEncoded(builder, "device_id", getSyncDeviceId());
-            if (useLiveQuery) {
-                builderQueryParamEncoded(builder, "case_sync", "livequery");
-            }
             if (asUsername != null) {
                 String unEncodedAsUsername = asUsername;
                 if (!asUsername.contains("@")) {
@@ -815,14 +810,6 @@ public class RestoreFactory {
 
     public String getScrubbedUsername() {
         return scrubbedUsername;
-    }
-
-    public boolean isUseLiveQuery() {
-        return useLiveQuery;
-    }
-
-    public void setUseLiveQuery(boolean useLiveQuery) {
-        this.useLiveQuery = useLiveQuery;
     }
 
     public boolean getHasRestored() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -725,7 +725,7 @@ public class BaseTestClass {
         Pair<String, InstallRequestBean> refAndBean = getInstallReferenceAndBean(requestPath, InstallRequestBean.class);
         InstallRequestBean bean = refAndBean.second;
         storageFactoryMock.configure(bean);
-        restoreFactoryMock.configure(bean, new DjangoAuth("key"), bean.getUseLiveQuery());
+        restoreFactoryMock.configure(bean, new DjangoAuth("key"));
         if (bean.isMustRestore()) {
             restoreFactoryMock.performTimedSync();
         }
@@ -799,7 +799,7 @@ public class BaseTestClass {
 
         if (bean instanceof AuthenticatedRequestBean) {
             restoreFactoryMock.getSQLiteDB().closeConnection();
-            restoreFactoryMock.configure((AuthenticatedRequestBean) bean, new DjangoAuth("derp"), false);
+            restoreFactoryMock.configure((AuthenticatedRequestBean) bean, new DjangoAuth("derp"));
         }
 
         if (bean instanceof InstallRequestBean) {

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -35,7 +35,7 @@ public class RestoreFactoryTest {
         requestBean.setRestoreAs(asUsername);
         requestBean.setUsername(username);
         requestBean.setDomain(domain);
-        restoreFactorySpy.configure(requestBean, new DjangoAuth("key"), false);
+        restoreFactorySpy.configure(requestBean, new DjangoAuth("key"));
     }
 
     private void mockSyncFreq(String freq) {


### PR DESCRIPTION
Now that HQ will only support livequery, we don't need these options in the formplayer code.