### PR TITLE
Switch case search to make a post request (redo)

### DIFF
--- a/src/main/java/org/commcare/formplayer/screens/FormplayerQueryScreen.java
+++ b/src/main/java/org/commcare/formplayer/screens/FormplayerQueryScreen.java
@@ -1,14 +1,6 @@
 package org.commcare.formplayer.screens;
 
-import org.commcare.session.RemoteQuerySessionManager;
-import org.commcare.suite.model.QueryPrompt;
 import org.commcare.util.screen.QueryScreen;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import java.net.URI;
-import java.net.URL;
-
-import com.google.common.collect.*;
 
 /**
  * Created by willpride on 8/7/16.
@@ -19,27 +11,4 @@ public class FormplayerQueryScreen extends QueryScreen {
         super(null, null, null);
     }
 
-    /**
-     * @param skipDefaultPromptValues don't apply the default value expressions for query prompts
-     * @return case search url with search prompt values
-     */
-    public URI getUri(boolean skipDefaultPromptValues) {
-        URL url = getBaseUrl();
-        Multimap<String, String> queryParams = getQueryParams(skipDefaultPromptValues);
-        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url.toString());
-        for (String key : queryParams.keySet()) {
-            QueryPrompt prompt = userInputDisplays.get(key);
-            for (String value : queryParams.get(key)) {
-                if (prompt != null) {
-                    String[] choices = RemoteQuerySessionManager.extractMultipleChoices(value);
-                    for (String choice : choices) {
-                        builder.queryParam(key, choice);
-                    }
-                } else {
-                    builder.queryParam(key, value);
-                }
-            }
-        }
-        return builder.build().toUri();
-    }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -104,9 +104,7 @@ public class MenuSessionFactory {
                             throw new CommCareSessionException("Query URL format error: " + e.getMessage(), e);
                         }
                         ImmutableMultimap.Builder<String, String> dataBuilder = ImmutableMultimap.builder();
-                        step.getExtras().entrySet().forEach(entry -> {
-                            dataBuilder.put(entry.getKey(), entry.getValue().toString());
-                        });
+                        step.getExtras().forEach((key, value) -> dataBuilder.put(key, value.toString()));
                         try {
                             ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(
                                 queryScreen.getQueryDatum().getDataId(),

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.services;
 
+import com.google.common.collect.ImmutableMultimap;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.*;
 
@@ -102,15 +103,16 @@ public class MenuSessionFactory {
                             e.printStackTrace();
                             throw new CommCareSessionException("Query URL format error: " + e.getMessage(), e);
                         }
-                        UriComponentsBuilder builder = UriComponentsBuilder.fromUri(uri);
+                        ImmutableMultimap.Builder<String, String> dataBuilder = ImmutableMultimap.builder();
                         step.getExtras().entrySet().forEach(entry -> {
-                            builder.queryParam(entry.getKey(), entry.getValue());
+                            dataBuilder.put(entry.getKey(), entry.getValue().toString());
                         });
                         try {
                             ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(
                                 queryScreen.getQueryDatum().getDataId(),
                                 queryScreen.getQueryDatum().useCaseTemplate(),
-                                builder.build().toUri()
+                                uri.toURL(),
+                                dataBuilder.build()
                             );
                             queryScreen.setQueryDatum(searchDataInstance);
                             screen = menuSession.getNextScreen(false);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -461,9 +461,12 @@ public class MenuSessionRunnerService {
         String error = null;
         ExternalDataInstance searchDataInstance;
         try {
-            searchDataInstance = searchAndSetResult(
-                    screen,
-                    screen.getUri(skipDefaultPromptValues));
+            searchDataInstance = caseSearchHelper.getRemoteDataInstance(
+                    screen.getQueryDatum().getDataId(),
+                    screen.getQueryDatum().useCaseTemplate(),
+                    screen.getBaseUrl(),
+                    screen.getRequestData(skipDefaultPromptValues));
+        screen.setQueryDatum(searchDataInstance);
             if (searchDataInstance == null) {
                 error = "No result from query";
             }
@@ -485,15 +488,6 @@ public class MenuSessionRunnerService {
         log.info("Next screen after query: " + nextScreen);
         return notificationMessage;
     }
-
-    public ExternalDataInstance searchAndSetResult(FormplayerQueryScreen screen, URI uri)
-            throws UnfullfilledRequirementsException, XmlPullParserException, IOException, InvalidStructureException {
-        ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(screen.getQueryDatum().getDataId(),
-                screen.getQueryDatum().useCaseTemplate(), uri);
-        screen.setQueryDatum(searchDataInstance);
-        return searchDataInstance;
-    }
-
 
     public BaseResponseBean resolveFormGetNext(MenuSession menuSession) throws Exception {
         if (executeAndRebuildSession(menuSession)) {

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -37,11 +37,13 @@ public class WebClient {
     }
 
     public <T> String postFormData(String url, Multimap<String, String> data) {
+        LinkedMultiValueMap<String, String> postData = new LinkedMultiValueMap<>();
+        data.forEach(postData::add);
         return restTemplate.exchange(
                 RequestEntity.post(url)
-                             .headers(restoreFactory.getUserHeaders())
-                             .contentType(MediaType.MULTIPART_FORM_DATA)
-                             .body(data),
+                        .headers(restoreFactory.getUserHeaders())
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .body(postData),
                 String.class
         ).getBody();
     }

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -42,7 +42,7 @@ public class WebClient {
         return restTemplate.exchange(
                 RequestEntity.post(url)
                         .headers(restoreFactory.getUserHeaders())
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .body(postData),
                 String.class
         ).getBody();

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -3,11 +3,9 @@ package org.commcare.formplayer.web.client;
 import com.google.common.collect.Multimap;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -1,8 +1,10 @@
 package org.commcare.formplayer.web.client;
 
+import com.google.common.collect.Multimap;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.MultiValueMap;
@@ -36,4 +38,15 @@ public class WebClient {
                 RequestEntity.post(url).headers(restoreFactory.getUserHeaders()).body(body), String.class
         ).getBody();
     }
+
+    public <T> String postFormData(String url, Multimap<String, String> data) {
+        return restTemplate.exchange(
+                RequestEntity.post(url)
+                             .headers(restoreFactory.getUserHeaders())
+                             .contentType(MediaType.MULTIPART_FORM_DATA)
+                             .body(data),
+                String.class
+        ).getBody();
+    }
+
 }

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -46,11 +46,12 @@ public class WebClient {
     }
 
     public <T> String postFormData(String url, Multimap<String, String> data) {
+        URI uri = URI.create(url);
         LinkedMultiValueMap<String, String> postData = new LinkedMultiValueMap<>();
         data.forEach(postData::add);
         return restTemplate.exchange(
-                RequestEntity.post(url)
-                        .headers(restoreFactory.getUserHeaders())
+                RequestEntity.post(uri)
+                        .headers(restoreFactory.getRequestHeaders(uri))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .body(postData),
                 String.class

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -13,10 +14,8 @@ import java.net.URI;
 @Component
 public class WebClient {
 
-    @Autowired
     RestTemplate restTemplate;
 
-    @Autowired
     RestoreFactory restoreFactory;
 
     public String get(String url) {
@@ -47,4 +46,13 @@ public class WebClient {
         ).getBody();
     }
 
+    @Autowired
+    public void setRestoreFactory(RestoreFactory restoreFactory) {
+        this.restoreFactory = restoreFactory;
+    }
+
+    @Autowired
+    public void setRestTemplate(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
 }

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.tests;
 
+import com.google.common.collect.Multimap;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,7 +21,7 @@ import java.util.Hashtable;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 
 /**
@@ -82,8 +82,9 @@ public class CaseClaimNavigationTests extends BaseTestClass {
 
     @Test
     public void testEofNavigation() throws Exception {
-        when(webClientMock.get(eq(new URI("https://www.commcarehq.org/a/shubhamgoyaltest/phone/search/?rating=5&case_type=song&commcare_blacklisted_owner_ids=fef71c7ff9d54471ab3cbd2c828b0e13"))))
-                .thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_response.xml"));
+        when(webClientMock.postFormData(anyString(), argThat(data -> {
+            return ((Multimap<String, String>) data).get("case_type").contains("song");
+        }))).thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_response.xml"));
         String appName = APP_CASE_CLAIM_EOF_NAVIGATION;
         ArrayList<String> selections = new ArrayList<>();
         selections.add("1");
@@ -135,8 +136,9 @@ public class CaseClaimNavigationTests extends BaseTestClass {
         queryData.setInputs("search_command.m1", inputs);
 
         // return search results that doesn't have the selected case
-        when(webClientMock.get(eq(new URI("https://www.commcarehq.org/a/shubhamgoyaltest/phone/search/?case_type=song&rating=3&commcare_blacklisted_owner_ids=fef71c7ff9d54471ab3cbd2c828b0e13"))))
-                .thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_child_response.xml"));
+        when(webClientMock.postFormData(any(), argThat(data -> {
+            return ((Multimap<String, String>) data).get("case_type").contains("song");
+        }))).thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_child_response.xml"));
 
         // since the case claim has happened already, this should not redo the search and trigger the query above
         // If that happens, it would result into a Entity Screen selection error
@@ -369,11 +371,15 @@ public class CaseClaimNavigationTests extends BaseTestClass {
     }
 
     private void configureQueryMock() throws URISyntaxException {
-        when(webClientMock.get(eq(new URI("https://staging.commcarehq.org/a/bosco/phone/search/?case_type=song"))))
-                .thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_response.xml"));
+        when(webClientMock.postFormData(anyString(), argThat(data -> {
+            return (data != null) &&
+                   ((Multimap<String, String>) data).get("case_type").contains("song");
+        }))).thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_response.xml"));
 
-        when(webClientMock.get(new URI("https://staging.commcarehq.org/a/bosco/phone/search/?case_type=show")))
-                .thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_child_response.xml"));
+        when(webClientMock.postFormData(anyString(), argThat(data -> {
+            return (data != null) &&
+                   ((Multimap<String, String>) data).get("case_type").contains("show");
+        }))).thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_parent_child_child_response.xml"));
     }
 
     private HashMap<String, Object> getAnswers(String index, String answer) {

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.tests;
 
+import com.google.common.collect.Multimap;
 import org.commcare.cases.model.Case;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
@@ -19,11 +20,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.net.URI;
 import java.util.Hashtable;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -42,7 +42,10 @@ public class CaseClaimTests extends BaseTestClass {
     CacheManager cacheManager;
 
     @Captor
-    ArgumentCaptor<URI> uriCaptor;
+    ArgumentCaptor<String> urlCaptor;
+
+    @Captor
+    ArgumentCaptor<Multimap<String, String>> requestDataCaptor;
 
     @Override
     @BeforeEach
@@ -106,9 +109,15 @@ public class CaseClaimTests extends BaseTestClass {
                 queryData,
                 true,
                 EntityListResponse.class);
-        verify(webClientMock, times(1)).get(uriCaptor.capture());
-        List<URI> uris = uriCaptor.getAllValues();
-        assert uris.get(0).equals(new URI("http://localhost:8000/a/test/phone/search/?case_type=case1&case_type=case2&case_type=case3&include_closed=False&name=&state="));
+        verify(webClientMock, times(1)).postFormData(urlCaptor.capture(), requestDataCaptor.capture());
+        assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(0));
+        Multimap<String, String> requestData = requestDataCaptor.getAllValues().get(0);
+        assertEquals(4, requestData.keySet().size());
+        assertArrayEquals(new String[]{"case1", "case2", "case3"},
+                          requestData.get("case_type").toArray());
+        assertArrayEquals(new String[]{""}, requestData.get("name").toArray());
+        assertArrayEquals(new String[]{""}, requestData.get("state").toArray());
+        assertArrayEquals(new String[]{"False"}, requestData.get("include_closed").toArray());
 
         // select empty with a valid choice
         inputs.put("name", "#,#chris");
@@ -130,9 +139,16 @@ public class CaseClaimTests extends BaseTestClass {
                 queryData,
                 true,
                 EntityListResponse.class);
-        verify(webClientMock, times(2)).get(uriCaptor.capture());
-        uris = uriCaptor.getAllValues();
-        assert uris.get(2).equals(new URI("http://localhost:8000/a/test/phone/search/?case_type=case1&case_type=case2&case_type=case3&district=&district=hampi&include_closed=False&name=&name=chris&state=ka"));
+        verify(webClientMock, times(2)).postFormData(urlCaptor.capture(), requestDataCaptor.capture());
+        assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(2));
+        requestData = requestDataCaptor.getAllValues().get(2);
+        assertEquals(5, requestData.keySet().size());
+        assertArrayEquals(new String[]{"case1", "case2", "case3"},
+                          requestData.get("case_type").toArray());
+        assertArrayEquals(new String[]{"", "chris"}, requestData.get("name").toArray());
+        assertArrayEquals(new String[]{"", "hampi"}, requestData.get("district").toArray());
+        assertArrayEquals(new String[]{"ka"}, requestData.get("state").toArray());
+        assertArrayEquals(new String[]{"False"}, requestData.get("include_closed").toArray());
     }
 
     @Test
@@ -151,7 +167,7 @@ public class CaseClaimTests extends BaseTestClass {
                 EntityListResponse.class);
 
         assert cacheManager.getCache("case_search")
-                .get("caseclaimdomain_caseclaimusername_http://localhost:8000/a/test/phone/search/?case_type=case1&case_type=case2&case_type=case3&include_closed=False") != null;
+                .get("caseclaimdomain_caseclaimusername_http://localhost:8000/a/test/phone/search/_case_type=case1=case2=case3_include_closed=False") != null;
 
         assert responseBean.getEntities().length == 1;
         assert responseBean.getEntities()[0].getId().equals("0156fa3e-093e-4136-b95c-01b13dae66c6");
@@ -241,7 +257,7 @@ public class CaseClaimTests extends BaseTestClass {
         assert responseBean.getEntities()[0].getId().equals("0156fa3e-093e-4136-b95c-01b13dae66c6");
         assert caseStorage.getNumRecords() == 21;
 
-        // When we sync afterwards, include new case and case-claim 
+        // When we sync afterwards, include new case and case-claim
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim2.xml");
         Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
 
@@ -255,15 +271,28 @@ public class CaseClaimTests extends BaseTestClass {
         assert commandResponse.getSelections()[1].equals("0156fa3e-093e-4136-b95c-01b13dae66c6");
         assert caseStorage.getNumRecords() == 23;
 
-        // verify search uris
-        verify(webClientMock, times(2)).get(uriCaptor.capture());
-        List<URI> uris = uriCaptor.getAllValues();
+        verify(webClientMock, times(2)).postFormData(urlCaptor.capture(), requestDataCaptor.capture());
+
         // when default search, prompts doesn't get included
-        assert uris.get(0).equals(new URI("http://localhost:8000/a/test/phone/search/?case_type=case1&case_type=case2&case_type=case3&include_closed=False"));
+        assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(0));
+        Multimap<String, String> requestData = requestDataCaptor.getAllValues().get(0);
+        assertEquals(2, requestData.keySet().size());
+        assertArrayEquals(new String[]{"case1", "case2", "case3"},
+                          requestData.get("case_type").toArray());
+        assertArrayEquals(new String[]{"False"}, requestData.get("include_closed").toArray());
+
         // when default search but forceManualSearch, prompts should get included
         // Subsequently when search happens as part of replaying a session, prompts should be same as the last search
         // and therefore be served through cache. Therefore there are only 2 http calls here instead of 3
-        assert uris.get(1).equals(new URI("http://localhost:8000/a/test/phone/search/?case_type=case1&case_type=case2&case_type=case3&district=bang&district=hampi&include_closed=False&name=Burt&state=ka"));
+        assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(1));
+        requestData = requestDataCaptor.getAllValues().get(1);
+        assertEquals(5, requestData.keySet().size());
+        assertArrayEquals(new String[]{"case1", "case2", "case3"},
+                          requestData.get("case_type").toArray());
+        assertArrayEquals(new String[]{"Burt"}, requestData.get("name").toArray());
+        assertArrayEquals(new String[]{"bang", "hampi"}, requestData.get("district").toArray());
+        assertArrayEquals(new String[]{"ka"}, requestData.get("state").toArray());
+        assertArrayEquals(new String[]{"False"}, requestData.get("include_closed").toArray());
     }
 
     @Test
@@ -293,12 +322,12 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     private void configureQueryMock() {
-        when(webClientMock.get(any(URI.class)))
+        when(webClientMock.postFormData(anyString(), any(Multimap.class)))
                 .thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_response.xml"));
     }
 
     private void configureQueryMockOwned() {
-        when(webClientMock.get(any(URI.class)))
+        when(webClientMock.postFormData(anyString(), any(Multimap.class)))
                 .thenReturn(FileUtils.getFile(this.getClass(), "query_responses/case_claim_response_owned.xml"));
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingWithQueryTests.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.tests;
 
 
+import com.google.common.collect.ImmutableMultimap;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.mocks.casexml.CaseFixtureBlock;
@@ -54,8 +55,7 @@ public class EndOfFormNavFormLinkingWithQueryTests extends BaseTestClass{
         assertEquals("2nd Followup Form", formResponse.getTitle());
     }
 
-    private void configureQueryMock() throws URISyntaxException {
-        URI searchURI = new URI("http://localhost:8000/a/test/phone/search/c4d2d3a7b32948cea64d28e961b183cb/?commcare_registry=test&case_type=case");
+    private void configureQueryMock() {
         String searchResponse = CaseFixtureResultSerializer.blocksToString(
                 new CaseFixtureBlock.Builder("case", "first_case")
                         .withProperty("case_name", "first_case")
@@ -65,12 +65,17 @@ public class EndOfFormNavFormLinkingWithQueryTests extends BaseTestClass{
                         .withProperty("case_name", "second_case")
                         .build()
         );
-        when(webClientMock.get(eq(searchURI))).thenReturn(searchResponse);
+        String searchUrl = "http://localhost:8000/a/test/phone/search/c4d2d3a7b32948cea64d28e961b183cb/";
+        ImmutableMultimap<String, String> data = ImmutableMultimap.of("commcare_registry", "test", "case_type", "case");
+        when(webClientMock.postFormData(eq(searchUrl), eq(data))).thenReturn(searchResponse);
 
-        URI firstQueryURI = new URI("http://localhost:8000/a/test/phone/registry_case/c4d2d3a7b32948cea64d28e961b183cb/?commcare_registry=test&case_type=case&case_id=first_case");
-        when(webClientMock.get(eq(firstQueryURI))).thenReturn(searchResponse);
+        String registryUrl = "http://localhost:8000/a/test/phone/registry_case/c4d2d3a7b32948cea64d28e961b183cb/";
+        ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+        builder.putAll(data).put("case_id", "first_case");
+        when(webClientMock.postFormData(eq(registryUrl), eq(builder.build()))).thenReturn(searchResponse);
 
-        URI secondQueryURI = new URI("http://localhost:8000/a/test/phone/registry_case/c4d2d3a7b32948cea64d28e961b183cb/?commcare_registry=test&case_type=case&case_id=second_case");
-        when(webClientMock.get(eq(secondQueryURI))).thenReturn(searchResponse);
+        builder = ImmutableMultimap.builder();
+        builder.putAll(data).put("case_id", "second_case");
+        when(webClientMock.postFormData(eq(registryUrl), eq(builder.build()))).thenReturn(searchResponse);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingWithQueryTests.java
@@ -14,8 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
@@ -1,6 +1,9 @@
 package org.commcare.formplayer.tests;
 
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.commcare.formplayer.beans.EvaluateXPathResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
@@ -74,11 +77,8 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 EntityListResponse.class);
 
         // Check if form's query was executed
-        verify(webClientMock, times(1)).get(uriCaptor.capture());
-        List<URI> uris = uriCaptor.getAllValues();
-        // when default search, prompts doesn't get included
-        assert uris.get(0).equals(new URI("http://localhost:8000/a/test-1/phone/search/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case"));
-
+        verify(webClientMock).postFormData(any(), any());
+        verifyNoMoreInteractions(webClientMock);
 
         // Open the form with `query` blocks
         NewFormResponse formResponse = sessionNavigateWithQuery(new String[]{"1", "0156fa3e-093e-4136-b95c-01b13dae66c6", "0"},
@@ -88,10 +88,8 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 NewFormResponse.class);
 
         // verify the second query block to fetch the remote case was executed
-        verify(webClientMock, times(2)).get(uriCaptor.capture());
-        uris = uriCaptor.getAllValues();
-        // when default search, prompts doesn't get included
-        assert uris.get(2).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=0156fa3e-093e-4136-b95c-01b13dae66c6"));
+        verify(webClientMock, times(2)).postFormData(any(), any());
+        verifyNoMoreInteractions(webClientMock);
 
         // see if the instance is retained into the form session
         checkXpath(
@@ -131,10 +129,8 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 EntityListResponse.class);
 
         // Check if form's query was executed
-        verify(webClientMock, times(1)).get(uriCaptor.capture());
-        List<URI> uris = uriCaptor.getAllValues();
-        // when default search, prompts doesn't get included
-        assert uris.get(0).equals(new URI("http://localhost:8000/a/test-1/phone/search/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case"));
+        verify(webClientMock).postFormData(any(), any());
+        verifyNoMoreInteractions(webClientMock);
 
         // Select a case
         CommandListResponseBean menuResponse = sessionNavigateWithQuery(new String[]{"2", "0156fa3e-093e-4136-b95c-01b13dae66c6"},
@@ -148,11 +144,8 @@ public class FormEntryWithQueryTests extends BaseTestClass{
 
         // verify the second query block to fetch the remote case was executed as well as the 3rd query block
         // to do a custom lookup
-        verify(webClientMock, times(3)).get(uriCaptor.capture());
-        uris = uriCaptor.getAllValues();
-        // when default search, prompts doesn't get included
-        assert uris.get(2).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=0156fa3e-093e-4136-b95c-01b13dae66c6"));
-        assert uris.get(3).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=dupe_case_id"));
+        verify(webClientMock, times(3)).postFormData(any(), any());
+        verifyNoMoreInteractions(webClientMock);
 
         // Open the form
         NewFormResponse formResponse = sessionNavigateWithQuery(new String[]{"2", "0156fa3e-093e-4136-b95c-01b13dae66c6", "0"},
@@ -161,10 +154,8 @@ public class FormEntryWithQueryTests extends BaseTestClass{
                 false,
                 NewFormResponse.class);
 
-        verify(webClientMock, times(3)).get(uriCaptor.capture());
-        uris = uriCaptor.getAllValues();
-        assert uris.get(2).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=0156fa3e-093e-4136-b95c-01b13dae66c6"));
-        assert uris.get(3).equals(new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=dupe_case_id"));
+        verify(webClientMock, times(3)).postFormData(any(), any());
+        verifyNoMoreInteractions(webClientMock);
 
         // check we can access the 'registry' instance in the form
         checkXpath(
@@ -194,17 +185,21 @@ public class FormEntryWithQueryTests extends BaseTestClass{
         return "restores/caseclaim.xml";
     }
 
-    private void configureQueryMock() throws URISyntaxException {
-        URI searchURI = new URI("http://localhost:8000/a/test-1/phone/search/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case");
+    private void configureQueryMock() {
+        String searchURI = "http://localhost:8000/a/test-1/phone/search/dec220eae9974c788654f23320f3a8d3/";
         String searchResponse = "query_responses/case_claim_response.xml";
-        when(webClientMock.get(eq(searchURI))).thenReturn(FileUtils.getFile(this.getClass(), searchResponse));
+        ImmutableMultimap<String, String> data = ImmutableMultimap.of("commcare_registry", "shubham", "case_type", "case");
+        when(webClientMock.postFormData(eq(searchURI), eq(data))).thenReturn(FileUtils.getFile(this.getClass(), searchResponse));
 
-        URI firstQueryURI = new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=0156fa3e-093e-4136-b95c-01b13dae66c6");
+        String registryUrl = "http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/";
+        ImmutableMultimap.Builder<String, String> builder = ImmutableMultimap.builder();
+        builder.putAll(data).put("case_id", "0156fa3e-093e-4136-b95c-01b13dae66c6");
         String firstQueryResponse = "query_responses/case_claim_response.xml";
-        when(webClientMock.get(eq(firstQueryURI))).thenReturn(FileUtils.getFile(this.getClass(), firstQueryResponse));
+        when(webClientMock.postFormData(eq(registryUrl), eq(builder.build()))).thenReturn(FileUtils.getFile(this.getClass(), firstQueryResponse));
 
-        URI secondQueryURI = new URI("http://localhost:8000/a/test-1/phone/registry_case/dec220eae9974c788654f23320f3a8d3/?commcare_registry=shubham&case_type=case&case_id=dupe_case_id");
+        builder = ImmutableMultimap.builder();
+        builder.putAll(data).put("case_id", "dupe_case_id");
         String secondQueryResponse = "query_responses/registry_query_response.xml";
-        when(webClientMock.get(eq(secondQueryURI))).thenReturn(FileUtils.getFile(this.getClass(), secondQueryResponse));
+        when(webClientMock.postFormData(eq(registryUrl), eq(builder.build()))).thenReturn(FileUtils.getFile(this.getClass(), secondQueryResponse));
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
@@ -1,9 +1,7 @@
 package org.commcare.formplayer.tests;
 
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import org.commcare.formplayer.beans.EvaluateXPathResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
@@ -15,7 +13,6 @@ import org.commcare.formplayer.session.FormSession;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.FileUtils;
 import org.commcare.formplayer.utils.TestContext;
-import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,9 +25,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Hashtable;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/org/commcare/formplayer/web/client/WebClientTest.java
+++ b/src/test/java/org/commcare/formplayer/web/client/WebClientTest.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URISyntaxException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
@@ -47,7 +48,7 @@ public class WebClientTest {
         webClient.setRestoreFactory(restoreFactory);
         webClient.setRestTemplate(restTemplate);
 
-        when(restoreFactory.getUserHeaders()).thenReturn(new HttpHeaders());
+        when(restoreFactory.getRequestHeaders(any())).thenReturn(new HttpHeaders());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/web/client/WebClientTest.java
+++ b/src/test/java/org/commcare/formplayer/web/client/WebClientTest.java
@@ -1,0 +1,80 @@
+package org.commcare.formplayer.web.client;
+
+import com.google.common.collect.ImmutableListMultimap;
+import org.commcare.formplayer.services.RestoreFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URISyntaxException;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+public class WebClientTest {
+
+    private RestTemplate restTemplate;
+
+    private MockRestServiceServer mockServer;
+
+    private WebClient webClient;
+
+    @Mock
+    private RestoreFactory restoreFactory;
+
+    @BeforeEach
+    public void init() throws URISyntaxException {
+        MockitoAnnotations.openMocks(this);
+
+        RestTemplateConfig config = new RestTemplateConfig("", "");
+        restTemplate = config.restTemplate(new RestTemplateBuilder());
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+
+        webClient = new WebClient();
+        webClient.setRestoreFactory(restoreFactory);
+        webClient.setRestTemplate(restTemplate);
+
+        when(restoreFactory.getUserHeaders()).thenReturn(new HttpHeaders());
+    }
+
+    @Test
+    public void testPostFormData() {
+        String url = "http://localhost:8000/a/demo/receiver/1234";
+        ImmutableListMultimap<String, String> postData = ImmutableListMultimap.of(
+                "a", "1",
+                "b", "2",
+                "b", "not 2"
+        );
+
+        MultiValueMap<String, String> expectedBody = new LinkedMultiValueMap<>();
+        postData.forEach(expectedBody::add);
+
+        mockServer.expect(ExpectedCount.once(), requestTo(url))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().formData(expectedBody))
+                .andRespond(withStatus(HttpStatus.OK)
+                        .contentType(MediaType.TEXT_HTML)
+                        .body("response123")
+                );
+
+        // call method under test
+        String response = webClient.postFormData(url, postData);
+        Assertions.assertEquals("response123", response);
+
+        mockServer.verify();
+    }
+
+}


### PR DESCRIPTION
Redo of https://github.com/dimagi/formplayer/pull/1029 with changes from master.

https://dimagi-dev.atlassian.net/browse/USH-1308

cross request: https://github.com/dimagi/commcare-core/pull/1060

This will require HQ changes since the `registry_case` endpoint only supports GET: https://github.com/dimagi/commcare-hq/blob/0f4bb130fc2da56882a499e88a3f580e1cd66810/corehq/apps/ota/views.py#L410-L414