### PR TITLE
Use shared form definition from postgres

### DIFF
--- a/src/main/java/org/commcare/formplayer/repo/FormDefinitionRepo.java
+++ b/src/main/java/org/commcare/formplayer/repo/FormDefinitionRepo.java
@@ -1,0 +1,16 @@
+package org.commcare.formplayer.repo;
+
+import org.commcare.formplayer.objects.SerializableFormDefinition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Abstracted layer for SerializableFormDefinition database operations
+ */
+public interface FormDefinitionRepo extends JpaRepository<SerializableFormDefinition, Long> {
+    Optional<SerializableFormDefinition> findByAppIdAndFormXmlnsAndFormVersion(
+            String appId,
+            String formXmlns,
+            String formVersion);
+}

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -1,0 +1,57 @@
+package org.commcare.formplayer.services;
+
+import org.commcare.formplayer.objects.SerializableFormDefinition;
+import org.commcare.formplayer.repo.FormDefinitionRepo;
+import org.commcare.formplayer.util.serializer.FormDefStringSerializer;
+import org.javarosa.core.log.WrappedException;
+import org.javarosa.core.model.FormDef;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Service class that abstracts interactions with FormDefinitionRepo
+ */
+@Service
+@CacheConfig(cacheNames = {"form_definition"})
+public class FormDefinitionService {
+
+    @Autowired
+    private FormDefinitionRepo formDefinitionRepo;
+
+    /**
+     * Checks if an entry for this (appId, formXmlns, formVersion) combination already exists, and returns if so
+     * Otherwise creates a new entry which entails serializing the formDef object (costly operation)
+     *
+     * @param appId       id for application built in HQ
+     * @param formXmlns   xmlns identifier for specific form within app
+     * @param formVersion version of form xml
+     * @param formDef     FormDef to serialize and save to SQL if needed
+     * @return already existing or newly created SerializableFormDefinition
+     */
+    @Cacheable(key = "{#appId, #formXmlns, #formVersion}")
+    public SerializableFormDefinition getOrCreateFormDefinition(
+            String appId,
+            String formXmlns,
+            String formVersion,
+            FormDef formDef) {
+        Optional<SerializableFormDefinition> optFormDef = this.formDefinitionRepo
+                .findByAppIdAndFormXmlnsAndFormVersion(appId, formXmlns, formVersion);
+        return optFormDef.orElseGet(() -> {
+            String serializedFormDef;
+            try {
+                serializedFormDef = FormDefStringSerializer.serialize(formDef);
+            } catch (IOException e) {
+                throw new WrappedException("Error serializing form def", e);
+            }
+            SerializableFormDefinition newFormDef = new SerializableFormDefinition(
+                    appId, formXmlns, formVersion, serializedFormDef
+            );
+            return this.formDefinitionRepo.save(newFormDef);
+        });
+    }
+}

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -92,6 +92,9 @@ public class MenuSessionRunnerService {
     protected FormSessionService formSessionService;
 
     @Autowired
+    protected FormDefinitionService formDefinitionService;
+
+    @Autowired
     protected MenuSessionService menuSessionService;
 
     @Autowired
@@ -683,7 +686,7 @@ public class MenuSessionRunnerService {
     private NewFormResponse generateFormEntrySession(MenuSession menuSession) throws Exception {
         menuSessionService.saveSession(menuSession.serialize());
         FormSession formEntrySession = menuSession.getFormEntrySession(formSendCalloutHandler, storageFactory,
-                caseSearchHelper);
+                caseSearchHelper, formDefinitionService);
 
         NewFormResponse response = newFormResponseFactory.getResponse(formEntrySession);
         response.setNotification(establishVolatility(formEntrySession));

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -3,6 +3,7 @@ package org.commcare.formplayer.services;
 import org.apache.commons.io.IOUtils;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.NewSessionRequestBean;
+import org.commcare.formplayer.objects.SerializableFormDefinition;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.session.FormSession;
@@ -39,6 +40,9 @@ public class NewFormResponseFactory {
     private FormSessionService formSessionService;
 
     @Autowired
+    private FormDefinitionService formDefinitionService;
+
+    @Autowired
     private FormSendCalloutHandler formSendCalloutHandler;
 
     @Autowired
@@ -68,8 +72,18 @@ public class NewFormResponseFactory {
                 bean.getRestoreAs(),
                 bean.getRestoreAsCaseId());
 
+        FormDef formDef = parseFormDef(formXml);
+        SerializableFormDefinition serializableFormDefinition = this.formDefinitionService
+                .getOrCreateFormDefinition(
+                        bean.getSessionData().getAppId(),
+                        formDef.getMainInstance().schema,
+                        bean.getSessionData().getAppVersion(),
+                        formDef
+                );
+
         FormSession formSession = new FormSession(
                 sandbox,
+                serializableFormDefinition,
                 parseFormDef(formXml),
                 bean.getUsername(),
                 bean.getDomain(),

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -6,11 +6,13 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.core.interfaces.RemoteInstanceFetcher;
 import org.commcare.formplayer.engine.FormplayerConfigEngine;
+import org.commcare.formplayer.objects.SerializableFormDefinition;
 import org.commcare.formplayer.objects.SerializableMenuSession;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.screens.FormplayerQueryScreen;
 import org.commcare.formplayer.screens.FormplayerSyncScreen;
 import org.commcare.formplayer.services.CaseSearchHelper;
+import org.commcare.formplayer.services.FormDefinitionService;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
 import org.commcare.formplayer.services.InstallService;
 import org.commcare.formplayer.services.RestoreFactory;
@@ -319,16 +321,23 @@ public class MenuSession implements HereFunctionHandlerListener {
     @Trace
     public FormSession getFormEntrySession(FormSendCalloutHandler formSendCalloutHandler,
             FormplayerStorageFactory storageFactory,
-            CaseSearchHelper caseSearchHelper) throws Exception {
+            CaseSearchHelper caseSearchHelper,
+            FormDefinitionService formDefinitionService) throws Exception {
         String formXmlns = sessionWrapper.getForm();
-        FormDef formDef = engine.loadFormByXmlns(formXmlns);
+        FormDef formDef = this.engine.loadFormByXmlns(formXmlns);
+        SerializableFormDefinition serializableFormDefinition = formDefinitionService.getOrCreateFormDefinition(
+                this.getAppId(),
+                formXmlns,
+                this.getAppVersion(),
+                formDef
+        );
         HashMap<String, String> sessionData = getSessionData();
         String postUrl = sessionWrapper.getPlatform().getPropertyManager().getSingularProperty("PostURL");
-        return new FormSession(sandbox, formDef, session.getUsername(), session.getDomain(),
-                sessionData, postUrl, session.getLocale(), session.getId(),
-                null, oneQuestionPerScreen,
-                session.getAsUser(), session.getAppId(), null, formSendCalloutHandler, storageFactory,
-                false, null, new SessionFrame(sessionWrapper.getFrame()), caseSearchHelper);
+        return new FormSession(sandbox, serializableFormDefinition, formDef, session.getUsername(),
+                session.getDomain(), sessionData, postUrl, session.getLocale(), session.getId(), null,
+                oneQuestionPerScreen, session.getAsUser(), session.getAppId(), null,
+                formSendCalloutHandler, storageFactory, false, null,
+                new SessionFrame(sessionWrapper.getFrame()), caseSearchHelper);
     }
 
     public SessionWrapper getSessionWrapper() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,7 +33,7 @@ management.metrics.enable.formplayer.http.client=false
 
 # caching (override type in application.properties to enable)
 spring.cache.type=caffeine
-spring.cache.cache-names=form_session,case_search,menu_session
+spring.cache.cache-names=form_session,case_search,menu_session,form_definition
 spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=300s,expireAfterWrite=300s
 
 # sentry

--- a/src/test/java/org/commcare/formplayer/repo/FormDefinitionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormDefinitionRepoTest.java
@@ -1,0 +1,83 @@
+package org.commcare.formplayer.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.commcare.formplayer.objects.SerializableFormDefinition;
+import org.commcare.formplayer.utils.JpaTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+/**
+ * Tests to ensure the FormDefinitionRepo behaves as expected
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnableJpaAuditing
+public class FormDefinitionRepoTest {
+
+    @Autowired
+    FormDefinitionRepo formDefinitionRepo;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    public void setUp() {
+        this.jdbcTemplate.execute("DELETE from formplayer_sessions");
+        this.jdbcTemplate.execute("DELETE from form_definition");
+    }
+
+    @Test
+    public void testSaveAndLoad() {
+        SerializableFormDefinition formDef = new SerializableFormDefinition(
+                "appId",
+                "formXmlns",
+                "formVersion",
+                "formDef"
+        );
+        formDefinitionRepo.saveAndFlush(formDef);
+        entityManager.clear(); // clear the EM cache to force a re-fetch from DB
+        SerializableFormDefinition loaded = JpaTestUtils.unwrapProxy(
+                formDefinitionRepo.getById(formDef.getId())
+        );
+        assertThat(loaded).usingRecursiveComparison().ignoringFields("dateCreated", "id").isEqualTo(formDef);
+        Instant dateCreated = loaded.getDateCreated();
+        assertThat(dateCreated).isNotNull();
+
+        formDefinitionRepo.saveAndFlush(loaded);
+        assertThat(loaded.getDateCreated()).isEqualTo(dateCreated);
+    }
+
+    @Test
+    public void testFindByAppIdAndFormXmlnsAndFormVersion() {
+        SerializableFormDefinition formDef = new SerializableFormDefinition(
+                "appId",
+                "formXmlns",
+                "formVersion",
+                "formDef"
+        );
+        formDefinitionRepo.save(formDef);
+        Optional<SerializableFormDefinition> optFormDef = formDefinitionRepo.findByAppIdAndFormXmlnsAndFormVersion(
+                "appId", "formXmlns", "formVersion"
+        );
+        assertThat(optFormDef.isPresent()).isTrue();
+        SerializableFormDefinition fetchedFormDef = optFormDef.get();
+        assertThat(fetchedFormDef.getAppId()).isEqualTo("appId");
+        assertThat(fetchedFormDef.getFormXmlns()).isEqualTo("formXmlns");
+        assertThat(fetchedFormDef.getFormVersion()).isEqualTo("formVersion");
+        assertThat(fetchedFormDef.getDateCreated()).isEqualTo(formDef.getDateCreated());
+    }
+}

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -43,11 +43,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Tests for FormDefinitionService
+ */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 public class FormDefinitionServiceTest {
 
-    final private Map<List<String>, SerializableFormDefinition> formDefinitionMap = new HashMap<>();
+    private final Map<List<String>, SerializableFormDefinition> formDefinitionMap = new HashMap<>();
     @Autowired
     FormDefinitionService formDefinitionService;
     @Autowired
@@ -173,8 +176,10 @@ public class FormDefinitionServiceTest {
                 new InputStreamReader(IOUtils.toInputStream(formXml, "UTF-8")));
     }
 
-    // only include the service under test and it's dependencies
-    // This should not be necessary but we're using older versions of junit and spring
+    /**
+     * Only include the service under test and its dependencies
+     * This should not be necessary, but we're using older versions of junit and spring
+     */
     @ComponentScan(
             basePackageClasses = {FormDefinitionService.class},
             useDefaultFilters = false,

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -1,0 +1,199 @@
+package org.commcare.formplayer.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import static java.util.Optional.ofNullable;
+
+import org.apache.commons.io.IOUtils;
+import org.commcare.formplayer.objects.SerializableFormDefinition;
+import org.commcare.formplayer.repo.FormDefinitionRepo;
+import org.commcare.formplayer.utils.FileUtils;
+import org.javarosa.core.api.ClassNameHasher;
+import org.javarosa.core.model.FormDef;
+import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.xform.util.XFormUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+public class FormDefinitionServiceTest {
+
+    final private Map<List<String>, SerializableFormDefinition> formDefinitionMap = new HashMap<>();
+    @Autowired
+    FormDefinitionService formDefinitionService;
+    @Autowired
+    CacheManager cacheManager;
+    @Autowired
+    private FormDefinitionRepo formDefinitionRepo;
+    private String appId;
+    private String formXmlns;
+    private String formVersion;
+    private FormDef formDef;
+
+    @BeforeAll
+    public static void setUpAll() {
+        PrototypeFactory.setStaticHasher(new ClassNameHasher());
+    }
+
+    private void mockFormDefinitionRepo() {
+        // the repo always returns the saved object so simulate that in the mock
+        when(this.formDefinitionRepo.save(any())).thenAnswer(new Answer<SerializableFormDefinition>() {
+            @Override
+            public SerializableFormDefinition answer(InvocationOnMock invocation) throws Throwable {
+                SerializableFormDefinition formDef = (SerializableFormDefinition)invocation.getArguments()[0];
+                formDefinitionMap.put(
+                        Arrays.asList(formDef.getAppId(), formDef.getFormXmlns(), formDef.getFormVersion()),
+                        formDef
+                );
+                return formDef;
+            }
+        });
+
+        // need to mock this to test get is successful
+        when(this.formDefinitionRepo.findByAppIdAndFormXmlnsAndFormVersion(any(), any(), any())).thenAnswer(
+                new Answer<Optional<SerializableFormDefinition>>() {
+                    @Override
+                    public Optional<SerializableFormDefinition> answer(InvocationOnMock invocation)
+                            throws Throwable {
+                        String appId = (String)invocation.getArguments()[0];
+                        String formXmlns = (String)invocation.getArguments()[1];
+                        String formVersion = (String)invocation.getArguments()[2];
+                        List<String> keyList = Arrays.asList(appId, formXmlns, formVersion);
+                        if (formDefinitionMap.containsKey(keyList)) {
+                            return Optional.of(formDefinitionMap.get(keyList));
+                        }
+                        return Optional.empty();
+                    }
+                });
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        this.mockFormDefinitionRepo();
+
+        this.appId = "123456789";
+        this.formXmlns = "abc-123";
+        this.formVersion = "1";
+        this.formDef = loadFormDef();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        this.cacheManager.getCache("form_definition").clear();
+    }
+
+    @Test
+    public void testGetOrCreateFormDefinitionCreatesSuccessfully() {
+        SerializableFormDefinition createdFormDefinition = this.formDefinitionService.getOrCreateFormDefinition(
+                this.appId, this.formXmlns, this.formVersion, this.formDef
+        );
+        assertNotNull(createdFormDefinition);
+    }
+
+    @Test
+    public void testGetOrCreateFormDefinitionGetsSuccessfully() {
+        SerializableFormDefinition createdFormDef = this.formDefinitionService.getOrCreateFormDefinition(
+                this.appId, this.formXmlns, this.formVersion, this.formDef
+        );
+
+        this.cacheManager.getCache("form_definition").clear();
+
+        SerializableFormDefinition fetchedFormDef = this.formDefinitionService.getOrCreateFormDefinition(
+                this.appId, this.formXmlns, this.formVersion, this.formDef
+        );
+        assertEquals(createdFormDef, fetchedFormDef);
+    }
+
+    @Test
+    public void testGetOrCreateFormDefinitionCachesSuccessfully() {
+        assertEquals(Optional.empty(), getCachedFormDefinition(this.appId, this.formXmlns, this.formVersion));
+
+        SerializableFormDefinition formDefinition = this.formDefinitionService.getOrCreateFormDefinition(
+                this.appId, this.formXmlns, this.formVersion, this.formDef
+        );
+
+        assertEquals(Optional.of(formDefinition),
+                getCachedFormDefinition(this.appId, this.formXmlns, this.formVersion));
+    }
+
+    @Test
+    public void testGetOrCreateFormDefinitionNewVersionNotEqual() {
+        SerializableFormDefinition formDefinitionV1 = this.formDefinitionService.getOrCreateFormDefinition(
+                this.appId, this.formXmlns, this.formVersion, this.formDef
+        );
+
+        String updatedFormVersion = "2";
+        SerializableFormDefinition formDefinitionV2 = this.formDefinitionService.getOrCreateFormDefinition(
+                this.appId, this.formXmlns, updatedFormVersion, this.formDef
+        );
+
+        assertNotEquals(formDefinitionV1, formDefinitionV2);
+    }
+
+    private Optional<SerializableFormDefinition> getCachedFormDefinition(
+            String appId, String formXmlns, String formVersion) {
+        List<String> idArray = Arrays.asList(appId, formXmlns, formVersion);
+        return ofNullable(this.cacheManager.getCache("form_definition")).map(
+                cache -> cache.get(idArray, SerializableFormDefinition.class)
+        );
+    }
+
+    private FormDef loadFormDef() throws Exception {
+        String formXml = FileUtils.getFile(this.getClass(), "xforms/hidden_value_form.xml");
+        return XFormUtils.getFormRaw(
+                new InputStreamReader(IOUtils.toInputStream(formXml, "UTF-8")));
+    }
+
+    // only include the service under test and it's dependencies
+    // This should not be necessary but we're using older versions of junit and spring
+    @ComponentScan(
+            basePackageClasses = {FormDefinitionService.class},
+            useDefaultFilters = false,
+            includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                    FormDefinitionService.class})
+    )
+    @EnableCaching
+    @Configuration
+    public static class FormDefinitionServiceTestConfig {
+
+        @MockBean
+        public FormDefinitionRepo formDefinitionRepo;
+
+        @MockBean
+        public JdbcTemplate jdbcTemplate;
+
+        @Bean
+        public CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("form_definition");
+        }
+    }
+}

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -72,6 +72,7 @@ import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
 import org.commcare.formplayer.util.PrototypeUtils;
 import org.commcare.formplayer.util.SessionUtils;
+import org.commcare.formplayer.util.serializer.FormDefStringSerializer;
 import org.commcare.formplayer.util.serializer.SessionSerializer;
 import org.commcare.formplayer.utils.CheckedSupplier;
 import org.commcare.formplayer.utils.FileUtils;
@@ -79,6 +80,7 @@ import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.web.client.WebClient;
 import org.commcare.modern.util.Pair;
 import org.commcare.session.CommCareSession;
+import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.TimezoneProvider;
@@ -223,10 +225,11 @@ public class BaseTestClass {
 
     protected ObjectMapper mapper;
 
-    final Map<String, SerializableFormSession> sessionMap =
-            new HashMap<String, SerializableFormSession>();
-    final Map<String, SerializableMenuSession> menuSessionMap =
-            new HashMap<String, SerializableMenuSession>();
+    final Map<String, SerializableFormSession> sessionMap = new HashMap<>();
+    final Map<Long, SerializableFormDefinition> formDefinitionMap = new HashMap<>();
+    final Map<String, SerializableMenuSession> menuSessionMap = new HashMap<>();
+
+    protected Long currentFormDefinitionId = 1L;
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -268,6 +271,7 @@ public class BaseTestClass {
         DateUtils.setTimezoneProvider(tzProvider);
 
         mockFormSessionService();
+        mockFormDefinitionService();
         mockMenuSessionService();
     }
 
@@ -312,6 +316,48 @@ public class BaseTestClass {
                 return null;
             }
         }).when(formSessionService).deleteSessionById(anyString());
+    }
+
+    /*
+     * Setup mocking for the FormDefinitionService that allows saving and retrieving form definitions.
+     * The 'persisted' definitions are cleared at the start of each test.
+     */
+    private void mockFormDefinitionService() {
+        formDefinitionMap.clear();
+        currentFormDefinitionId = 1L;
+        doAnswer(new Answer<SerializableFormDefinition>() {
+            @Override
+            public SerializableFormDefinition answer(InvocationOnMock invocation) throws Throwable {
+                String appId = ((String)invocation.getArguments()[0]);
+                String appVersion = ((String)invocation.getArguments()[1]);
+                String xmlns = ((String)invocation.getArguments()[2]);
+                for (SerializableFormDefinition tmp : formDefinitionMap.values()) {
+                    if (tmp.getAppId().equals(appId) && tmp.getFormXmlns().equals(xmlns)
+                            && tmp.getFormVersion().equals(appVersion)) {
+                        return tmp;
+                    }
+                }
+                // else create a new one
+                String serializedFormDef;
+                try {
+                    serializedFormDef = FormDefStringSerializer.serialize(((FormDef)invocation.getArguments()[3]));
+                } catch (IOException ex) {
+                    serializedFormDef = "could not serialize provided form def";
+                }
+                SerializableFormDefinition serializableFormDef = new SerializableFormDefinition(
+                        appId, appVersion, xmlns, serializedFormDef
+                );
+                if (serializableFormDef.getId() == null) {
+                    // this is normally taken care of by Hibernate
+                    ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId);
+                    currentFormDefinitionId++;
+                }
+                formDefinitionMap.put(serializableFormDef.getId(), serializableFormDef);
+                return serializableFormDef;
+            }
+        }).when(this.formDefinitionService).getOrCreateFormDefinition(
+                anyString(), anyString(), anyString(), any(FormDef.class)
+        );
     }
 
     private void mockMenuSessionService() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -48,11 +48,13 @@ import org.commcare.formplayer.exceptions.FormNotFoundException;
 import org.commcare.formplayer.exceptions.MenuNotFoundException;
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
 import org.commcare.formplayer.objects.QueryData;
+import org.commcare.formplayer.objects.SerializableFormDefinition;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.objects.SerializableMenuSession;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.services.CategoryTimingHelper;
+import org.commcare.formplayer.services.FormDefinitionService;
 import org.commcare.formplayer.services.FormSessionService;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
 import org.commcare.formplayer.services.InstallService;
@@ -143,6 +145,9 @@ public class BaseTestClass {
 
     @Autowired
     protected FormSessionService formSessionService;
+
+    @Autowired
+    protected FormDefinitionService formDefinitionService;
 
     @Autowired
     private MenuSessionService menuSessionService;

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
+import org.commcare.formplayer.repo.FormDefinitionRepo;
 import org.commcare.formplayer.repo.FormSessionRepo;
 import org.commcare.formplayer.repo.MenuSessionRepo;
 import org.commcare.formplayer.services.HqUserDetailsService;
@@ -38,6 +39,10 @@ public class HqUserDetailsServiceTests {
     // mock this so we don't need to configure a DB
     @MockBean
     public FormSessionRepo formSessionRepo;
+
+    // mock this so we don't need to configure a DB
+    @MockBean
+    public FormDefinitionRepo formDefinitionRepo;
 
     // mock this so we don't need to configure a DB
     @MockBean

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -8,6 +8,7 @@ import org.commcare.formplayer.mocks.TestInstallService;
 import org.commcare.formplayer.objects.FormVolatilityRecord;
 import org.commcare.formplayer.services.CaseSearchHelper;
 import org.commcare.formplayer.services.CategoryTimingHelper;
+import org.commcare.formplayer.services.FormDefinitionService;
 import org.commcare.formplayer.services.FormSessionService;
 import org.commcare.formplayer.services.FormplayerFormSendCalloutHandler;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
@@ -72,6 +73,9 @@ public class TestContext {
 
     @MockBean
     public FormSessionService formSessionService;
+
+    @MockBean
+    public FormDefinitionService formDefinitionService;
 
     @MockBean
     public MenuSessionService menuSessionService;


### PR DESCRIPTION
[SAAS-13377](https://dimagi-dev.atlassian.net/browse/SAAS-13377)

### Context
This is a re-do of https://github.com/dimagi/formplayer/pull/1075 since the commit history got pretty messy. I know this causes an inconvenience to reviewers, but I think the clean commit history is better in the long run. The link to the closed PR will still be available here if more context if needed, but I'll try to summarize everything below. The only difference between this PR and the previous is that this includes the FormDefinitionServiceTest class. Everything else remains the same. I've tested this locally, and plan to run another pass of QA on this to ensure nothing went wrong in creating this new branch.

### Summary
This PR makes use of the newly added SerializableFormDefinition to store unique form definitions in postgres. A form definition is considered unique based on the app id, form xmlns, and form version. So for a new value in any of those three variables, a new SerializableFormDefinition is created.

Notably, the current implementation in this PR uses the _app_ version in place of the _form_ version due to an existing bug that is being tracked in [SAAS-13364](https://dimagi-dev.atlassian.net/browse/SAAS-13364) where the form version is not set on the FormInstance object. This only results in creating more SerializableFormDefinitions than potentially necessary, as the app version is updated for any change to any form or app setting, whereas the form version is only set to the latest app version when a change to that specific form is made.

### Rollback Plan
This PR is **safe to rollback** as it continues to write to both the SerializableFormSession and SerializableFormDefinition, and falls back on reading from the SerializableFormSession if it cannot find a matching SerializableFormDefinition, which means it will not break existing incomplete sessions.

### QA
https://dimagi-dev.atlassian.net/browse/QA-3798

### Tests
I've added tests for the FormDefinitionRepo and FormDefinitionService.