### PR TITLE
refator advance session with selections

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -131,7 +131,7 @@ public class MenuSessionFactory {
             }
         }
         if (screen != null) {
-            menuSession.autoAdvance(false, storageFactory.getPropertyManager().isAutoAdvanceMenu());
+            menuSession.autoAdvance(screen, storageFactory.getPropertyManager().isAutoAdvanceMenu());
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -7,7 +7,6 @@ import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.core.interfaces.RemoteInstanceFetcher;
-import org.commcare.suite.model.EntityDatum;
 import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
@@ -16,8 +15,6 @@ import org.commcare.util.screen.EntityScreen;
 import org.commcare.util.screen.MenuScreen;
 import org.commcare.util.screen.QueryScreen;
 import org.commcare.util.screen.Screen;
-import org.javarosa.core.model.instance.TreeReference;
-import org.javarosa.core.util.OrderedHashtable;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +25,6 @@ import org.commcare.formplayer.session.MenuSession;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
-import java.util.Set;
 import java.util.Vector;
 
 /**
@@ -131,7 +127,7 @@ public class MenuSessionFactory {
             }
         }
         if (screen != null) {
-            menuSession.autoAdvance(screen, storageFactory.getPropertyManager().isAutoAdvanceMenu());
+            menuSession.autoAdvanceMenu(screen, storageFactory.getPropertyManager().isAutoAdvanceMenu());
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -125,10 +125,13 @@ public class MenuSessionFactory {
             if (currentStep == null) {
                 break;
             } else if (currentStep != NEXT_SCREEN) {
-                menuSession.handleInput(currentStep, false, true, false, storageFactory.getPropertyManager().isAutoAdvanceMenu());
+                menuSession.handleInput(currentStep, false, true, false);
                 menuSession.addSelection(currentStep);
                 screen = menuSession.getNextScreen(false);
             }
+        }
+        if (screen != null) {
+            menuSession.autoAdvance(false, storageFactory.getPropertyManager().isAutoAdvanceMenu());
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -372,11 +372,10 @@ public class MenuSessionRunnerService {
         if ((queryData != null && queryData.getExecute(queryKey)) || autoSearch) {
             NotificationMessage notificationMessage = doQuery(
                     queryScreen,
-                    menuSession,
                     queryData == null ? null : queryData.getInputs(queryKey),
                     queryScreen.doDefaultSearch() && !forceManualAction
             );
-            if (notificationMessage != null && notificationMessage.isError()) {
+            if (notificationMessage.isError()) {
                 throw new CommCareSessionException(notificationMessage.getMessage());
             }
             return true;
@@ -464,12 +463,9 @@ public class MenuSessionRunnerService {
      * Will do nothing if this wasn't a query screen.
      */
     private NotificationMessage doQuery(FormplayerQueryScreen screen,
-                                        MenuSession menuSession,
                                         Hashtable<String, String> queryDictionary,
-                                        boolean skipDefaultPromptValues) throws CommCareSessionException {
+                                        boolean skipDefaultPromptValues) {
         log.info("Formplayer doing query with dictionary " + queryDictionary);
-        NotificationMessage notificationMessage = null;
-
         if (queryDictionary != null) {
             screen.answerPrompts(queryDictionary);
         }
@@ -488,6 +484,7 @@ public class MenuSessionRunnerService {
             error = "Query response format error: " + e.getMessage();
         }
 
+        NotificationMessage notificationMessage;
         if (error != null) {
             notificationMessage = new NotificationMessage(
                     "Query failed with message " + error,
@@ -497,8 +494,6 @@ public class MenuSessionRunnerService {
             notificationMessage = new NotificationMessage(screen.getCurrentMessage(), false, NotificationMessage.Tag.query);
         }
 
-        Screen nextScreen = menuSession.getNextScreen();
-        log.info("Next screen after query: " + nextScreen);
         return notificationMessage;
     }
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -271,12 +271,7 @@ public class MenuSessionRunnerService {
             }
 
             if (nextScreen instanceof FormplayerSyncScreen) {
-                BaseResponseBean syncResponse = doSyncGetNext(
-                        (FormplayerSyncScreen)nextScreen,
-                        menuSession);
-                if (syncResponse != null) {
-                    return syncResponse;
-                }
+                return doSyncGetNext((FormplayerSyncScreen)nextScreen, menuSession);
             }
 
             if (nextScreen == null && menuSession.getSessionWrapper().getForm() == null) {
@@ -310,8 +305,7 @@ public class MenuSessionRunnerService {
             if (notificationMessage == null) {
                 notificationMessage = new NotificationMessage(null, false, NotificationMessage.Tag.selection);
             }
-            BaseResponseBean responseBean = new BaseResponseBean(null, notificationMessage,true);
-            return responseBean;
+            return new BaseResponseBean(null, notificationMessage,true);
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -257,7 +257,7 @@ public class MenuSessionRunnerService {
             // minimal entity screens are only safe if there will be no further selection
             // and we do not need the case detail
             needsDetail = detailSelection != null || i != selections.length;
-            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, true, isAutoAdvanceMenu());
+            boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, confirmed, true);
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
                         "Overflowed selections with selection " + selection + " at index " + i,
@@ -265,6 +265,7 @@ public class MenuSessionRunnerService {
                         NotificationMessage.Tag.selection);
                 break;
             }
+            menuSession.autoAdvance(needsDetail, isAutoAdvanceMenu());
             Screen nextScreen = menuSession.getNextScreen(needsDetail);
 
             String nextInput = i == selections.length ? "" : selections[i];
@@ -386,7 +387,7 @@ public class MenuSessionRunnerService {
             EntityScreen entityScreen = (EntityScreen) nextScreen;
             entityScreen.evaluateAutoLaunch(nextInput);
             if (entityScreen.getAutoLaunchAction() != null) {
-                menuSession.handleInput(selection, needsDetail, confirmed, true, isAutoAdvanceMenu());
+                menuSession.handleInput(selection, needsDetail, confirmed, true);
                 nextScreen = menuSession.getNextScreen(needsDetail);
             }
         }
@@ -507,6 +508,7 @@ public class MenuSessionRunnerService {
             Screen nextScreen = menuSession.getNextScreen();
             nextScreen = handleAutoLaunch(nextScreen, menuSession, "", false, false, "");
             handleQueryScreen(nextScreen, menuSession, new QueryData(), false, false);
+            menuSession.autoAdvance(false, isAutoAdvanceMenu());
             BaseResponseBean response = getNextMenu(menuSession);
             response.setSelections(menuSession.getSelections());
             return response;

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -245,7 +245,6 @@ public class MenuSessionRunnerService {
             );
         }
         NotificationMessage notificationMessage = null;
-        boolean rebuildSession = false;
         for (int i = 1; i <= selections.length; i++) {
             String selection = selections[i - 1];
 
@@ -263,9 +262,11 @@ public class MenuSessionRunnerService {
                 break;
             }
             String nextInput = i == selections.length ? NO_SELECTION : selections[i];
-            Screen nextScreen = null;
+            Screen nextScreen;
             try {
-                nextScreen = autoAdvanceSession(menuSession, selection, nextInput, queryData, needsDetail, confirmed, forceManualAction);
+                nextScreen = autoAdvanceSession(
+                        menuSession, selection, nextInput, queryData, needsDetail, confirmed, forceManualAction
+                );
             } catch (CommCareSessionException e) {
                 notificationMessage = new NotificationMessage(e.getMessage(), true, NotificationMessage.Tag.query);
                 break;
@@ -283,7 +284,6 @@ public class MenuSessionRunnerService {
             if (nextScreen == null && menuSession.getSessionWrapper().getForm() == null) {
                 // we don't have a resolution, try rebuilding session to execute any pending ops
                 executeAndRebuildSession(menuSession);
-                rebuildSession = true;
             } else {
                 menuSession.addSelection(selection);
             }
@@ -325,9 +325,9 @@ public class MenuSessionRunnerService {
             boolean needsDetail,
             boolean confirmed,
             boolean forceManualAction) throws CommCareSessionException {
-        boolean sessionAdvanced = false;
+        boolean sessionAdvanced;
 
-        Screen nextScreen = null;
+        Screen nextScreen;
         do {
             sessionAdvanced = false;
             nextScreen = menuSession.getNextScreen(needsDetail);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -265,7 +265,6 @@ public class MenuSessionRunnerService {
                         NotificationMessage.Tag.selection);
                 break;
             }
-            menuSession.autoAdvance(needsDetail, isAutoAdvanceMenu());
             Screen nextScreen = menuSession.getNextScreen(needsDetail);
 
             String nextInput = i == selections.length ? "" : selections[i];
@@ -286,6 +285,7 @@ public class MenuSessionRunnerService {
                     return syncResponse;
                 }
             }
+            menuSession.autoAdvance(needsDetail, isAutoAdvanceMenu());
 
             if (nextScreen == null && menuSession.getSessionWrapper().getForm() == null) {
                 // we don't have a resolution, try rebuilding session to execute any pending ops

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -285,7 +285,9 @@ public class MenuSessionRunnerService {
                     return syncResponse;
                 }
             }
-            menuSession.autoAdvance(nextScreen, isAutoAdvanceMenu());
+            if (menuSession.autoAdvance(nextScreen, isAutoAdvanceMenu())) {
+                nextScreen = menuSession.getNextScreen(needsDetail);
+            }
 
             if (nextScreen == null && menuSession.getSessionWrapper().getForm() == null) {
                 // we don't have a resolution, try rebuilding session to execute any pending ops

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -390,7 +390,6 @@ public class MenuSessionRunnerService {
             );
             return true;
         } else if (queryData != null) {
-            // TODO: this doesn't belong here. Move it to menuSession.handleInput
             answerQueryPrompts(queryScreen, queryData.getInputs(queryKey));
             return false;
         }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -335,9 +335,12 @@ public class MenuSessionRunnerService {
         boolean sessionAdvanced;
         Screen nextScreen = null;
         Screen previousScreen;
+        int iterationCount = 0;
+        int maxIterations = 50; // maximum plausible iterations
         do {
             sessionAdvanced = false;
             previousScreen = nextScreen;
+            iterationCount += 1;
 
             nextScreen = menuSession.getNextScreen(needsDetail);
             if (previousScreen != null) {
@@ -358,7 +361,7 @@ public class MenuSessionRunnerService {
             } else if (nextScreen instanceof MenuScreen) {
                 sessionAdvanced = menuSession.autoAdvanceMenu(nextScreen, isAutoAdvanceMenu());
             }
-        } while(sessionAdvanced);
+        } while(!Thread.interrupted() && sessionAdvanced && iterationCount < maxIterations);
 
         return nextScreen;
     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -483,9 +483,6 @@ public class MenuSessionRunnerService {
             URI uri = screen.getUri(skipDefaultPromptValues);
             ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(
                     screen.getQueryDatum().getDataId(), screen.getQueryDatum().useCaseTemplate(), uri);
-            if (searchDataInstance == null) {
-                throw new CommCareSessionException("No result from query");
-            }
             screen.setQueryDatum(searchDataInstance);
         } catch (InvalidStructureException | IOException
                 | XmlPullParserException | UnfullfilledRequirementsException e) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -329,6 +329,7 @@ public class MenuSessionRunnerService {
 
         Screen nextScreen = null;
         do {
+            sessionAdvanced = false;
             nextScreen = menuSession.getNextScreen(needsDetail);
             if (nextScreen instanceof EntityScreen) {
                 // Advance the session in case auto launch is set

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -229,8 +229,6 @@ public class MenuSessionRunnerService {
                                                          boolean forceManualAction,
                                                          int casesPerPage,
                                                          String smartLinkTemplate) throws Exception {
-        BaseResponseBean nextResponse;
-        boolean needsDetail;
         // If we have no selections, we're are the root screen.
         if (selections == null) {
             return getNextMenu(
@@ -252,7 +250,7 @@ public class MenuSessionRunnerService {
 
             // minimal entity screens are only safe if there will be no further selection
             // and we do not need the case detail
-            needsDetail = detailSelection != null || i != selections.length;
+            boolean needsDetail = detailSelection != null || i != selections.length;
             boolean gotNextScreen = menuSession.handleInput(selection, needsDetail, inputValidated, true);
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
@@ -289,7 +287,7 @@ public class MenuSessionRunnerService {
             }
         }
 
-        nextResponse = getNextMenu(
+        BaseResponseBean nextResponse = getNextMenu(
                 menuSession,
                 detailSelection,
                 offset,

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -285,7 +285,7 @@ public class MenuSessionRunnerService {
                     return syncResponse;
                 }
             }
-            menuSession.autoAdvance(needsDetail, isAutoAdvanceMenu());
+            menuSession.autoAdvance(nextScreen, isAutoAdvanceMenu());
 
             if (nextScreen == null && menuSession.getSessionWrapper().getForm() == null) {
                 // we don't have a resolution, try rebuilding session to execute any pending ops
@@ -507,8 +507,8 @@ public class MenuSessionRunnerService {
 
             Screen nextScreen = menuSession.getNextScreen();
             nextScreen = handleAutoLaunch(nextScreen, menuSession, "", false, false, "");
-            handleQueryScreen(nextScreen, menuSession, new QueryData(), false, false);
-            menuSession.autoAdvance(false, isAutoAdvanceMenu());
+            nextScreen = handleQueryScreen(nextScreen, menuSession, new QueryData(), false, false);
+            menuSession.autoAdvance(nextScreen, isAutoAdvanceMenu());
             BaseResponseBean response = getNextMenu(menuSession);
             response.setSelections(menuSession.getSelections());
             return response;

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -479,28 +479,19 @@ public class MenuSessionRunnerService {
             screen.answerPrompts(queryDictionary);
         }
 
-        ExternalDataInstance searchDataInstance;
         try {
-            searchDataInstance = searchAndSetResult(
-                    screen,
-                    screen.getUri(skipDefaultPromptValues));
+            URI uri = screen.getUri(skipDefaultPromptValues);
+            ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(
+                    screen.getQueryDatum().getDataId(), screen.getQueryDatum().useCaseTemplate(), uri);
             if (searchDataInstance == null) {
                 throw new CommCareSessionException("No result from query");
             }
+            screen.setQueryDatum(searchDataInstance);
         } catch (InvalidStructureException | IOException
                 | XmlPullParserException | UnfullfilledRequirementsException e) {
             throw new CommCareSessionException("Query response format error: " + e.getMessage(), e);
         }
     }
-
-    public ExternalDataInstance searchAndSetResult(FormplayerQueryScreen screen, URI uri)
-            throws UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
-        ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(screen.getQueryDatum().getDataId(),
-                screen.getQueryDatum().useCaseTemplate(), uri);
-        screen.setQueryDatum(searchDataInstance);
-        return searchDataInstance;
-    }
-
 
     public BaseResponseBean resolveFormGetNext(MenuSession menuSession) throws Exception {
         if (executeAndRebuildSession(menuSession)) {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -130,7 +130,7 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @param allowAutoLaunch If this step is allowed to automatically launch an action,
      *                        assuming it has an autolaunch action specified.
      */
-    public boolean handleInput(String input, boolean needsDetail, boolean confirmed, boolean allowAutoLaunch, boolean autoAdvanceMenu) throws CommCareSessionException {
+    public boolean handleInput(String input, boolean needsDetail, boolean confirmed, boolean allowAutoLaunch) throws CommCareSessionException {
         Screen screen = getNextScreen(needsDetail);
         log.info("Screen " + screen + " handling input " + input);
         if (screen == null) {
@@ -145,7 +145,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 if (input.startsWith("action ") || (autoLaunch) || !confirmed) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, confirmed, allowAutoLaunch, autoAdvanceMenu);
+                        return handleInput(input, true, confirmed, allowAutoLaunch);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input, allowAutoLaunch);
                 } else {
@@ -158,8 +158,6 @@ public class MenuSession implements HereFunctionHandlerListener {
             if (addBreadcrumb) {
                 addTitle(input, screen);
             }
-
-            autoAdvance(needsDetail, autoAdvanceMenu);
 
             return true;
         } catch (ArrayIndexOutOfBoundsException | NullPointerException e) {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -177,8 +177,11 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @throws CommCareSessionException
      */
     public void autoAdvance(boolean needsDetail, boolean autoAdvanceMenu) throws CommCareSessionException {
+        if (!autoAdvanceMenu) {
+            return;
+        }
         Screen nextScreen = getNextScreen(needsDetail);
-        if (nextScreen instanceof MenuScreen && autoAdvanceMenu) {
+        if (nextScreen instanceof MenuScreen) {
             ((MenuScreen)nextScreen).handleAutoMenuAdvance(sessionWrapper);
         }
     }

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -125,12 +125,12 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @param input           The user step input
      * @param needsDetail     Whether a full entity screen is required for this request
      *                        or if a list of references is sufficient
-     * @param confirmed       Whether the input has been previously validated,
+     * @param inputValidated  Whether the input has been previously validated,
      *                        allowing this step to skip validation
      * @param allowAutoLaunch If this step is allowed to automatically launch an action,
      *                        assuming it has an autolaunch action specified.
      */
-    public boolean handleInput(String input, boolean needsDetail, boolean confirmed, boolean allowAutoLaunch) throws CommCareSessionException {
+    public boolean handleInput(String input, boolean needsDetail, boolean inputValidated, boolean allowAutoLaunch) throws CommCareSessionException {
         Screen screen = getNextScreen(needsDetail);
         log.info("Screen " + screen + " handling input " + input);
         if (screen == null) {
@@ -142,10 +142,10 @@ public class MenuSession implements HereFunctionHandlerListener {
                 EntityScreen entityScreen = (EntityScreen)screen;
                 boolean autoLaunch = entityScreen.getAutoLaunchAction() != null && allowAutoLaunch;
                 addBreadcrumb = !autoLaunch;
-                if (input.startsWith("action ") || (autoLaunch) || !confirmed) {
+                if (input.startsWith("action ") || (autoLaunch) || !inputValidated) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, confirmed, allowAutoLaunch);
+                        return handleInput(input, true, inputValidated, allowAutoLaunch);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input, allowAutoLaunch);
                 } else {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -172,14 +172,16 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @param screen The current screen that has been navigated to.
      * @param autoAdvanceMenu Whether the menu navigation should be advanced if it can be.
      * @throws CommCareSessionException
+     * @return true if the session was advanced
      */
-    public void autoAdvance(Screen screen, boolean autoAdvanceMenu) throws CommCareSessionException {
+    public boolean autoAdvance(Screen screen, boolean autoAdvanceMenu) throws CommCareSessionException {
         if (!autoAdvanceMenu) {
-            return;
+            return false;
         }
         if (screen instanceof MenuScreen) {
-            ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
+            return ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
         }
+        return false;
     }
 
     private void addTitle(String input, Screen previousScreen) {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -154,16 +154,17 @@ public class MenuSession implements HereFunctionHandlerListener {
             } else {
                 screen.handleInputAndUpdateSession(sessionWrapper, input, allowAutoLaunch);
             }
-            Screen previousScreen = screen;
+
+            if (addBreadcrumb) {
+                addTitle(input, screen);
+            }
+
             screen = getNextScreen(needsDetail);
 
             if (screen instanceof MenuScreen && autoAdvanceMenu) {
                 ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
             }
 
-            if (addBreadcrumb) {
-                addTitle(input, previousScreen);
-            }
             return true;
         } catch (ArrayIndexOutOfBoundsException | NullPointerException e) {
             throw new RuntimeException("Screen " + screen + "  handling input " + input +

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -159,17 +159,27 @@ public class MenuSession implements HereFunctionHandlerListener {
                 addTitle(input, screen);
             }
 
-            Screen nextScreen = getNextScreen(needsDetail);
-
-            if (nextScreen instanceof MenuScreen && autoAdvanceMenu) {
-                ((MenuScreen)nextScreen).handleAutoMenuAdvance(sessionWrapper);
-            }
+            autoAdvance(needsDetail, autoAdvanceMenu);
 
             return true;
         } catch (ArrayIndexOutOfBoundsException | NullPointerException e) {
             throw new RuntimeException("Screen " + screen + "  handling input " + input +
                     " threw exception " + e.getMessage() + ". Please try reloading this application" +
                     " and if the problem persists please report a bug.", e);
+        }
+    }
+
+    /**
+     *
+     * @param needsDetail Whether a full entity screen is required for this request
+     *                    or if a list of references is sufficient
+     * @param autoAdvanceMenu Whether the menu navigation should be advanced if it can be
+     * @throws CommCareSessionException
+     */
+    public void autoAdvance(boolean needsDetail, boolean autoAdvanceMenu) throws CommCareSessionException {
+        Screen nextScreen = getNextScreen(needsDetail);
+        if (nextScreen instanceof MenuScreen && autoAdvanceMenu) {
+            ((MenuScreen)nextScreen).handleAutoMenuAdvance(sessionWrapper);
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -175,13 +175,10 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @return true if the session was advanced
      */
     public boolean autoAdvanceMenu(Screen screen, boolean autoAdvanceMenu) throws CommCareSessionException {
-        if (!autoAdvanceMenu) {
+        if (!autoAdvanceMenu || !(screen instanceof MenuScreen)) {
             return false;
         }
-        if (screen instanceof MenuScreen) {
-            return ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
-        }
-        return false;
+        return ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
     }
 
     private void addTitle(String input, Screen previousScreen) {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -145,7 +145,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 if (input.startsWith("action ") || (autoLaunch) || !inputValidated) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, needsDetail, inputValidated, allowAutoLaunch);
+                        return handleInput(input, true, inputValidated, allowAutoLaunch);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input, allowAutoLaunch);
                 } else {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -159,10 +159,10 @@ public class MenuSession implements HereFunctionHandlerListener {
                 addTitle(input, screen);
             }
 
-            screen = getNextScreen(needsDetail);
+            Screen nextScreen = getNextScreen(needsDetail);
 
-            if (screen instanceof MenuScreen && autoAdvanceMenu) {
-                ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
+            if (nextScreen instanceof MenuScreen && autoAdvanceMenu) {
+                ((MenuScreen)nextScreen).handleAutoMenuAdvance(sessionWrapper);
             }
 
             return true;

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -122,15 +122,6 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     /**
-     * Handle a user step, ignoring performance optimizations and not allowing autolaunch actions.
-     *
-     * @param input The user step input
-     */
-    public boolean handleInput(String input, boolean autoAdvanceMenu) throws CommCareSessionException {
-        return handleInput(input, true, false, false, autoAdvanceMenu);
-    }
-
-    /**
      * @param input           The user step input
      * @param needsDetail     Whether a full entity screen is required for this request
      *                        or if a list of references is sufficient

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -145,7 +145,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                 if (input.startsWith("action ") || (autoLaunch) || !inputValidated) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {
-                        return handleInput(input, true, inputValidated, allowAutoLaunch);
+                        return handleInput(input, needsDetail, inputValidated, allowAutoLaunch);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input, allowAutoLaunch);
                 } else {

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -174,7 +174,7 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @throws CommCareSessionException
      * @return true if the session was advanced
      */
-    public boolean autoAdvance(Screen screen, boolean autoAdvanceMenu) throws CommCareSessionException {
+    public boolean autoAdvanceMenu(Screen screen, boolean autoAdvanceMenu) throws CommCareSessionException {
         if (!autoAdvanceMenu) {
             return false;
         }

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -169,18 +169,16 @@ public class MenuSession implements HereFunctionHandlerListener {
 
     /**
      *
-     * @param needsDetail Whether a full entity screen is required for this request
-     *                    or if a list of references is sufficient
-     * @param autoAdvanceMenu Whether the menu navigation should be advanced if it can be
+     * @param screen The current screen that has been navigated to.
+     * @param autoAdvanceMenu Whether the menu navigation should be advanced if it can be.
      * @throws CommCareSessionException
      */
-    public void autoAdvance(boolean needsDetail, boolean autoAdvanceMenu) throws CommCareSessionException {
+    public void autoAdvance(Screen screen, boolean autoAdvanceMenu) throws CommCareSessionException {
         if (!autoAdvanceMenu) {
             return;
         }
-        Screen nextScreen = getNextScreen(needsDetail);
-        if (nextScreen instanceof MenuScreen) {
-            ((MenuScreen)nextScreen).handleAutoMenuAdvance(sessionWrapper);
+        if (screen instanceof MenuScreen) {
+            ((MenuScreen)screen).handleAutoMenuAdvance(sessionWrapper);
         }
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
@@ -18,14 +18,11 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.net.URI;
 import java.util.Hashtable;
 
 import static org.commcare.formplayer.util.FormplayerPropertyManager.AUTO_ADVANCE_MENU;
@@ -44,9 +41,6 @@ public class FormEntryWithQueryTests extends BaseTestClass{
 
     @Autowired
     CacheManager cacheManager;
-
-    @Captor
-    ArgumentCaptor<URI> uriCaptor;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -199,10 +193,7 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 EntityListResponse.class);
 
         // Check if form's query was executed
-        verify(webClientMock, times(1)).get(uriCaptor.capture());
-        List<URI> uris = uriCaptor.getAllValues();
-        // when default search, prompts doesn't get included
-        assert uris.get(0).equals(new URI("http://localhost:8000/a/test-1/phone/search/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case"));
+        verify(webClientMock, times(1)).get(any(), any());
 
         // with auto-advance enabled the selection of a case should result in the session
         // being auto-advanced directly to the form (since there is only one form to choose from)
@@ -214,10 +205,7 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 NewFormResponse.class);
 
         assertEquals(formResponse.getTitle(), "Followup Form");
-        verify(webClientMock, times(3)).get(uriCaptor.capture());
-        uris = uriCaptor.getAllValues();
-        assert uris.get(2).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=0156fa3e-093e-4136-b95c-01b13dae66c6"));
-        assert uris.get(3).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=dupe_case_id"));
+        verify(webClientMock, times(3)).get(any(), any());
     }
 
     private void checkXpath(NewFormResponse formResponse, String xpath, String expectedValue) throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
@@ -193,7 +193,7 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 EntityListResponse.class);
 
         // Check if form's query was executed
-        verify(webClientMock, times(1)).get(any(), any());
+        verify(webClientMock, times(1)).postFormData(any(), any());
 
         // with auto-advance enabled the selection of a case should result in the session
         // being auto-advanced directly to the form (since there is only one form to choose from)
@@ -205,7 +205,7 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 NewFormResponse.class);
 
         assertEquals(formResponse.getTitle(), "Followup Form");
-        verify(webClientMock, times(3)).get(any(), any());
+        verify(webClientMock, times(3)).postFormData(any(), any());
     }
 
     private void checkXpath(NewFormResponse formResponse, String xpath, String expectedValue) throws Exception {


### PR DESCRIPTION
The main impetus for this refactor was to get `cc-auto-advance-menu` to work when there are queries after the last selection. Previously the auto-advance logic was executed during screen selection processing. When there is a query after the last selection the auto-advance was skipped.

This refactor moves all non-selection based navigation to it's own method and runs the logic in a loop as long as the session was advanced which makes it a more generalised solution.

The refactor also allowed simplifying some other logic.

Best reviewed by commit.

I made this branch on top of https://github.com/dimagi/formplayer/pull/1028 since that is where the query logic is added but I do not intend to merge it into that branch and will keep it separate until #1028 is merged.

Cross request: https://github.com/dimagi/commcare-core/pull/1057
Jira: https://dimagi-dev.atlassian.net/browse/USH-1381