### PR TITLE
refactor restore factory getUrl and getHeaders

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -431,10 +431,9 @@ public class RestoreFactory {
     public InputStream getRestoreXml(boolean skipFixtures) {
         ensureValidParameters();
         URI url = getRestoreUrl(skipFixtures);
-        HttpHeaders headers = getRequestHeaders(url);
         recordSentryData(url.toString());
         log.info("Restoring from URL " + url);
-        InputStream restoreStream = getRestoreXmlHelper(url, headers);
+        InputStream restoreStream = getRestoreXmlHelper(url);
         setLastSyncTime();
         return restoreStream;
     }
@@ -529,7 +528,7 @@ public class RestoreFactory {
         );
     }
 
-    private InputStream getRestoreXmlHelper(URI restoreUrl, HttpHeaders headers) {
+    private InputStream getRestoreXmlHelper(URI restoreUrl) {
         ResponseEntity<org.springframework.core.io.Resource> response;
         String status = "error";
         log.info("Restoring at domain: " + domain + " with url: " + restoreUrl.toString());

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -595,9 +595,18 @@ public class RestoreFactory {
                     " did not have an authentication key.");
         }
         HttpHeaders headers = getHqAuth().getAuthHeaders();
-        headers.set("X-CommCareHQ-LastSyncToken", getSyncToken());
-        headers.set("X-OpenRosa-Version", "3.0");
-        headers.set("X-OpenRosa-DeviceId", getSyncDeviceId());
+        headers.addAll(getStandardHeaders());
+        return headers;
+    }
+
+    private HttpHeaders getStandardHeaders() {
+        HttpHeaders headers = new HttpHeaders() {
+            {
+                add("X-CommCareHQ-LastSyncToken", getSyncToken());
+                add("X-OpenRosa-Version", "3.0");
+                add("X-OpenRosa-DeviceId", getSyncDeviceId());
+            }
+        };
         headers.setAll(getOriginTokenHeader());
         return headers;
     }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -610,10 +610,6 @@ public class RestoreFactory {
         headers.set("X-CommCareHQ-Origin-Token", originToken);
     }
 
-    public Pair<URI, HttpHeaders> getRestoreUrlAndHeaders() {
-        return getRestoreUrlAndHeaders(false);
-    }
-
     public Pair<URI, HttpHeaders> getRestoreUrlAndHeaders(boolean skipFixtures) {
         if (caseId != null) {
             return getCaseRestoreUrlAndHeaders();
@@ -667,10 +663,6 @@ public class RestoreFactory {
         HttpHeaders headers = getHmacHeaders(builder.toString());
         String fullUrl = host + builder.toString();
         return new Pair<>(UriComponentsBuilder.fromUriString(fullUrl).build(true).toUri(), headers);
-    }
-
-    public Pair<URI, HttpHeaders> getUserRestoreUrlAndHeaders() {
-        return getUserRestoreUrlAndHeaders(false);
     }
 
     public Pair<URI, HttpHeaders> getUserRestoreUrlAndHeaders(boolean skipFixtures) {
@@ -816,19 +808,11 @@ public class RestoreFactory {
         return hasRestored;
     }
 
-    public SimpleTimer getDownloadRestoreTimer() {
-        return downloadRestoreTimer;
-    }
-
     public void setCaseId(String caseId) {
         this.caseId = caseId;
     }
 
     public String getCaseId() {
         return caseId;
-    }
-
-    public boolean isConfigured() {
-        return this.configured;
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -256,10 +256,6 @@ public class RestoreFactory {
         }
     }
 
-    private UserSqlSandbox restoreUser() throws Exception {
-        return restoreUser(false);
-    }
-
     private UserSqlSandbox restoreUser(boolean skipFixtures) throws
             UnfullfilledRequirementsException, InvalidStructureException, IOException, XmlPullParserException {
         PrototypeFactory.setStaticHasher(new ClassNameHasher());

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -433,7 +433,7 @@ public class RestoreFactory {
     public InputStream getRestoreXml(boolean skipFixtures) {
         ensureValidParameters();
         URI url = getRestoreUrl(skipFixtures);
-        HttpHeaders headers = getRestoreHeaders(url);
+        HttpHeaders headers = getRequestHeaders(url);
         recordSentryData(url.toString());
         log.info("Restoring from URL " + url);
         InputStream restoreStream = getRestoreXmlHelper(url, headers);
@@ -441,7 +441,7 @@ public class RestoreFactory {
         return restoreStream;
     }
 
-    private HttpHeaders getRestoreHeaders(URI url) {
+    public HttpHeaders getRequestHeaders(URI url) {
         if (getHqAuth() == null) {
             // Do HMAC auth which requires only the path and query components of the URL
             return getHmacHeaders(url);

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -659,22 +659,22 @@ public class RestoreFactory {
     }
 
     public Pair<URI, HttpHeaders> getCaseRestoreUrlAndHeaders() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("/a/");
-        builder.append(domain);
-        builder.append("/case_migrations/restore/");
-        builder.append(caseId);
-        builder.append("/");
-        String fullUrl = host + builder.toString();
-        URI uri = UriComponentsBuilder.fromUriString(fullUrl).build(true).toUri();
+        String path = buildUrlPath(host, "/a/", domain, "/case_migrations/restore/", caseId, "/");
+        URI uri = UriComponentsBuilder.fromUriString(path).build(true).toUri();
         HttpHeaders headers = getHmacHeaders(uri);
         return new Pair<>(uri, headers);
     }
 
+    private String buildUrlPath(String... parts) {
+        StringBuilder builder = new StringBuilder(host);
+        for (String part : parts) {
+            builder.append(part);
+        }
+        return builder.toString();
+    }
+
     public Pair<URI, HttpHeaders> getUserRestoreUrlAndHeaders(boolean skipFixtures) {
-        // URI
-        String restoreUrl = "/a/" + domain + "/phone/restore/?version=2.0";
-        String uri = host + restoreUrl;
+        String uri = buildUrlPath(host, "/a/", domain, "/phone/restore/?version=2.0");
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(uri);
         String syncToken = getSyncToken();
         // Add query params.

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -430,10 +430,6 @@ public class RestoreFactory {
         }
     }
 
-    public InputStream getRestoreXml() {
-        return getRestoreXml(false);
-    }
-
     public InputStream getRestoreXml(boolean skipFixtures) {
         ensureValidParameters();
         URI url = getRestoreUrl(skipFixtures);

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -19,6 +19,7 @@ import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.util.*;
+import org.commcare.formplayer.web.client.WebClient;
 import org.commcare.modern.database.TableBuilder;
 import org.javarosa.core.api.ClassNameHasher;
 import org.javarosa.core.model.User;
@@ -34,11 +35,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -111,7 +110,7 @@ public class RestoreFactory {
     private FormplayerStorageFactory storageFactory;
 
     @Autowired
-    private RestTemplate restTemplate;
+    private WebClient webClient;
 
     @Autowired
     private RedisTemplate redisTemplateLong;
@@ -537,10 +536,7 @@ public class RestoreFactory {
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE, domain);
         downloadRestoreTimer.start();
         try {
-            response = restTemplate.exchange(
-                    RequestEntity.get(restoreUrl).headers(headers).build(),
-                    org.springframework.core.io.Resource.class
-            );
+            response = webClient.getRaw(restoreUrl, org.springframework.core.io.Resource.class);
             status = response.getStatusCode().toString();
         } catch (HttpClientErrorException e) {
             status = e.getStatusCode().toString();

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -637,12 +637,7 @@ public class RestoreFactory {
             throw new RuntimeException(String.format("Tried getting HMAC Auth for request %s but this request" +
                     "was not validated with HMAC.", requestPath));
         }
-        HttpHeaders headers = new HttpHeaders() {
-            {
-                add("x-openrosa-version", "2.0");
-            }
-        };
-        headers.setAll(getOriginTokenHeader());
+        HttpHeaders headers = getStandardHeaders();
         try {
             String digest = RequestUtils.getHmac(formplayerAuthKey, requestPath);
             headers.add("X-MAC-DIGEST", digest);

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -665,7 +665,7 @@ public class RestoreFactory {
     }
 
     private String buildUrlPath(String... parts) {
-        StringBuilder builder = new StringBuilder(host);
+        StringBuilder builder = new StringBuilder();
         for (String part : parts) {
             builder.append(part);
         }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -713,9 +713,7 @@ public class RestoreFactory {
             authPath.port(null);
             headers = getHmacHeaders(authPath.build(true).toUriString());
         } else {
-            headers = getHqAuth().getAuthHeaders();
-            headers.add("x-openrosa-version", "2.0");
-            headers.setAll(getOriginTokenHeader());
+            headers = getUserHeaders();
         }
         URI fullUrl = builder.build(true).toUri();
         return new Pair<>(fullUrl, headers);

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -599,11 +599,14 @@ public class RestoreFactory {
     private HttpHeaders getStandardHeaders() {
         HttpHeaders headers = new HttpHeaders() {
             {
-                add("X-CommCareHQ-LastSyncToken", getSyncToken());
-                add("X-OpenRosa-Version", "3.0");
-                add("X-OpenRosa-DeviceId", getSyncDeviceId());
+                set("X-OpenRosa-Version", "3.0");
+                set("X-OpenRosa-DeviceId", getSyncDeviceId());
             }
         };
+        String syncToken = getSyncToken();
+        if (syncToken != null) {
+            headers.set("X-CommCareHQ-LastSyncToken", getSyncToken());
+        }
         headers.setAll(getOriginTokenHeader());
         return headers;
     }

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -2,10 +2,9 @@ package org.commcare.formplayer.web.client;
 
 import org.commcare.formplayer.services.RestoreFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -21,15 +20,21 @@ public class WebClient {
 
     public String get(String url) {
         URI uri = URI.create(url);
-        return restTemplate.exchange(
-                RequestEntity.get(uri).headers(restoreFactory.getRequestHeaders(uri)).build(), String.class
-        ).getBody();
+        return get(uri, String.class);
     }
 
     public String get(URI uri) {
+        return get(uri, String.class);
+    }
+
+    public <T> T get(URI uri, Class<T> responseType) {
+        return getRaw(uri, responseType).getBody();
+    }
+
+    public <T> ResponseEntity<T> getRaw(URI uri, Class<T> responseType) {
         return restTemplate.exchange(
-                RequestEntity.get(uri).headers(restoreFactory.getRequestHeaders(uri)).build(), String.class
-        ).getBody();
+                RequestEntity.get(uri).headers(restoreFactory.getRequestHeaders(uri)).build(), responseType
+        );
     }
 
     public <T> String post(String url, T body) {

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -20,20 +20,22 @@ public class WebClient {
     RestoreFactory restoreFactory;
 
     public String get(String url) {
+        URI uri = URI.create(url);
         return restTemplate.exchange(
-                RequestEntity.get(url).headers(restoreFactory.getUserHeaders()).build(), String.class
+                RequestEntity.get(uri).headers(restoreFactory.getRequestHeaders(uri)).build(), String.class
         ).getBody();
     }
 
     public String get(URI uri) {
         return restTemplate.exchange(
-                RequestEntity.get(uri).headers(restoreFactory.getUserHeaders()).build(), String.class
+                RequestEntity.get(uri).headers(restoreFactory.getRequestHeaders(uri)).build(), String.class
         ).getBody();
     }
 
     public <T> String post(String url, T body) {
+        URI uri = URI.create(url);
         return restTemplate.exchange(
-                RequestEntity.post(url).headers(restoreFactory.getUserHeaders()).body(body), String.class
+                RequestEntity.post(uri).headers(restoreFactory.getRequestHeaders(uri)).body(body), String.class
         ).getBody();
     }
 }


### PR DESCRIPTION
This is a (almost) pure refactor with the following goals:

* simplify logic
* create a single entry point for collecting request headers
* tests for the logic

One side effect here is that the `X-OpenRosa-Version` header is now always set to `3.0` where before it was sometimes `2.0`. I consider this an improvement.

The other side effect of the separation between restore type and the request headers is that HMAC auth is no longer enforced 'case restore' requests. I don't think that is and issue.

Best reviewed by commit.