### PR TITLE
include queryKey in EntityList responses

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/CommandListResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/CommandListResponseBean.java
@@ -43,6 +43,7 @@ public class CommandListResponseBean extends MenuBean {
         }
 
         this.layoutStyle = session.getPlatform().getMenuDisplayStyle(menuId);
+        setQueryKey(menuId);
     }
 
     @Override

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -55,6 +55,8 @@ public class EntityListResponse extends MenuBean {
     private int maxWidth;
     private int maxHeight;
 
+    private String queryKey;
+
     public EntityListResponse() {
     }
 
@@ -117,6 +119,7 @@ public class EntityListResponse extends MenuBean {
         this.headers = pair.first;
         this.widthHints = pair.second;
         this.sortIndices = detail.getOrderedFieldIndicesForSorting();
+        this.queryKey = session.getCommand();
     }
 
     private void processCaseTiles(Detail shortDetail) {
@@ -251,6 +254,10 @@ public class EntityListResponse extends MenuBean {
 
     public void setSortIndices(int[] sortIndices) {
         this.sortIndices = sortIndices;
+    }
+
+    public String getQueryKey() {
+        return queryKey;
     }
 
     static class LogNotifier implements EntitySortNotificationInterface {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -55,8 +55,6 @@ public class EntityListResponse extends MenuBean {
     private int maxWidth;
     private int maxHeight;
 
-    private String queryKey;
-
     public EntityListResponse() {
     }
 
@@ -119,7 +117,7 @@ public class EntityListResponse extends MenuBean {
         this.headers = pair.first;
         this.widthHints = pair.second;
         this.sortIndices = detail.getOrderedFieldIndicesForSorting();
-        this.queryKey = session.getCommand();
+        setQueryKey(session.getCommand());
     }
 
     private void processCaseTiles(Detail shortDetail) {
@@ -254,10 +252,6 @@ public class EntityListResponse extends MenuBean {
 
     public void setSortIndices(int[] sortIndices) {
         this.sortIndices = sortIndices;
-    }
-
-    public String getQueryKey() {
-        return queryKey;
     }
 
     static class LogNotifier implements EntitySortNotificationInterface {

--- a/src/main/java/org/commcare/formplayer/beans/menus/MenuBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/MenuBean.java
@@ -12,6 +12,7 @@ public class MenuBean extends BaseResponseBean {
     private String[] locales;
     private String[] breadcrumbs;
     private EntityDetailResponse persistentCaseTile;
+    private String queryKey;
 
     @Override
     public String toString() {
@@ -41,5 +42,13 @@ public class MenuBean extends BaseResponseBean {
 
     public void setPersistentCaseTile(EntityDetailResponse persistentCaseTile) {
         this.persistentCaseTile = persistentCaseTile;
+    }
+
+    public String getQueryKey() {
+        return queryKey;
+    }
+
+    public void setQueryKey(String queryKey) {
+        this.queryKey = queryKey;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -21,7 +21,6 @@ import java.util.Hashtable;
 public class QueryResponseBean extends MenuBean {
 
     private DisplayElement[] displays;
-    private String queryKey;
     private final String type = "query";
 
     QueryResponseBean() {
@@ -81,7 +80,7 @@ public class QueryResponseBean extends MenuBean {
             count++;
         }
         setTitle(queryScreen.getScreenTitle());
-        this.queryKey = session.getCommand();
+        setQueryKey(session.getCommand());
     }
 
     @Override
@@ -92,15 +91,5 @@ public class QueryResponseBean extends MenuBean {
 
     public String getType() {
         return type;
-    }
-
-    @JsonGetter(value = "queryKey")
-    public String getQueryKey() {
-        return queryKey;
-    }
-
-    @JsonSetter(value = "queryKey")
-    public void setQueryKey(String queryKey) {
-        this.queryKey = queryKey;
     }
 }


### PR DESCRIPTION
This allows Web Apps to know what the current command is which is
necessary when sending back query data.

This is required after the changes pass `force_manual_action` in the query data:
* https://github.com/dimagi/commcare-hq/pull/31152
* https://github.com/dimagi/formplayer/pull/1097

Related HQ change: https://github.com/dimagi/commcare-hq/pull/31273

Note: must be deployed before or at the same time as the CommCare PR