### PR TITLE
move prepare external sources into the session wrapper

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -34,6 +34,9 @@ public class MenuSessionFactory {
     private InstallService installService;
 
     @Autowired
+    private CaseSearchHelper caseSearchHelper;
+
+    @Autowired
     protected FormplayerStorageFactory storageFactory;
 
     @Value("${commcarehq.host}")
@@ -96,10 +99,11 @@ public class MenuSessionFactory {
                                     String asUser,
                                     boolean preview) throws Exception {
         return new MenuSession(username, domain, appId, locale,
-                installService, restoreFactory, host, oneQuestionPerScreen, asUser, preview);
+                installService, restoreFactory, host, oneQuestionPerScreen, asUser, preview,
+                caseSearchHelper);
     }
 
     public MenuSession buildSession(SerializableMenuSession serializableMenuSession) throws Exception {
-        return new MenuSession(serializableMenuSession, installService, restoreFactory, host);
+        return new MenuSession(serializableMenuSession, installService, restoreFactory, caseSearchHelper);
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.services;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.SessionDatum;
@@ -49,7 +50,7 @@ public class MenuSessionFactory {
      * By re-walking the frame, we establish the set of selections the user 'would' have made to get
      * to this state without doing end of form navigation. Such a path must always exist in a valid app.
      */
-    public void rebuildSessionFromFrame(MenuSession menuSession) throws CommCareSessionException {
+    public void rebuildSessionFromFrame(MenuSession menuSession) throws CommCareSessionException, RemoteInstanceFetcher.RemoteInstanceException {
         Vector<StackFrameStep> steps = menuSession.getSessionWrapper().getFrame().getSteps();
         menuSession.resetSession();
         Screen screen = menuSession.getNextScreen(false);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -500,7 +500,6 @@ public class MenuSessionRunnerService {
     // Rebuild the session after executing any pending session stack
     private boolean executeAndRebuildSession(MenuSession menuSession) throws CommCareSessionException, RemoteInstanceFetcher.RemoteInstanceException {
         menuSession.getSessionWrapper().syncState();
-        menuSession.getSessionWrapper().prepareExternalSources(caseSearchHelper);
         if (menuSession.getSessionWrapper().finishExecuteAndPop(menuSession.getSessionWrapper().getEvaluationContext())) {
             menuSession.getSessionWrapper().clearVolatiles();
             menuSessionFactory.rebuildSessionFromFrame(menuSession);

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -127,7 +127,7 @@ public class FormSession {
         if (sessionFrame == null) {
             sessionFrame = createSessionFrame(session.getSessionData());
         }
-        initialize(false, session.getSessionData(), storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
+        initialize(false, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
     }
 
     public FormSession(UserSqlSandbox sandbox,
@@ -168,9 +168,9 @@ public class FormSession {
 
         if (instanceContent != null) {
             loadInstanceXml(formDef, instanceContent);
-            initialize(false, sessionData, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
+            initialize(false, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
         } else {
-            initialize(true, sessionData, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
+            initialize(true, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
         }
 
         if (oneQuestionPerScreen) {
@@ -242,11 +242,11 @@ public class FormSession {
         }
     }
 
-    private void initialize(boolean newInstance, Map<String, String> sessionData, StorageManager storageManager,
+    private void initialize(boolean newInstance, StorageManager storageManager,
                             SessionFrame sessionFrame, CaseSearchHelper caseSearchHelper) throws RemoteInstanceFetcher.RemoteInstanceException {
         CommCarePlatform platform = new CommCarePlatform(CommCareConfigEngine.MAJOR_VERSION,
                 CommCareConfigEngine.MINOR_VERSION, CommCareConfigEngine.MINIMAL_VERSION, storageManager);
-        FormplayerSessionWrapper sessionWrapper = new FormplayerSessionWrapper(platform, this.sandbox, sessionData, sessionFrame);
+        FormplayerSessionWrapper sessionWrapper = new FormplayerSessionWrapper(platform, this.sandbox, sessionFrame);
 
         sessionWrapper.prepareExternalSources(caseSearchHelper);
 

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -1,7 +1,6 @@
 package org.commcare.formplayer.session;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.core.interfaces.RemoteInstanceFetcher;
@@ -13,7 +12,6 @@ import org.commcare.formplayer.objects.FormVolatilityRecord;
 import org.commcare.formplayer.objects.FunctionHandler;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
-import org.commcare.formplayer.services.CaseSearchHelper;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.util.Constants;
@@ -27,8 +25,6 @@ import org.commcare.util.engine.CommCareConfigEngine;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.FormIndex;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
-import org.javarosa.core.model.instance.DataInstance;
-import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.utils.DateUtils;
@@ -40,23 +36,15 @@ import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.model.xform.XFormSerializingVisitor;
 import org.javarosa.xform.parse.XFormParser;
-import org.javarosa.xml.util.InvalidStructureException;
-import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.javarosa.xpath.XPathException;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.Map;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Date;
+import java.util.Map;
 
 import static org.commcare.session.SessionFrame.STATE_DATUM_COMPUTED;
 import static org.commcare.session.SessionFrame.STATE_DATUM_VAL;
@@ -103,7 +91,7 @@ public class FormSession {
                        FormSendCalloutHandler formSendCalloutHandler,
                        FormplayerStorageFactory storageFactory,
                        @Nullable CommCareSession commCareSession,
-                       CaseSearchHelper caseSearchHelper) throws Exception {
+                       RemoteInstanceFetcher instanceFetcher) throws Exception {
 
         this.session = session;
         //We don't want ongoing form sessions to change their db state underneath in the middle,
@@ -127,7 +115,7 @@ public class FormSession {
         if (sessionFrame == null) {
             sessionFrame = createSessionFrame(session.getSessionData());
         }
-        initialize(false, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
+        initialize(false, storageFactory.getStorageManager(), sessionFrame, instanceFetcher);
     }
 
     public FormSession(UserSqlSandbox sandbox,
@@ -148,7 +136,7 @@ public class FormSession {
                        boolean inPromptMode,
                        String caseId,
                        @Nullable SessionFrame sessionFrame,
-                       CaseSearchHelper caseSearchHelper) throws Exception {
+                       RemoteInstanceFetcher instanceFetcher) throws Exception {
 
         this.formDef = formDef;
         session = new SerializableFormSession(
@@ -168,9 +156,9 @@ public class FormSession {
 
         if (instanceContent != null) {
             loadInstanceXml(formDef, instanceContent);
-            initialize(false, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
+            initialize(false, storageFactory.getStorageManager(), sessionFrame, instanceFetcher);
         } else {
-            initialize(true, storageFactory.getStorageManager(), sessionFrame, caseSearchHelper);
+            initialize(true, storageFactory.getStorageManager(), sessionFrame, instanceFetcher);
         }
 
         if (oneQuestionPerScreen) {
@@ -243,12 +231,11 @@ public class FormSession {
     }
 
     private void initialize(boolean newInstance, StorageManager storageManager,
-                            SessionFrame sessionFrame, CaseSearchHelper caseSearchHelper) throws RemoteInstanceFetcher.RemoteInstanceException {
+                            SessionFrame sessionFrame, RemoteInstanceFetcher instanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
         CommCarePlatform platform = new CommCarePlatform(CommCareConfigEngine.MAJOR_VERSION,
                 CommCareConfigEngine.MINOR_VERSION, CommCareConfigEngine.MINIMAL_VERSION, storageManager);
-        FormplayerSessionWrapper sessionWrapper = new FormplayerSessionWrapper(platform, this.sandbox, sessionFrame);
-
-        sessionWrapper.prepareExternalSources(caseSearchHelper);
+        FormplayerSessionWrapper sessionWrapper = new FormplayerSessionWrapper(
+                platform, this.sandbox, sessionFrame, instanceFetcher);
 
         formDef.initialize(newInstance, sessionWrapper.getIIF(), session.getInitLang(), false);
 

--- a/src/main/java/org/commcare/formplayer/session/FormplayerInstanceInitializer.java
+++ b/src/main/java/org/commcare/formplayer/session/FormplayerInstanceInitializer.java
@@ -23,17 +23,14 @@ import java.util.Map;
  */
 public class FormplayerInstanceInitializer extends CommCareInstanceInitializer {
 
-    private Map<String, String> sessionData;
 
     public FormplayerInstanceInitializer(UserSqlSandbox sandbox) {
         super(sandbox);
     }
 
     public FormplayerInstanceInitializer(FormplayerSessionWrapper formplayerSessionWrapper,
-                                         UserSqlSandbox mSandbox, CommCarePlatform mPlatform,
-                                         Map<String, String> sessionData) {
+                                         UserSqlSandbox mSandbox, CommCarePlatform mPlatform) {
         super(formplayerSessionWrapper, mSandbox, mPlatform);
-        this.sessionData = sessionData;
     }
 
     @Override

--- a/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
+++ b/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.session;
 
+import lombok.SneakyThrows;
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.core.interfaces.UserSandbox;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.modern.session.SessionWrapper;
@@ -14,25 +16,37 @@ import java.util.Map;
  * Created by willpride on 1/29/16.
  */
 class FormplayerSessionWrapper extends SessionWrapper {
+    private RemoteInstanceFetcher remoteInstanceFetcher;
 
-    public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox) {
-        this(platform, sandbox, new SessionFrame());
+    public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox,
+                                    RemoteInstanceFetcher remoteInstanceFetcher) {
+        this(platform, sandbox, new SessionFrame(), remoteInstanceFetcher);
     }
 
-    public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox, SessionFrame sessionFrame) {
+    public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox, SessionFrame sessionFrame,
+                                    RemoteInstanceFetcher remoteInstanceFetcher) {
         super(platform, sandbox);
         this.frame = sessionFrame;
+        this.remoteInstanceFetcher = remoteInstanceFetcher;
     }
 
-    public FormplayerSessionWrapper(CommCareSession session, CommCarePlatform platform, UserSandbox sandbox) {
+    public FormplayerSessionWrapper(CommCareSession session, CommCarePlatform platform, UserSandbox sandbox,
+                                    RemoteInstanceFetcher remoteInstanceFetcher) {
         super(session, platform, sandbox);
+        this.remoteInstanceFetcher = remoteInstanceFetcher;
+    }
+
+    @SneakyThrows
+    private void initialize() {
+        if (initializer == null) {
+            prepareExternalSources(remoteInstanceFetcher);
+            initializer = new FormplayerInstanceInitializer(this, (UserSqlSandbox) mSandbox, mPlatform);
+        }
     }
 
     @Override
     public CommCareInstanceInitializer getIIF() {
-        if (initializer == null) {
-            initializer = new FormplayerInstanceInitializer(this, (UserSqlSandbox) mSandbox, mPlatform);
-        }
+        initialize();
         return initializer;
     }
 }

--- a/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
+++ b/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
@@ -15,22 +15,17 @@ import java.util.Map;
  */
 class FormplayerSessionWrapper extends SessionWrapper {
 
-    private final Map<String, String> sessionData;
-
     public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox) {
-        this(platform, sandbox, null, new SessionFrame());
+        this(platform, sandbox, new SessionFrame());
     }
 
-    public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox,
-                                    Map<String, String> sessionData, SessionFrame sessionFrame) {
+    public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox, SessionFrame sessionFrame) {
         super(platform, sandbox);
-        this.sessionData = sessionData;
         this.frame = sessionFrame;
     }
 
     public FormplayerSessionWrapper(CommCareSession session, CommCarePlatform platform, UserSandbox sandbox) {
         super(session, platform, sandbox);
-        this.sessionData = null;
     }
 
     @Override

--- a/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
+++ b/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
@@ -19,34 +19,31 @@ class FormplayerSessionWrapper extends SessionWrapper {
     private RemoteInstanceFetcher remoteInstanceFetcher;
 
     public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox,
-                                    RemoteInstanceFetcher remoteInstanceFetcher) {
+                                    RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
         this(platform, sandbox, new SessionFrame(), remoteInstanceFetcher);
     }
 
     public FormplayerSessionWrapper(CommCarePlatform platform, UserSandbox sandbox, SessionFrame sessionFrame,
-                                    RemoteInstanceFetcher remoteInstanceFetcher) {
+                                    RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
         super(platform, sandbox);
         this.frame = sessionFrame;
         this.remoteInstanceFetcher = remoteInstanceFetcher;
+        prepareExternalSources(remoteInstanceFetcher);
     }
 
     public FormplayerSessionWrapper(CommCareSession session, CommCarePlatform platform, UserSandbox sandbox,
-                                    RemoteInstanceFetcher remoteInstanceFetcher) {
+                                    RemoteInstanceFetcher remoteInstanceFetcher) throws RemoteInstanceFetcher.RemoteInstanceException {
         super(session, platform, sandbox);
         this.remoteInstanceFetcher = remoteInstanceFetcher;
+        prepareExternalSources(remoteInstanceFetcher);
     }
 
-    @SneakyThrows
-    private void initialize() {
-        if (initializer == null) {
-            prepareExternalSources(remoteInstanceFetcher);
-            initializer = new FormplayerInstanceInitializer(this, (UserSqlSandbox) mSandbox, mPlatform);
-        }
-    }
 
     @Override
     public CommCareInstanceInitializer getIIF() {
-        initialize();
+        if (initializer == null) {
+            initializer = new FormplayerInstanceInitializer(this, (UserSqlSandbox) mSandbox, mPlatform);
+        }
         return initializer;
     }
 }

--- a/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
+++ b/src/main/java/org/commcare/formplayer/session/FormplayerSessionWrapper.java
@@ -36,7 +36,7 @@ class FormplayerSessionWrapper extends SessionWrapper {
     @Override
     public CommCareInstanceInitializer getIIF() {
         if (initializer == null) {
-            initializer = new FormplayerInstanceInitializer(this, (UserSqlSandbox) mSandbox, mPlatform, sessionData);
+            initializer = new FormplayerInstanceInitializer(this, (UserSqlSandbox) mSandbox, mPlatform);
         }
         return initializer;
     }

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -107,7 +107,7 @@ public class MenuSession implements HereFunctionHandlerListener {
         initializeBreadcrumbs();
     }
 
-    public void resetSession() {
+    public void resetSession() throws RemoteInstanceFetcher.RemoteInstanceException {
         this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox, instanceFetcher);
         clearEntityScreenCache();
         initializeBreadcrumbs();

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.session;
 
+import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.formplayer.engine.FormplayerConfigEngine;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -63,15 +64,17 @@ public class MenuSession implements HereFunctionHandlerListener {
     // Stores the entity screens created to manage state for the lifecycle of this request
     private Map<String, EntityScreen> entityScreenCache = new HashMap<>();
     private boolean oneQuestionPerScreen;
+    private RemoteInstanceFetcher instanceFetcher;
 
     public MenuSession(SerializableMenuSession session, InstallService installService,
-                       RestoreFactory restoreFactory, String host) throws Exception {
+                       RestoreFactory restoreFactory, RemoteInstanceFetcher instanceFetcher) throws Exception {
+        this.instanceFetcher = instanceFetcher;
         this.session = session;
         this.engine = installService.configureApplication(session.getInstallReference(), session.isPreview()).first;
         this.sandbox = restoreFactory.getSandbox();
         this.sessionWrapper = new FormplayerSessionWrapper(
                 SessionSerializer.deserialize(engine.getPlatform(), session.getCommcareSession()),
-                engine.getPlatform(), sandbox);
+                engine.getPlatform(), sandbox, instanceFetcher);
         SessionUtils.setLocale(session.getLocale());
         sessionWrapper.syncState();
         initializeBreadcrumbs();
@@ -79,8 +82,10 @@ public class MenuSession implements HereFunctionHandlerListener {
 
     public MenuSession(String username, String domain, String appId, String locale,
                        InstallService installService, RestoreFactory restoreFactory, String host,
-                       boolean oneQuestionPerScreen, String asUser, boolean preview) throws Exception {
+                       boolean oneQuestionPerScreen, String asUser, boolean preview,
+                       RemoteInstanceFetcher instanceFetcher) throws Exception {
         this.oneQuestionPerScreen = oneQuestionPerScreen;
+        this.instanceFetcher = instanceFetcher;
         String resolvedInstallReference = resolveInstallReference(appId, host, domain);
         this.session = new SerializableMenuSession(
                 TableBuilder.scrubName(username),
@@ -97,13 +102,13 @@ public class MenuSession implements HereFunctionHandlerListener {
             this.sandbox = restoreFactory.performTimedSync();
         }
         this.sandbox = restoreFactory.getSandbox();
-        this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox);
+        this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox, instanceFetcher);
         SessionUtils.setLocale(locale);
         initializeBreadcrumbs();
     }
 
     public void resetSession() {
-        this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox);
+        this.sessionWrapper = new FormplayerSessionWrapper(engine.getPlatform(), sandbox, instanceFetcher);
         clearEntityScreenCache();
         initializeBreadcrumbs();
         selections.clear();


### PR DESCRIPTION
PR into https://github.com/dimagi/commcare-core/pull/1040

This moves the initialisation of external data sources to the session wrapper to ensure that they are always initialised when required. The potential downside here is that it get's called more frequently than required.

First two commits are a minor pre-factor.