### PR TITLE
[bugfix] Fix HMAC header for requests without URL query params

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -613,7 +613,10 @@ public class RestoreFactory {
 
     private HttpHeaders getHmacHeader(URI url) {
         // Do HMAC auth which requires only the path and query components of the URL
-        String requestPath = String.format("%s?%s", url.getRawPath(), url.getRawQuery());
+        String requestPath = url.getRawPath();
+        if (url.getRawQuery() != null) {
+            requestPath = String.format("%s?%s", requestPath, url.getRawQuery());
+        }
         if (!RequestUtils.requestAuthedWithHmac()) {
             throw new RuntimeException(String.format("Tried getting HMAC Auth for request %s but this request" +
                     "was not validated with HMAC.", requestPath));

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -1,9 +1,8 @@
 package org.commcare.formplayer.services;
 
 import com.timgroup.statsd.StatsDClient;
-
+import io.sentry.SentryLevel;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.cases.util.InvalidCaseGraphException;
@@ -48,11 +47,9 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
-import javax.servlet.http.HttpServletRequest;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,8 +62,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import io.sentry.SentryLevel;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -436,7 +431,7 @@ public class RestoreFactory {
 
     public HttpHeaders getRequestHeaders(URI url) {
         HttpHeaders headers;
-        if (getHqAuth() == null) {
+        if (RequestUtils.requestAuthedWithHmac()) {
             headers = getHmacHeader(url);
         } else {
             headers = getHqAuth().getAuthHeaders();;
@@ -619,12 +614,7 @@ public class RestoreFactory {
     private HttpHeaders getHmacHeader(URI url) {
         // Do HMAC auth which requires only the path and query components of the URL
         String requestPath = String.format("%s?%s", url.getRawPath(), url.getRawQuery());
-        HttpServletRequest request = RequestUtils.getCurrentRequest();
-        if (request == null) {
-            throw new RuntimeException(String.format(
-                    "HMAC Auth not available outside of a web request %s", requestPath
-            ));
-        } else if (BooleanUtils.isNotTrue((Boolean)request.getAttribute(Constants.HMAC_REQUEST_ATTRIBUTE))) {
+        if (!RequestUtils.requestAuthedWithHmac()) {
             throw new RuntimeException(String.format("Tried getting HMAC Auth for request %s but this request" +
                     "was not validated with HMAC.", requestPath));
         }

--- a/src/main/java/org/commcare/formplayer/util/RequestUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/RequestUtils.java
@@ -104,4 +104,16 @@ public class RequestUtils {
         }
         return Optional.empty();
     }
+
+    /**
+     * @return True if there is request in the context AND the request was authenticated with HMAC auth
+     */
+    public static boolean requestAuthedWithHmac() {
+        HttpServletRequest request = getCurrentRequest();
+        if (request == null) {
+            return false;
+        }
+        Object attribute = request.getAttribute(Constants.HMAC_REQUEST_ATTRIBUTE);
+        return attribute != null && (Boolean) attribute;
+    }
 }

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.web.client;
 
 import com.google.common.collect.Multimap;
 import org.commcare.formplayer.services.RestoreFactory;
+import org.commcare.formplayer.util.RequestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
@@ -39,6 +40,7 @@ public class WebClient {
     }
 
     public <T> String post(String url, T body) {
+        checkHmac();
         URI uri = URI.create(url);
         return restTemplate.exchange(
                 RequestEntity.post(uri).headers(restoreFactory.getRequestHeaders(uri)).body(body), String.class
@@ -46,6 +48,7 @@ public class WebClient {
     }
 
     public <T> String postFormData(String url, Multimap<String, String> data) {
+        checkHmac();
         URI uri = URI.create(url);
         LinkedMultiValueMap<String, String> postData = new LinkedMultiValueMap<>();
         data.forEach(postData::add);
@@ -56,6 +59,16 @@ public class WebClient {
                         .body(postData),
                 String.class
         ).getBody();
+    }
+
+    /**
+     * This is not a technical limitation, just a code limitation that should
+     * be fixed in the future.
+     */
+    private void checkHmac() {
+        if (RequestUtils.requestAuthedWithHmac()) {
+            throw new RuntimeException("HMAC auth not supported for POST requests");
+        }
     }
 
     @Autowired

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -26,7 +26,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -231,7 +230,7 @@ public class RestoreFactoryTest {
     }
 
     @Test
-    public void testGetRequestHeaders_HmacAuthRequestWithUserDetails() throws Exception {
+    public void testGetRequestHeaders_UseHmacAuthEvenIfHqAuthPresent() throws Exception {
         mockHmacRequest();
         String requestPath = "/a/restore-domain/case_migrations/restore/case_id_123/";
         HttpHeaders headers = restoreFactorySpy.getRequestHeaders(new URI("http://localhost:8000" + requestPath));

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -3,6 +3,7 @@ package org.commcare.formplayer.tests;
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.services.RestoreFactory;
+import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.TestContext;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -11,13 +12,19 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -25,9 +32,10 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by benrudolph on 1/19/17.
@@ -44,10 +52,16 @@ public class RestoreFactoryTest {
     @Autowired
     RestoreFactory restoreFactorySpy;
 
+    @Mock
+    private ServletRequestAttributes requestAttributes;
+
+    @Mock
+    private HttpServletRequest request;
+
     @BeforeEach
     public void setUp() throws Exception {
-        Mockito.reset(restoreFactorySpy);
         MockitoAnnotations.openMocks(this);
+        Mockito.reset(restoreFactorySpy);
         AuthenticatedRequestBean requestBean = new AuthenticatedRequestBean();
         requestBean.setRestoreAs(asUsername);
         requestBean.setUsername(username);
@@ -55,6 +69,14 @@ public class RestoreFactoryTest {
         restoreFactorySpy.configure(requestBean, new DjangoAuth("key"));
         restoreFactorySpy.setAsUsername(null);
         restoreFactorySpy.setCaseId(null);
+
+        // mock request
+        RequestContextHolder.setRequestAttributes(requestAttributes);
+        when(requestAttributes.getRequest()).thenReturn(request);
+    }
+
+    private void mockHmacRequest() {
+        when(request.getAttribute(eq(Constants.HMAC_REQUEST_ATTRIBUTE))).thenReturn(true);
     }
 
     private void mockSyncFreq(String freq) {
@@ -161,7 +183,7 @@ public class RestoreFactoryTest {
         String syncToken = "synctoken";
         Mockito.doReturn(syncToken).when(restoreFactorySpy).getSyncToken();
         HttpHeaders headers = restoreFactorySpy.getRequestHeaders(null);
-        hasSize(7).matches(headers);
+        assertEquals(7, headers.size());
         validateHeaders(headers, Arrays.asList(
                 hasEntry("Cookie", singletonList("sessionid=key")),
                 hasEntry("sessionid", singletonList("key")),
@@ -169,6 +191,35 @@ public class RestoreFactoryTest {
                 hasEntry("X-OpenRosa-Version", singletonList("3.0")),
                 hasEntry("X-OpenRosa-DeviceId", singletonList("WebAppsLogin")),
                 hasEntry("X-CommCareHQ-LastSyncToken", singletonList(syncToken)),
+                hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
+        );
+    }
+
+    @Test
+    public void testGetRequestHeaders_HmacAuth() throws URISyntaxException {
+        mockHmacRequest();
+        restoreFactorySpy.configure(domain, "case_id", null);
+        URI url = new URI("http://localhost:8000/a/restore-domain/case_migrations/restore/case_id_123/");
+        HttpHeaders headers = restoreFactorySpy.getRequestHeaders(url);
+        assertEquals(4, headers.size());
+        validateHeaders(headers, Arrays.asList(
+                hasEntry("X-MAC-DIGEST", singletonList("LAFtw7wwTodY3LINqfVsyle5dAXEEA2uglk1pkgev3U=")),
+                hasEntry("X-OpenRosa-Version", singletonList("3.0")),
+                hasEntry("X-OpenRosa-DeviceId", singletonList("WebAppsLogin")),
+                hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
+        );
+    }
+
+    @Test
+    public void testGetRequestHeaders_HmacAuthRequestWithUserDetails() throws URISyntaxException {
+        mockHmacRequest();
+        URI url = new URI("http://localhost:8000/a/restore-domain/case_migrations/restore/case_id_123/");
+        HttpHeaders headers = restoreFactorySpy.getRequestHeaders(url);
+        assertEquals(4, headers.size());
+        validateHeaders(headers, Arrays.asList(
+                hasEntry("X-MAC-DIGEST", singletonList("LAFtw7wwTodY3LINqfVsyle5dAXEEA2uglk1pkgev3U=")),
+                hasEntry("X-OpenRosa-Version", singletonList("3.0")),
+                hasEntry("X-OpenRosa-DeviceId", singletonList("WebAppsLogin")),
                 hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
         );
     }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-12830

The refactor in https://github.com/dimagi/formplayer/pull/1045 changed how HMAC auth was calculated for URLs with no query params.

First commit is a prefactor, 2nd commit is the actual fix.

This PR updates tests to validate the HMAC headers.