### PR TITLE
Cache FormDef by session

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/AbstractBaseController.java
+++ b/src/main/java/org/commcare/formplayer/application/AbstractBaseController.java
@@ -30,6 +30,9 @@ public abstract class AbstractBaseController {
     protected FormSessionService formSessionService;
 
     @Autowired
+    private FormDefinitionService formDefinitionService;
+
+    @Autowired
     protected MenuSessionService menuSessionService;
 
     @Autowired
@@ -102,7 +105,8 @@ public abstract class AbstractBaseController {
                 formSendCalloutHandler,
                 storageFactory,
                 getCommCareSession(serializableFormSession.getMenuSessionId()),
-                runnerService.getCaseSearchHelper());
+                runnerService.getCaseSearchHelper(),
+                formDefinitionService);
     }
 
 }

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -144,7 +144,14 @@ public class NewFormResponseFactory {
     }
 
     public FormSession getFormSession(SerializableFormSession serializableFormSession, CommCareSession commCareSession) throws Exception {
-        return new FormSession(serializableFormSession, restoreFactory, formSendCalloutHandler, storageFactory, commCareSession, caseSearchHelper);
+        return new FormSession(serializableFormSession,
+                restoreFactory,
+                formSendCalloutHandler,
+                storageFactory,
+                commCareSession,
+                caseSearchHelper,
+                formDefinitionService
+        );
     }
 
     private String getFormXml(String formUrl) {

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -17,6 +17,7 @@ import org.commcare.formplayer.objects.FormVolatilityRecord;
 import org.commcare.formplayer.objects.FunctionHandler;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
+import org.commcare.formplayer.services.FormDefinitionService;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.util.Constants;
@@ -97,7 +98,8 @@ public class FormSession {
             FormSendCalloutHandler formSendCalloutHandler,
             FormplayerStorageFactory storageFactory,
             @Nullable CommCareSession commCareSession,
-            RemoteInstanceFetcher instanceFetcher) throws Exception {
+            RemoteInstanceFetcher instanceFetcher,
+            FormDefinitionService formDefinitionService) throws Exception {
 
         this.session = session;
         //We don't want ongoing form sessions to change their db state underneath in the middle,
@@ -107,7 +109,11 @@ public class FormSession {
 
         this.sandbox = restoreFactory.getSandbox();
         if (session.getFormDefinition() != null) {
-            this.formDef = FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());
+            this.formDef = formDefinitionService.getFormDef(session.getFormDefinition().getAppId(),
+                    session.getFormDefinition().getFormXmlns(),
+                    session.getFormDefinition().getFormVersion(),
+                    session.getId(),
+                    session.getFormDefinition().getSerializedFormDef());
         } else {
             // DEPRECATED: this code will be removed once all incomplete sessions that depend on this are purged
             this.formDef = FormDefStringSerializer.deserialize(session.getFormXml());

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -348,6 +348,7 @@ public class BaseTestClass {
                 SerializableFormDefinition serializableFormDef = new SerializableFormDefinition(
                         appId, appVersion, xmlns, serializedFormDef
                 );
+                serializableFormDef.setFormDef(((FormDef)invocation.getArguments()[3]));
                 if (serializableFormDef.getId() == null) {
                     // this is normally taken care of by Hibernate
                     ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId);
@@ -359,6 +360,10 @@ public class BaseTestClass {
         }).when(this.formDefinitionService).getOrCreateFormDefinition(
                 anyString(), anyString(), anyString(), any(FormDef.class)
         );
+
+        when(this.formDefinitionService.getFormDef(
+                anyString(), anyString(), anyString(), anyString(), anyString()
+        )).thenCallRealMethod();
     }
 
     private void mockMenuSessionService() {
@@ -1065,7 +1070,8 @@ public class BaseTestClass {
                 formSendCalloutHandlerMock,
                 storageFactoryMock,
                 getCommCareSession(serializableFormSession.getMenuSessionId()),
-                menuSessionRunnerService.getCaseSearchHelper());
+                menuSessionRunnerService.getCaseSearchHelper(),
+                formDefinitionService);
     }
 
     @Nullable

--- a/src/test/java/org/commcare/formplayer/tests/SavedFormDefTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SavedFormDefTest.java
@@ -63,8 +63,14 @@ public class SavedFormDefTest extends BaseTestClass {
 
         SerializableFormSession session = this.formSessionService.getSessionById(
                 newSessionResponse.getSessionId());
-        FormSession formSession = new FormSession(session, this.restoreFactoryMock, null,
-                this.storageFactoryMock, null, this.remoteInstanceFetcherMock);
+        FormSession formSession = new FormSession(session,
+                this.restoreFactoryMock,
+                null,
+                this.storageFactoryMock,
+                null,
+                this.remoteInstanceFetcherMock,
+                this.formDefinitionService
+        );
         assertEquals(formSession.getInstanceXml(true), session.getInstanceXml());
     }
 
@@ -80,8 +86,13 @@ public class SavedFormDefTest extends BaseTestClass {
         answerQuestionGetResult("0", "9", sessionId);
         SerializableFormSession session = this.formSessionService.getSessionById(
                 newSessionResponse.getSessionId());
-        FormSession formSession = new FormSession(session, this.restoreFactoryMock, null,
-                this.storageFactoryMock, null, this.remoteInstanceFetcherMock);
+        FormSession formSession = new FormSession(session,
+                this.restoreFactoryMock,
+                null,
+                this.storageFactoryMock,
+                null,
+                this.remoteInstanceFetcherMock,
+                this.formDefinitionService);
         SubmitResponseBean submitResponseBean = submitForm(
                 "requests/submit/submit_hidden_value_form.json", sessionId);
         assertEquals("success", submitResponseBean.getStatus());


### PR DESCRIPTION
As mentioned in https://github.com/dimagi/formplayer/pull/1121#issuecomment-1099297838
> It would be good to know specifically which part of the request lifecycle
this pooling is intended to optimize. If, for instance, it's the
deserialization of the object in between requests from the same user /
session it feels like caching the object in memory in between requests (if
available) is a safer play.

this is the implementation for caching FormDefs for specific sessions in between requests. As Cal mentions further in the thread, this would solve the majority of performance issues with regards to FormDef serialization. 

I based this on top of the existing shared form definition work, even though it isn't necessarily directly related. The SerializableFormDefinition does have all of the information needed in one place which made this easier. This does feel a bit clunky so if anyone has cleaner ideas on how to implement this, I'm all ears.

**I didn't add the user id as a cache key because it seemed safe to assume a session would be specific to a user**. If that is not the case definitely flag it.