### PR TITLE
Removed CC version string from app version text

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -193,7 +193,7 @@ public class MenuSessionRunnerService {
 
         menuResponseBean.setBreadcrumbs(menuSession.getBreadcrumbs());
         menuResponseBean.setAppId(menuSession.getAppId());
-        menuResponseBean.setAppVersion(menuSession.getCommCareVersionString() + ", App Version: " + menuSession.getAppVersion());
+        menuResponseBean.setAppVersion("App Version: " + menuSession.getAppVersion());
         menuResponseBean.setPersistentCaseTile(getPersistentDetail(menuSession, storageFactory.getPropertyManager().isFuzzySearchEnabled()));
         return menuResponseBean;
     }
@@ -625,7 +625,7 @@ public class MenuSessionRunnerService {
         if (menuSession.getSessionWrapper().getForm() != null) {
             NewFormResponse formResponseBean = generateFormEntrySession(menuSession);
             formResponseBean.setAppId(menuSession.getAppId());
-            formResponseBean.setAppVersion(menuSession.getCommCareVersionString() + ", App Version: " + menuSession.getAppVersion());
+            formResponseBean.setAppVersion("App Version: " + menuSession.getAppVersion());
             formResponseBean.setPersistentCaseTile(getPersistentDetail(menuSession, storageFactory.getPropertyManager().isFuzzySearchEnabled()));
             formResponseBean.setBreadcrumbs(menuSession.getBreadcrumbs());
             // update datadog/sentry metrics

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -334,10 +334,6 @@ public class MenuSession implements HereFunctionHandlerListener {
         return session.getAppId();
     }
 
-    public String getCommCareVersionString() {
-        return sessionWrapper.getIIF().getVersionString();
-    }
-
     public String getAppVersion() {
         return "" + this.engine.getPlatform().getCurrentProfile().getVersion();
     }


### PR DESCRIPTION
Removes CC version from web apps footer, just leaving app version. The version shown wasn't accurate, as it was pulling from [here](https://github.com/dimagi/commcare-core/blob/670ff633bf303978f96d8f2e03de205918c34941/src/cli/java/org/commcare/util/engine/CommCareConfigEngine.java#L70-L72). I considered using HQ to populate this, using the latest available CC build, but the current build is typically marked with " (dev)" which seems like a source of confusion/concern.

![Screen Shot 2022-02-10 at 12 11 31 PM](https://user-images.githubusercontent.com/1486591/153460090-d6950ecf-1341-4593-8bd4-4ee8fe0219ea.png)

