### PR TITLE
Removed automatic sync from smart link navigation

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -700,8 +700,6 @@ public class MenuSessionRunnerService {
             throw new RuntimeException(String.format("Invalid arguments supplied for link.%s%s", missingMessage, unexpectedMessage));
         }
 
-        restoreFactory.performTimedSync(false, false, false);
-
         // Sync requests aren't run when executing operations, so stop and check for them after each operation
         for (StackOperation op : endpoint.getStackOperations()) {
             sessionWrapper.executeStackOperations(new Vector<>(Arrays.asList(op)), evalContext);


### PR DESCRIPTION
PR into https://github.com/dimagi/formplayer/pull/1028

I [originally added this sync](https://github.com/dimagi/formplayer/pull/984#issuecomment-876702999) for the sake of claiming cases, but syncing is now handled a few lines down, in `doSyncGetNext`, only if a claim actually happens.