### PR TITLE
upgrade log4j due to  CVE-2021-44228

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,16 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-autoconfigure'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
+    implementation('org.apache.logging.log4j:log4j-to-slf4j') {
+        version {
+            strictly '2.15.0'
+        }
+    }
+    implementation('org.apache.logging.log4j:log4j-api') {
+        version {
+            strictly '2.15.0'
+        }
+    }
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation group: 'org.xerial', name: 'sqlite-jdbc'
     implementation group: 'redis.clients', name: 'jedis'


### PR DESCRIPTION
I do not think we are vulnerable to this CVE since we do not use log4j however for the sake of precaution we are updating the 'log4j-to-slf4j' library along with 'log4j-api'.

CVE: https://www.randori.com/blog/cve-2021-44228/

If there are compatibility issues we will need to upgrade Spring to > 2.6.0 which is currently blocked by our usage of PostgreSQL 9.6: https://github.com/dimagi/formplayer/pull/1053