### PR TITLE
refactor restore URLs to use URL templates from properties

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.services;
 
+import com.google.common.collect.ImmutableMap;
 import com.timgroup.statsd.StatsDClient;
 import io.sentry.SentryLevel;
 import org.apache.commons.io.IOUtils;
@@ -60,6 +61,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -74,6 +76,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class RestoreFactory {
     @Value("${commcarehq.host}")
     private String host;
+
+    @Value("${commcarehq.restore.url}")
+    private String restoreUrl;
 
     @Value("${commcarehq.restore.url.case}")
     private String caseRestoreUrl;
@@ -662,32 +667,39 @@ public class RestoreFactory {
     }
 
     public URI getUserRestoreUrl(boolean skipFixtures) {
-        String uri = buildUrlPath(host, "/a/", domain, "/phone/restore/?version=2.0");
-        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(uri);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(restoreUrl).encode();
+
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("version", "2.0");
+        params.put("device_id", getSyncDeviceId());
+
         String syncToken = getSyncToken();
         // Add query params.
-        try {
-            if (syncToken != null && !"".equals(syncToken)) {
-                builderQueryParamEncoded(builder, "since", syncToken);
-            }
-            builderQueryParamEncoded(builder, "device_id", getSyncDeviceId());
-            if (asUsername != null) {
-                String unEncodedAsUsername = asUsername;
-                if (!asUsername.contains("@")) {
-                    unEncodedAsUsername += "@" + domain + ".commcarehq.org";
-                }
-                builderQueryParamEncoded(builder, "as", unEncodedAsUsername);
-            } else if (getHqAuth() == null && username != null) {
-                // HQ requesting to force a sync for a user
-                builderQueryParamEncoded(builder, "as", username);
-            }
-            if (skipFixtures) {
-                builderQueryParamEncoded(builder, "skip_fixtures", "true");
-            }
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(String.format("Restore Error: " + e.getMessage()));
+        if (syncToken != null && !"".equals(syncToken)) {
+            params.put("since", syncToken);
         }
-        return builder.build(true).toUri();
+        if (asUsername != null) {
+            String asUserParam = asUsername;
+            if (!asUsername.contains("@")) {
+                asUserParam += "@" + domain + ".commcarehq.org";
+            }
+            params.put("as", asUserParam);
+        } else if (getHqAuth() == null && username != null) {
+            // HQ requesting to force a sync for a user
+            params.put("as", username);
+        }
+        if (skipFixtures) {
+            params.put("skip_fixtures", "true");
+        }
+
+        // add the params to the query builder as templates
+        params.forEach((key, value) -> builder.queryParam(key, String.format("{%s}", key)));
+
+        Map<String, String> templateVars = ImmutableMap.<String, String>builder()
+                .putAll(params)
+                .put("domain", this.domain)
+                .build();
+        return builder.buildAndExpand(templateVars).toUri();
     }
 
     /**

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -74,9 +74,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 @Component
 @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class RestoreFactory {
-    @Value("${commcarehq.host}")
-    private String host;
-
     @Value("${commcarehq.restore.url}")
     private String restoreUrl;
 
@@ -644,26 +641,8 @@ public class RestoreFactory {
         };
     }
 
-    private void builderQueryParamEncoded(UriComponentsBuilder builder, String name, String value)
-            throws UnsupportedEncodingException {
-        try {
-            builder.queryParam(name,
-                    URLEncoder.encode(value, UTF_8.toString()));
-        } catch (UnsupportedEncodingException e) {
-            throw new UnsupportedEncodingException(String.format("Unable to encode '%s'", name));
-        }
-    }
-
     public URI getCaseRestoreUrl() {
         return UriComponentsBuilder.fromHttpUrl(caseRestoreUrl).buildAndExpand(domain, caseId).toUri();
-    }
-
-    private String buildUrlPath(String... parts) {
-        StringBuilder builder = new StringBuilder();
-        for (String part : parts) {
-            builder.append(part);
-        }
-        return builder.toString();
     }
 
     public URI getUserRestoreUrl(boolean skipFixtures) {

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -75,6 +75,9 @@ public class RestoreFactory {
     @Value("${commcarehq.host}")
     private String host;
 
+    @Value("${commcarehq.restore.url.case}")
+    private String caseRestoreUrl;
+
     private String asUsername;
     private String username;
     private String scrubbedUsername;
@@ -647,8 +650,7 @@ public class RestoreFactory {
     }
 
     public URI getCaseRestoreUrl() {
-        String path = buildUrlPath(host, "/a/", domain, "/case_migrations/restore/", caseId, "/");
-        return UriComponentsBuilder.fromUriString(path).build(true).toUri();
+        return UriComponentsBuilder.fromHttpUrl(caseRestoreUrl).buildAndExpand(domain, caseId).toUri();
     }
 
     private String buildUrlPath(String... parts) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,6 +46,7 @@ commcarehq.host=${COMMCARE_HOST}
 commcarehq.alternate.origins=${COMMCARE_ALTERNATE_ORIGINS:}
 commcarehq.formplayerAuthKey=${AUTH_KEY}
 
+commcarehq.restore.url=${commcarehq.host}/a/{domain}/phone/restore/
 commcarehq.restore.url.case=${commcarehq.host}/a/{domain}/case_migrations/restore/{case_id}/
 
 formplayer.externalRequestMode=${EXTERNAL_REQUEST_MODE:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,6 +45,9 @@ sentry.send-default-pii=true
 commcarehq.host=${COMMCARE_HOST}
 commcarehq.alternate.origins=${COMMCARE_ALTERNATE_ORIGINS:}
 commcarehq.formplayerAuthKey=${AUTH_KEY}
+
+commcarehq.restore.url.case=${commcarehq.host}/a/{domain}/case_migrations/restore/{case_id}/
+
 formplayer.externalRequestMode=${EXTERNAL_REQUEST_MODE:}
 server.port=${SERVER_PORT:8080}
 redis.hostname=${REDIS_HOSTNAME:redis}

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -164,7 +164,7 @@ public class RestoreFactoryTest {
         restoreFactorySpy.setAsUsername("asUser@domain1.commcarehq.org");
         assertEquals(
                 BASE_URL + "?version=2.0" +
-                        "&device_id=WebAppsLogin*restore-dude*as*asUser%40domain1.commcarehq.org" +
+                        "&device_id=WebAppsLogin%2Arestore-dude%2Aas%2AasUser%40domain1.commcarehq.org" +
                         "&as=asUser%40domain1.commcarehq.org",
                 restoreFactorySpy.getUserRestoreUrl(false).toString()
         );
@@ -175,7 +175,7 @@ public class RestoreFactoryTest {
         restoreFactorySpy.setAsUsername("asUser+test-encoding@domain1.commcarehq.org");
         assertEquals(
                 BASE_URL + "?version=2.0" +
-                        "&device_id=WebAppsLogin*restore-dude*as*asUser%2Btest-encoding%40domain1.commcarehq.org" +
+                        "&device_id=WebAppsLogin%2Arestore-dude%2Aas%2AasUser%2Btest-encoding%40domain1.commcarehq.org" +
                         "&as=asUser%2Btest-encoding%40domain1.commcarehq.org",
                 restoreFactorySpy.getUserRestoreUrl(false).toString()
         );
@@ -187,7 +187,7 @@ public class RestoreFactoryTest {
         restoreFactorySpy.setAsUsername("asUser");
         assertEquals(
                 BASE_URL + "?version=2.0" +
-                        "&device_id=WebAppsLogin*restore-dude*as*asUser" +
+                        "&device_id=WebAppsLogin%2Arestore-dude%2Aas%2AasUser" +
                         "&as=asUser%40restore-domain.commcarehq.org",
                 restoreFactorySpy.getUserRestoreUrl(false).toString()
         );

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -170,6 +170,17 @@ public class RestoreFactoryTest {
         );
     }
 
+    @Test
+    public void testGetUserRestoreUrlWithLoginAs_encoded() {
+        restoreFactorySpy.setAsUsername("asUser+test-encoding@domain1.commcarehq.org");
+        assertEquals(
+                BASE_URL + "?version=2.0" +
+                        "&device_id=WebAppsLogin*restore-dude*as*asUser%2Btest-encoding%40domain1.commcarehq.org" +
+                        "&as=asUser%2Btest-encoding%40domain1.commcarehq.org",
+                restoreFactorySpy.getUserRestoreUrl(false).toString()
+        );
+    }
+
 
     @Test
     public void testGetUserRestoreUrlWithLoginAsNoDomain() {


### PR DESCRIPTION
Moves the restore URLs outside of the code and into the properties file. This also uses URL templates which handles all the encoding etc. which means we don't have to do it.

I started working on this because of the upcoming change in the "case restore" URL: https://github.com/dimagi/commcare-hq/pull/30826.

This does change the encoded URLs slightly since it also encodes characters like `*`. This is not an issue since it is a standard encoding which Django handles transparently.