### PR TITLE
Create form definition table in Postgres

### DIFF
--- a/src/main/java/org/commcare/formplayer/db/migration/V22__create_form_definition.java
+++ b/src/main/java/org/commcare/formplayer/db/migration/V22__create_form_definition.java
@@ -1,0 +1,31 @@
+package org.commcare.formplayer.db.migration;
+
+import java.util.Arrays;
+
+/**
+ * A table to hold a serialized FormDef objects that can be shared across sessions
+ * Uniquely identifiable by the combination of app id, form xmlns, and form version
+ * See SerializableFormDefinition for the Java representation
+ */
+public class V22__create_form_definition extends BaseFormplayerMigration {
+    @Override
+    public Iterable<String> getSqlStatements() {
+        return Arrays.asList(
+                "CREATE TABLE form_definition (\n" +
+                        "    id bigserial PRIMARY KEY,\n" +
+                        "    datecreated timestamp with time zone,\n" +
+                        "    appid text NOT NULL,\n" +
+                        "    formxmlns text NOT NULL,\n" +
+                        "    formversion text NOT NULL,\n" +
+                        "    formdef text NOT NULL,\n" +
+                        "    CONSTRAINT form_definition_version UNIQUE (appid, formxmlns, formversion)\n" +
+                        ")",
+
+                "ALTER TABLE formplayer_sessions ADD form_definition_id bigint",
+
+                "ALTER TABLE formplayer_sessions " +
+                        "ADD FOREIGN KEY (form_definition_id) " +
+                        "REFERENCES form_definition(id)"
+        );
+    }
+}

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormDefinition.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormDefinition.java
@@ -1,0 +1,54 @@
+package org.commcare.formplayer.objects;
+
+import java.time.Instant;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Java representation of form_definition sql table
+ * Used to share form definitions across sessions
+ */
+@Entity
+@Table(name = "form_definition")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class SerializableFormDefinition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(name = "datecreated")
+    private Instant dateCreated;
+
+    @Column(name = "appid")
+    private String appId;
+
+    @Column(name = "formxmlns")
+    private String formXmlns;
+
+    @Column(name = "formversion")
+    private String formVersion;
+
+    @Column(name = "formdef")
+    private String serializedFormDef;
+
+    protected SerializableFormDefinition() {}
+
+    public SerializableFormDefinition(String appId, String formXmlns, String formVersion, String formDef) {
+        this.appId = appId;
+        this.formXmlns = formXmlns;
+        this.formVersion = formVersion;
+        this.serializedFormDef = formDef;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -65,6 +65,11 @@ public class SerializableFormSession implements Serializable{
     @Column(name="instancexml")
     private String instanceXml;
 
+    @Setter
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "form_definition_id")
+    private SerializableFormDefinition formDefinition;
+
     @Column(updatable=false)
     private String username;
 

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -12,57 +12,57 @@ import java.time.Instant;
 import java.util.Map;
 
 @Entity
-@Table(name="formplayer_sessions")
+@Table(name = "formplayer_sessions")
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-public class SerializableFormSession implements Serializable{
+public class SerializableFormSession implements Serializable {
     public enum SubmitStatus {
         PROCESSED_XML,
         PROCESSED_STACK
     }
 
     @Id
-    @GeneratedValue( generator="uuid" )
-    @GenericGenerator(name="uuid", strategy="org.hibernate.id.UUIDGenerator")
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "org.hibernate.id.UUIDGenerator")
     private String id;
 
     @Version
     private int version;
 
     @CreatedDate
-    @Column(name="datecreated")
+    @Column(name = "datecreated")
     private Instant dateCreated;
 
-    @Column(updatable=false)
+    @Column(updatable = false)
     private String domain;
 
-    @Column(name="asuser", updatable=false)
+    @Column(name = "asuser", updatable = false)
     private String asUser;
 
-    @Column(name="appid", updatable=false)
+    @Column(name = "appid", updatable = false)
     private String appId;
 
-    @Column(name="caseid", updatable=false)
+    @Column(name = "caseid", updatable = false)
     private String restoreAsCaseId;
 
-    @Column(name="posturl", updatable=false)
+    @Column(name = "posturl", updatable = false)
     private String postUrl;
 
-    @Column(name="menu_session_id", updatable=false)
+    @Column(name = "menu_session_id", updatable = false)
     private String menuSessionId;
 
-    @Column(updatable=false)
+    @Column(updatable = false)
     private String title;
 
-    @Column(name="onequestionperscreen", updatable=false)
+    @Column(name = "onequestionperscreen", updatable = false)
     private boolean oneQuestionPerScreen;
 
     @Setter
-    @Column(name="formxml", updatable=false)
+    @Column(name = "formxml", updatable = false)
     private String formXml;
 
     @Setter
-    @Column(name="instancexml")
+    @Column(name = "instancexml")
     private String instanceXml;
 
     @Setter
@@ -70,26 +70,26 @@ public class SerializableFormSession implements Serializable{
     @JoinColumn(name = "form_definition_id")
     private SerializableFormDefinition formDefinition;
 
-    @Column(updatable=false)
+    @Column(updatable = false)
     private String username;
 
     @Setter
-    @Column(name="initlang")
+    @Column(name = "initlang")
     private String initLang;
 
-    @Column(name="sessiondata")
+    @Column(name = "sessiondata")
     @Convert(converter=ByteArrayConverter.class)
     private Map<String, String> sessionData;
 
     @Setter
-    @Column(name="currentindex")
+    @Column(name = "currentindex")
     private String currentIndex;
 
-    @Column(name="functioncontext")
+    @Column(name = "functioncontext")
     @Convert(converter=ByteArrayConverter.class)
     private Map<String, FunctionHandler[]> functionContext;
 
-    @Column(name="inpromptmode")
+    @Column(name = "inpromptmode")
     private boolean inPromptMode;
 
     private String submitStatus;


### PR DESCRIPTION
It is better practice to isolate the migration from the code that depends on it, which is currently not the case with https://github.com/dimagi/formplayer/pull/1075. This contains only the migration which is safe to deploy without the related code that makes use of it.