### PR TITLE
FormDef Object Pooler

### DIFF
--- a/src/main/java/org/commcare/formplayer/exceptions/AlreadyExistsInPoolException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/AlreadyExistsInPoolException.java
@@ -1,0 +1,7 @@
+package org.commcare.formplayer.exceptions;
+
+public class AlreadyExistsInPoolException extends Exception {
+    public AlreadyExistsInPoolException() {
+        super("Attempted to add form def object to pool that has already been added.");
+    }
+}

--- a/src/main/java/org/commcare/formplayer/exceptions/ExceedsMaxPoolSizeException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/ExceedsMaxPoolSizeException.java
@@ -1,0 +1,7 @@
+package org.commcare.formplayer.exceptions;
+
+public class ExceedsMaxPoolSizeException extends Exception {
+    public ExceedsMaxPoolSizeException(int totalSize) {
+        super("Exceeds max pool size " + totalSize);
+    }
+}

--- a/src/main/java/org/commcare/formplayer/exceptions/ExceedsMaxPoolSizePerId.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/ExceedsMaxPoolSizePerId.java
@@ -1,0 +1,7 @@
+package org.commcare.formplayer.exceptions;
+
+public class ExceedsMaxPoolSizePerId extends Exception {
+    public ExceedsMaxPoolSizePerId(int maxNum, String id) {
+        super("Max number (" + maxNum + ") of entries for id " + id + " exceeded.");
+    }
+}

--- a/src/main/java/org/commcare/formplayer/exceptions/FormDefEntryNotFoundException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/FormDefEntryNotFoundException.java
@@ -1,0 +1,7 @@
+package org.commcare.formplayer.exceptions;
+
+public class FormDefEntryNotFoundException extends Exception {
+    public FormDefEntryNotFoundException(String id) {
+        super("Form def for id " + id + " has not been added. Use create(...) to add new entries.");
+    }
+}

--- a/src/main/java/org/commcare/formplayer/objects/FormDefPool.java
+++ b/src/main/java/org/commcare/formplayer/objects/FormDefPool.java
@@ -1,0 +1,78 @@
+package org.commcare.formplayer.objects;
+
+import org.commcare.formplayer.exceptions.AlreadyExistsInPoolException;
+import org.commcare.formplayer.exceptions.FormDefEntryNotFoundException;
+import org.commcare.modern.util.Pair;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.core.model.instance.TreeReference;
+
+import java.util.*;
+
+public class FormDefPool {
+
+    private final Hashtable<String, Pair<TreeElement, List<FormDefPoolElement>>> pool;
+
+    public FormDefPool() {
+        this.pool = new Hashtable<>();
+    }
+
+    public void create(String id, FormDef formDef) throws AlreadyExistsInPoolException {
+        Pair<TreeElement, List<FormDefPoolElement>> pair = this.pool.get(id);
+        if (pair != null) {
+            addFormDefToExistingEntry(pair.second, formDef);
+        } else {
+            createNewFormDefPoolEntry(id, formDef);
+        }
+    }
+    public FormDef getFormDef(String id) {
+        Pair<TreeElement, List<FormDefPoolElement>> pair = this.pool.get(id);
+        // if an entry exists and there is an available form def to lease
+        if (pair != null) {
+            FormDefPoolElement availableElement = pair.second.stream()
+                    .filter(e -> !e.leased)
+                    .findFirst()
+                    .orElse(null);
+            if (availableElement != null) {
+                availableElement.leased = true;
+                return availableElement.formDef;
+            }
+        }
+        return null;
+    }
+
+    public void returnFormDef(String id, FormDef formDef) throws FormDefEntryNotFoundException {
+        Pair<TreeElement, List<FormDefPoolElement>> pair = this.pool.get(id);
+        if (pair == null) {
+            throw new FormDefEntryNotFoundException(id);
+        }
+
+        FormDef cleanedFormDef = resetFormDef(pair.first, formDef);
+        pair.second.stream().filter(e -> e.formDef == cleanedFormDef).findFirst().ifPresent(element -> element.leased = false);
+    }
+
+    private FormDef resetFormDef(TreeElement templateRoot, FormDef formDef) {
+        TreeElement copiedRoot = templateRoot.deepCopy(true);
+        TreeReference tr = TreeReference.rootRef();
+        tr.add(copiedRoot.getName(), TreeReference.INDEX_UNBOUND);
+        formDef.getMainInstance().setRoot(copiedRoot);
+        return formDef;
+    }
+
+    private void addFormDefToExistingEntry(List<FormDefPoolElement> elements, FormDef formDef) throws AlreadyExistsInPoolException {
+        FormDefPoolElement element = elements.stream().filter(e -> e.formDef == formDef).findFirst().orElse(null);
+        if (element != null) {
+            throw new AlreadyExistsInPoolException();
+        }
+        FormDefPoolElement elementToAdd = new FormDefPoolElement(formDef);
+        elements.add(elementToAdd);
+    }
+
+    private void createNewFormDefPoolEntry(String id, FormDef formDef) {
+        TreeElement templateRoot = formDef.getMainInstance().getRoot().deepCopy(true);
+        List<FormDefPoolElement> elements = new ArrayList<>();
+        FormDefPoolElement elementToAdd = new FormDefPoolElement(formDef);
+        elements.add(elementToAdd);
+        this.pool.put(id, new Pair(templateRoot, elements));
+    }
+}

--- a/src/main/java/org/commcare/formplayer/objects/FormDefPoolElement.java
+++ b/src/main/java/org/commcare/formplayer/objects/FormDefPoolElement.java
@@ -1,0 +1,13 @@
+package org.commcare.formplayer.objects;
+
+import org.javarosa.core.model.FormDef;
+
+public class FormDefPoolElement {
+    public FormDef formDef;
+    public Boolean leased;
+
+    public FormDefPoolElement(FormDef formDef) {
+        this.formDef = formDef;
+        this.leased = false;
+    }
+}

--- a/src/test/java/org/commcare/formplayer/tests/FormDefPoolTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormDefPoolTests.java
@@ -1,0 +1,158 @@
+package org.commcare.formplayer.tests;
+
+import org.apache.commons.io.IOUtils;
+import org.commcare.formplayer.exceptions.AlreadyExistsInPoolException;
+import org.commcare.formplayer.exceptions.FormDefEntryNotFoundException;
+import org.commcare.formplayer.objects.FormDefPool;
+import org.commcare.formplayer.utils.FileUtils;
+import org.commcare.formplayer.utils.TestContext;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xform.parse.XFormParser;
+import org.javarosa.xform.util.XFormUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.io.InputStreamReader;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@WebMvcTest
+@ContextConfiguration(classes = TestContext.class)
+public class FormDefPoolTests extends BaseTestClass {
+
+    private FormDefPool formDefPool;
+    private FormDef formDefToTest;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        this.formDefPool = new FormDefPool();
+        this.formDefToTest = this.loadFormDef();
+    }
+
+    @Test
+    public void testCreateThrowsExceptionIfFormDefAlreadyAdded() throws Exception {
+        this.formDefPool.create("abc123", this.formDefToTest);
+        assertThrows(AlreadyExistsInPoolException.class, () -> this.formDefPool.create("abc123", this.formDefToTest));
+    }
+
+    @Test
+    public void testCreateSuccessfulForDifferentCopies() throws Exception {
+        FormDef formDefToTest2 = loadFormDef();
+        assertNotSame(this.formDefToTest, formDefToTest2);
+        try {
+            this.formDefPool.create("abc123", this.formDefToTest);
+            this.formDefPool.create("abc123", formDefToTest2);
+        } catch (AlreadyExistsInPoolException e) {
+            fail("Unexpected AlreadyExistsInPoolException thrown");
+        }
+    }
+
+    @Test
+    public void testGetReturnsNullIfNoEntryExists() {
+        FormDef actualFormDef = this.formDefPool.getFormDef("abc123");
+        assertNull(actualFormDef);
+    }
+
+    @Test
+    public void testGetSucceedsIfEntryExists() throws Exception {
+        this.formDefPool.create("abc123", this.formDefToTest);
+        FormDef actualFormDef = this.formDefPool.getFormDef("abc123");
+        assertEquals(this.formDefToTest, actualFormDef);
+    }
+
+    @Test
+    public void testGetReturnsNullIfEntryIsUnavailable() throws Exception {
+        this.formDefPool.create("abc123", this.formDefToTest);
+
+        FormDef firstLease = this.formDefPool.getFormDef("abc123");
+        FormDef secondLease = this.formDefPool.getFormDef("abc123");
+
+        assertEquals(this.formDefToTest, firstLease);
+        assertNull(secondLease);
+    }
+
+    @Test
+    public void testReturnIsSuccessfulIfEntryCreatedPreviously() throws Exception {
+        this.formDefPool.create("abc123", this.formDefToTest);
+        FormDef firstLease = this.formDefPool.getFormDef("abc123");
+        try {
+            this.formDefPool.returnFormDef("abc123", firstLease);
+        } catch (FormDefEntryNotFoundException e) {
+            fail("Unexpected exception thrown: " + e);
+        }
+
+        FormDef postReturnFormDef = this.formDefPool.getFormDef("abc123");
+
+        assertEquals(this.formDefToTest, postReturnFormDef);
+    }
+
+    @Test
+    public void testReturnThrowsExceptionIfEntryNotCreatedPreviously() {
+        assertThrows(FormDefEntryNotFoundException.class, () -> {
+            this.formDefPool.returnFormDef("abc123", this.formDefToTest);
+        });
+    }
+
+    @Test
+    public void testReturnsCorrectFormDefForMultipleLikeEntries() throws Exception {
+        // NOTE: this also tests the create method for existing entries
+        this.formDefPool.create("abc123", this.formDefToTest);
+        FormDef formDefToTest2 = this.loadFormDef();
+        this.formDefPool.create("abc123", formDefToTest2);
+
+        FormDef formDef1 = this.formDefPool.getFormDef("abc123");
+        FormDef formDef2 = this.formDefPool.getFormDef("abc123");
+
+        assertEquals(this.formDefToTest, formDef1);
+        assertEquals(formDefToTest2, formDef2);
+    }
+
+    @Test
+    public void testReturnsCorrectFormDefForMultipleUniqueEntries() throws Exception {
+        this.formDefPool.create("abc123", this.formDefToTest);
+        FormDef formDefToTest2 = this.loadFormDef();
+        this.formDefPool.create("def456", formDefToTest2);
+
+        FormDef formDef1 = this.formDefPool.getFormDef("abc123");
+        FormDef formDef2 = this.formDefPool.getFormDef("def456");
+
+        assertEquals(this.formDefToTest, formDef1);
+        assertEquals(formDefToTest2, formDef2);
+    }
+
+    @Test
+    public void testFormDefIsResetAfterUse() throws Exception {
+        this.formDefPool.create("abc123", this.formDefToTest);
+        FormDef formDef = this.formDefPool.getFormDef("abc123");
+        TreeElement cleanRoot = formDef.getMainInstance().getRoot().deepCopy(true);
+        this.modifyFormDef(formDef);
+        TreeElement dirtyRoot = formDef.getMainInstance().getRoot().deepCopy(true);
+        assertNotEquals(cleanRoot, dirtyRoot);
+
+        this.formDefPool.returnFormDef("abc123", formDef);
+        FormDef cleanedFormDef = this.formDefPool.getFormDef("abc123");
+
+        assertEquals(cleanRoot, cleanedFormDef.getMainInstance().getRoot());
+        // ensure it is a copy
+        assertNotSame(cleanRoot, cleanedFormDef.getMainInstance().getRoot());
+    }
+
+    private void modifyFormDef(FormDef formDef) throws Exception {
+        String instanceContent = "<?xml version='1.0' ?><data uiVersion=\"1\" version=\"5\" name=\"Survey\" xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"http://openrosa.org/formdesigner/962C095E-3AB0-4D92-B9BA-08478FF94475\"><favorite_number /><twice_favorite_number /><n0:meta xmlns:n0=\"http://openrosa.org/jr/xforms\"><n0:deviceID>Formplayer</n0:deviceID><n0:timeStart>2022-04-13T07:43:38.119-07</n0:timeStart><n0:timeEnd /><n0:username>test</n0:username><n0:userID>a8f4c2aea6134d01a9ce5856064299b8</n0:userID><n0:instanceID>5c8f65a8-f80b-474a-91a7-684beaf8d83a</n0:instanceID><n1:appVersion xmlns:n1=\"http://commcarehq.org/xforms\">Formplayer Version: 2.53</n1:appVersion><n0:drift /></n0:meta></data>";
+        StringReader stringReader = new StringReader(instanceContent);
+        XFormParser.loadXmlInstance(formDef, stringReader);
+    }
+
+    private FormDef loadFormDef() throws Exception {
+        String formXml = FileUtils.getFile(this.getClass(), "xforms/hidden_value_form.xml");
+        return XFormUtils.getFormRaw(
+                new InputStreamReader(IOUtils.toInputStream(formXml, "UTF-8")));
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/tests/FormDefPoolTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormDefPoolTests.java
@@ -2,7 +2,9 @@ package org.commcare.formplayer.tests;
 
 import org.apache.commons.io.IOUtils;
 import org.commcare.formplayer.exceptions.AlreadyExistsInPoolException;
+import org.commcare.formplayer.exceptions.ExceedsMaxPoolSizeException;
 import org.commcare.formplayer.exceptions.FormDefEntryNotFoundException;
+import org.commcare.formplayer.exceptions.ExceedsMaxPoolSizePerId;
 import org.commcare.formplayer.objects.FormDefPool;
 import org.commcare.formplayer.utils.FileUtils;
 import org.commcare.formplayer.utils.TestContext;
@@ -39,6 +41,24 @@ public class FormDefPoolTests extends BaseTestClass {
     public void testCreateThrowsExceptionIfFormDefAlreadyAdded() throws Exception {
         this.formDefPool.create("abc123", this.formDefToTest);
         assertThrows(AlreadyExistsInPoolException.class, () -> this.formDefPool.create("abc123", this.formDefToTest));
+    }
+
+    @Test
+    public void testCreateThrowsExceptionWhenMaxObjsPerIdIsReached() throws Exception {
+        FormDefPool customFormDelPool = new FormDefPool(1, 10);
+        customFormDelPool.create("abc123", this.formDefToTest);
+        assertThrows(ExceedsMaxPoolSizePerId.class, () -> {
+            customFormDelPool.create("abc123", this.formDefToTest);
+        });
+    }
+
+    @Test
+    public void testCreateThrowsExceptionWhenMaxObjsTotalIsReached() throws Exception {
+        FormDefPool customFormDelPool = new FormDefPool(1, 1);
+        customFormDelPool.create("abc123", this.formDefToTest);
+        assertThrows(ExceedsMaxPoolSizeException.class, () -> {
+            customFormDelPool.create("def456", this.formDefToTest);
+        });
     }
 
     @Test


### PR DESCRIPTION
[SAAS-13404](https://dimagi-dev.atlassian.net/browse/SAAS-13404)

This is the initial implementation for a `FormDef` pool that will help boost performance between requests. We cannot rely on simply caching `FormDef` objects, because they must be copied (serialized/deserialized) which is costly. This allows us to avoid the serialization process when possible. The pool has a couple of tunable constraints, max total size and max size per id, which should allow us to keep this from taking up too much space in memory.

This is obviously incomplete on its own, but I wanted to create this PR in isolation of the future work that will come. To provide context, the idea is to add one more layer above the pool that is responsible for interfacing with both the pool and if necessary, the db to fetch the form definition for the given (app id, form xmlns, form version) combo. Once that layer is complete, other parts of formplayer can interact with that layer to obtain form defs when needed.

I've added unit tests for this, though am still concerned/would like to add more tests around the immutability of the root `TreeElement` as this is essential to this functioning properly. The biggest risk is leaking user data from one form session into another by not properly resetting a `FormDef` object.