### PR TITLE
Update README to include Mac installation error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ You're likely running the wrong version of Java. Check with `java -version` whic
   - Update `~/.gradle/gradle.properties` with `org.gradle.java.home=/JDK_PATH`
   - OR run append this to gradle commands: `-Dorg.gradle.java.home=/JDK_PATH`
 
+*Could not find tools.jar on MacOS*
+
+A Big Sur update caused the built-in Java to take precedence.Follow the steps in the number one answer [here](https://stackoverflow.com/questions/64968851/could-not-find-tools-jar-please-check-that-library-internet-plug-ins-javaapple) to add the non "Internet Plug-Ins" Java to your path.
+
 ### Running in IntelliJ
 
 In order to set breakpoints, step through code, and link the runtime with source you'll need to run the code in an IDE. We use IntelliJ. To setup

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You're likely running the wrong version of Java. Check with `java -version` whic
 
 *Could not find tools.jar on MacOS*
 
-A Big Sur update caused the built-in Java to take precedence.Follow the steps in the number one answer [here](https://stackoverflow.com/questions/64968851/could-not-find-tools-jar-please-check-that-library-internet-plug-ins-javaapple) to add the non "Internet Plug-Ins" Java to your path.
+A Big Sur update caused the built-in Java to take precedence. Follow the steps in the number one answer [here](https://stackoverflow.com/questions/64968851/could-not-find-tools-jar-please-check-that-library-internet-plug-ins-javaapple) to add the non "Internet Plug-Ins" Java to your path.
 
 ### Running in IntelliJ
 


### PR DESCRIPTION
I ran into an error with my Java version while trying to get Formplayer going from this repo. Turns out it's Mac related and added a link to a StackOverflowfix that might be helpful to others.

Only a Readme edit, no code changes.