### PR TITLE
Add and use forSubmission parameter to SessionRequestBean

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -267,7 +267,8 @@ public class FormController extends AbstractBaseController {
                                                   @CookieValue(name = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken) throws Exception {
         SerializableFormSession serializableFormSession = formSessionService.getSessionById(requestBean.getSessionId());
         FormSession formSession = getFormSession(serializableFormSession);
-        return new GetInstanceResponseBean(formSession);
+        Boolean serializeAllData = !requestBean.getForSubmission();
+        return new GetInstanceResponseBean(formSession, serializeAllData);
     }
 
 

--- a/src/main/java/org/commcare/formplayer/beans/GetInstanceResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/GetInstanceResponseBean.java
@@ -16,8 +16,8 @@ public class GetInstanceResponseBean extends BaseResponseBean {
     GetInstanceResponseBean() {
     }
 
-    public GetInstanceResponseBean(FormSession formSession) throws IOException {
-        this.output = formSession.getInstanceXml();
+    public GetInstanceResponseBean(FormSession formSession, Boolean serializeAllData) throws IOException {
+        this.output = formSession.getInstanceXml(serializeAllData);
         this.xmlns = formSession.getXmlns();
     }
 

--- a/src/main/java/org/commcare/formplayer/beans/SessionRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionRequestBean.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
  */
 public class SessionRequestBean extends AuthenticatedRequestBean {
     protected String sessionId;
+    protected Boolean forSubmission;
 
     @JsonGetter(value = "session_id")
     public String getSessionId() {
@@ -19,6 +20,16 @@ public class SessionRequestBean extends AuthenticatedRequestBean {
         if (sessionId != null) {
             this.sessionId = sessionId;
         }
+    }
+
+    @JsonGetter(value = "for_submission")
+    public Boolean getForSubmission() {
+        return forSubmission;
+    }
+
+    @JsonSetter(value = "for_submission")
+    public void setForSubmission(Boolean forSubmission) {
+        this.forSubmission = forSubmission;
     }
 
     @Deprecated


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13204

As the ticket describes, the issue is that form sessions that expire and submit partially completed forms do not respect relevancy. This is due to recent serialization changes, and despite inspecting this specific scenario [here](https://github.com/dimagi/formplayer/pull/1083#issuecomment-1018949957), I failed to take into consideration _all_ use cases of this request in HQ. If instance xml is being retrieved specifically for a submission, formplayer needs to be aware of this so it can properly serialize the xml.

A followup change will be made on HQ to take advantage of this new parameter when requesting an instance for submitting a partially completed form. 