### PR TITLE
Respect relevancy when returning instance xml for data preview

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/DebuggerController.java
+++ b/src/main/java/org/commcare/formplayer/application/DebuggerController.java
@@ -61,7 +61,7 @@ public class DebuggerController extends AbstractBaseController {
         SerializableFormSession serializableFormSession = formSessionService.getSessionById(debuggerRequest.getSessionId());
         SerializableMenuSession serializableMenuSession = menuSessionService.getSessionById(serializableFormSession.getMenuSessionId());
         FormSession formSession = getFormSession(serializableFormSession);
-        String instanceXml = formSession.getInstanceXml();
+        String instanceXml = formSession.getInstanceXml(false);
         FormattedQuestionsService.QuestionResponse response = formattedQuestionsService.getFormattedQuestions(
                 debuggerRequest.getDomain(),
                 serializableMenuSession.getAppId(),


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SUPPORT-12366

Bug introduced by [this PR](https://github.com/dimagi/formplayer/pull/1005) which defaulted `getInstanceXml()` to serialize all data (ignore relevancy). In addition to this identified spot, I'm looking through other `getInstanceXml()` calls to determine if it is expected that they serialize all data.

I replicated Clayton's [test app](https://www.commcarehq.org/a/corpora/apps/view/2d262ab3b3c5090876b15ba1e1021ef7/form/91f50ad022bf45cbbab460b32b37a6a9/source/#form/the_hidden_value_checker) locally to reproduce the issue. 
Before the fix:
<img width="297" alt="Screen Shot 2022-01-21 at 3 15 15 PM" src="https://user-images.githubusercontent.com/15785053/150612273-3656011f-fd50-4646-9add-e3f5c4834342.png">
After the fix:
<img width="293" alt="Screen Shot 2022-01-21 at 3 12 39 PM" src="https://user-images.githubusercontent.com/15785053/150612279-bf2ffc84-1507-47e1-82b3-d108f3eb617a.png">

