### PR TITLE
Cache deserialized FormDef by session id

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/AbstractBaseController.java
+++ b/src/main/java/org/commcare/formplayer/application/AbstractBaseController.java
@@ -30,6 +30,9 @@ public abstract class AbstractBaseController {
     protected FormSessionService formSessionService;
 
     @Autowired
+    private FormDefinitionService formDefinitionService;
+
+    @Autowired
     protected MenuSessionService menuSessionService;
 
     @Autowired
@@ -102,7 +105,8 @@ public abstract class AbstractBaseController {
                 formSendCalloutHandler,
                 storageFactory,
                 getCommCareSession(serializableFormSession.getMenuSessionId()),
-                runnerService.getCaseSearchHelper());
+                runnerService.getCaseSearchHelper(),
+                formDefinitionService);
     }
 
 }

--- a/src/main/java/org/commcare/formplayer/aspects/ConfigureStorageFromSessionAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/ConfigureStorageFromSessionAspect.java
@@ -28,6 +28,6 @@ public class ConfigureStorageFromSessionAspect {
         }
         final SessionRequestBean requestBean = (SessionRequestBean) args[0];
         storageFactory.configure(requestBean.getSessionId());
-        storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
+        storageFactory.registerFormDefStorage();
     }
 }

--- a/src/main/java/org/commcare/formplayer/aspects/ConfigureStorageFromSessionAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/ConfigureStorageFromSessionAspect.java
@@ -4,6 +4,7 @@ import org.commcare.formplayer.beans.SessionRequestBean;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.javarosa.core.model.FormDef;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
@@ -27,5 +28,6 @@ public class ConfigureStorageFromSessionAspect {
         }
         final SessionRequestBean requestBean = (SessionRequestBean) args[0];
         storageFactory.configure(requestBean.getSessionId());
+        storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
     }
 }

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormDefinition.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormDefinition.java
@@ -43,6 +43,10 @@ public class SerializableFormDefinition {
     @Column(name = "formdef")
     private String serializedFormDef;
 
+    public void setSerializedFormDef(String serializedFormDef) {
+        this.serializedFormDef = serializedFormDef;
+    }
+
     protected SerializableFormDefinition() {}
 
     public SerializableFormDefinition(String appId, String formXmlns, String formVersion, String formDef) {

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -99,7 +99,8 @@ public class FormDefinitionService {
             formDef = FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());
         } catch (Exception e) {
             String xmlns = session.getFormDefinition().getFormXmlns();
-            formDef = this.getFormDefStorage().getRecordForValue(FormDef.STORAGE_KEY, xmlns);
+            // TODO: getStorageManager() returns different instance that does not have FORMDEF registered
+            formDef = this.getFormDefStorage().getRecordForValue("XMLNS", xmlns);
         }
         return formDef;
     }

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -66,8 +66,18 @@ public class FormDefinitionService {
      * @param session session that contains session id and serialized formDef
      * @return deserialized FormDef object
      */
-    @Cacheable(key = "#session.id")
     public FormDef getFormDef(SerializableFormSession session) {
+        FormDef formDef = this.internalGetFormDef(session);
+        // ensure previous tree references are cleared (only necessary when retrieving from cache)
+        formDef.getMainInstance().cleanCache();
+        return formDef;
+    }
+
+    /**
+     * Always use public getFormDef to ensure internal FormDef cached references are cleared
+     */
+    @Cacheable(key = "#session.id")
+    private FormDef internalGetFormDef(SerializableFormSession session) {
         FormDef formDef;
         try {
             formDef = FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -79,7 +79,7 @@ public class FormDefinitionService {
             throw new WrappedException("Error serializing form def", e);
         }
         formDefinition.setSerializedFormDef(serializedFormDef);
-        return this.formDefinitionRepo.save(formDefinition);
+        return formDefinitionRepo.save(formDefinition);
     }
 
     /**
@@ -160,7 +160,7 @@ public class FormDefinitionService {
     }
 
     private IStorageUtilityIndexed<FormDef> getFormDefStorage() {
-        return this.storageFactory.getStorageManager().getStorage(FormDef.STORAGE_KEY);
+        return storageFactory.getStorageManager().getStorage(FormDef.STORAGE_KEY);
     }
 
 }

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -3,11 +3,13 @@ package org.commcare.formplayer.services;
 import org.commcare.formplayer.objects.SerializableFormDefinition;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.repo.FormDefinitionRepo;
+import org.commcare.formplayer.session.FormSession;
 import org.commcare.formplayer.util.serializer.FormDefStringSerializer;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.core.model.FormDef;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -73,5 +75,16 @@ public class FormDefinitionService {
             formDef = null;
         }
         return formDef;
+    }
+
+    /**
+     * Cache the form def for future requests in this session
+     *
+     * @param session grab the id to cache on and the deserialized form def from the session
+     * @return deserialized FormDef object
+     */
+    @CachePut(key = "#session.getSessionId()")
+    public FormDef cacheFormDef(FormSession session) {
+        return session.getFormDef();
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -89,7 +89,6 @@ public class FormDefinitionService {
      * @return True if the value was written to storage or False if it already exists in storage.
      */
     public boolean writeToLocalStorage(FormDef formDef) {
-        this.storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         String xmlns = formDef.getMainInstance().schema;
         if (getFormDefFromStorage(xmlns).isPresent()) {
             return false;
@@ -149,7 +148,6 @@ public class FormDefinitionService {
     }
 
     private Optional<FormDef> getFormDefFromStorage(String xmlns) {
-        this.storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         try {
             return Optional.of(getFormDefStorage().getRecordForValue("XMLNS", xmlns));
         } catch (NoSuchElementException e) {

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.services;
 
 import org.commcare.formplayer.objects.SerializableFormDefinition;
+import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.repo.FormDefinitionRepo;
 import org.commcare.formplayer.util.serializer.FormDefStringSerializer;
 import org.javarosa.core.log.WrappedException;
@@ -60,15 +61,14 @@ public class FormDefinitionService {
      * Deserializing a serialized FormDef object is costly, and this avoids doing so in between requests
      * within the same session
      *
-     * @param sessionId form session id
-     * @param serializedFormDef serialized FormDef object
+     * @param session session that contains session id and serialized formDef
      * @return deserialized FormDef object
      */
-    @Cacheable(key = "#sessionId")
-    public FormDef getFormDef(String sessionId, String serializedFormDef) {
+    @Cacheable(key = "#session.id")
+    public FormDef getFormDef(SerializableFormSession session) {
         FormDef formDef;
         try {
-            formDef = FormDefStringSerializer.deserialize(serializedFormDef);
+            formDef = FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());
         } catch (Exception e) {
             formDef = null;
         }

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -66,8 +66,10 @@ public class FormDefinitionService {
     /**
      * Ensure raw xml is accessible locally in case serialization changes which would break the ability to
      * deserialize the serialized form def in postgres
+     *
+     * @return True if the value was written to storage or False if it already exists in storage.
      */
-    public void writeToLocalStorage(FormDef formDef) {
+    public boolean writeToLocalStorage(FormDef formDef) {
         IStorageUtilityIndexed<FormDef> formStorage = this.getFormDefStorage();
         String xmlns = formDef.getMainInstance().schema;
         FormDef existing;
@@ -78,7 +80,9 @@ public class FormDefinitionService {
         }
         if (existing == null) {
             formStorage.write(formDef);
+            return true;
         }
+        return false;
     }
 
     /**

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -54,4 +54,24 @@ public class FormDefinitionService {
             return this.formDefinitionRepo.save(newFormDef);
         });
     }
+
+    /**
+     * This method uses the sessionId to cache deserialized FormDefs
+     * Deserializing a serialized FormDef object is costly, and this avoids doing so in between requests
+     * within the same session
+     *
+     * @param sessionId form session id
+     * @param serializedFormDef serialized FormDef object
+     * @return deserialized FormDef object
+     */
+    @Cacheable(key = "#sessionId")
+    public FormDef getFormDef(String sessionId, String serializedFormDef) {
+        FormDef formDef;
+        try {
+            formDef = FormDefStringSerializer.deserialize(serializedFormDef);
+        } catch (Exception e) {
+            formDef = null;
+        }
+        return formDef;
+    }
 }

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -75,6 +75,7 @@ public class FormDefinitionService {
      * @return True if the value was written to storage or False if it already exists in storage.
      */
     public boolean writeToLocalStorage(FormDef formDef) {
+        this.storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         String xmlns = formDef.getMainInstance().schema;
         if (getFormDefFromStorage(xmlns).isPresent()) {
             return false;
@@ -109,6 +110,7 @@ public class FormDefinitionService {
     }
 
     private FormDef getFormDefFromSession(SerializableFormSession session) {
+        this.storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         try {
             return FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());
         } catch (Exception e) {

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -15,6 +15,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 /**
@@ -69,7 +70,13 @@ public class FormDefinitionService {
     public void writeToLocalStorage(FormDef formDef) {
         IStorageUtilityIndexed<FormDef> formStorage = this.getFormDefStorage();
         String xmlns = formDef.getMainInstance().schema;
-        if (formStorage.getRecordForValue("XMLNS", xmlns) == null) {
+        FormDef existing;
+        try {
+            existing = formStorage.getRecordForValue("XMLNS", xmlns);
+        } catch (NoSuchElementException e) {
+            existing = null;
+        }
+        if (existing == null) {
             formStorage.write(formDef);
         }
     }

--- a/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
+++ b/src/main/java/org/commcare/formplayer/services/FormDefinitionService.java
@@ -110,7 +110,6 @@ public class FormDefinitionService {
     }
 
     private FormDef getFormDefFromSession(SerializableFormSession session) {
-        this.storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         try {
             return FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());
         } catch (Exception e) {
@@ -133,7 +132,7 @@ public class FormDefinitionService {
     }
 
     private Optional<FormDef> getFormDefFromStorage(String xmlns) {
-        // TODO: getStorageManager() returns different instance that does not have FORMDEF registered
+        this.storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
         try {
             return Optional.of(getFormDefStorage().getRecordForValue("XMLNS", xmlns));
         } catch (NoSuchElementException e) {

--- a/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
@@ -4,6 +4,7 @@ import datadog.trace.api.Trace;
 import org.commcare.formplayer.beans.InstallRequestBean;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.modern.database.TableBuilder;
+import org.javarosa.core.model.FormDef;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.properties.Property;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
@@ -102,6 +103,15 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory {
         if(sqLiteDB != null) {
             sqLiteDB.closeConnection();
         }
+    }
+
+    /**
+     * Call after configuring factory if form def storage needs to be accessible
+     * Menu navigation requests setup form def storage as part of MenuSession initialization
+     * Form controller requests do not setup form def storage as part of FormSession initialization
+     */
+    public void registerFormDefStorage() {
+        getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
     }
 
 

--- a/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
@@ -106,9 +106,9 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory {
     }
 
     /**
-     * Call after configuring factory if form def storage needs to be accessible
-     * Menu navigation requests setup form def storage as part of MenuSession initialization
-     * Form controller requests do not setup form def storage as part of FormSession initialization
+     * Call after configuring factory if form def storage needs to be accessible.
+     * Menu navigation requests setup form def storage as part of MenuSession initialization.
+     * Form controller requests do not setup form def storage as part of FormSession initialization.
      */
     public void registerFormDefStorage() {
         getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);

--- a/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerStorageFactory.java
@@ -3,6 +3,7 @@ package org.commcare.formplayer.services;
 import datadog.trace.api.Trace;
 import org.commcare.formplayer.beans.InstallRequestBean;
 import org.commcare.formplayer.objects.SerializableFormSession;
+import org.commcare.modern.database.TableBuilder;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.properties.Property;
 import org.javarosa.core.services.storage.IStorageIndexedFactory;
@@ -85,6 +86,7 @@ public class FormplayerStorageFactory implements IStorageIndexedFactory {
             throw new RuntimeException(String.format("Cannot configure FormplayerStorageFactory with null arguments. " +
                     "username = %s, domain = %s, appId = %s", username, domain, appId));
         }
+        username = TableBuilder.scrubName(username);
         this.username = username;
         this.asUsername = asUsername;
         this.domain = domain;

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -73,8 +73,7 @@ public class NewFormResponseFactory {
                 bean.getRestoreAsCaseId());
 
         FormDef formDef = parseFormDef(formXml);
-        // TODO: setup local form storage
-        this.formDefinitionService.writeToLocalStorage(formDef);
+
         SerializableFormDefinition serializableFormDefinition = this.formDefinitionService
                 .getOrCreateFormDefinition(
                         bean.getSessionData().getAppId(),
@@ -105,6 +104,10 @@ public class NewFormResponseFactory {
                 null,
                 caseSearchHelper
         );
+
+        // can only setup local storage once a form session has been created
+        this.storageFactory.configure(formSession.getSerializableSession());
+        this.formDefinitionService.writeToLocalStorage(formDef);
 
         NewFormResponse response = getResponse(formSession);
         if (bean.getNavMode() != null && bean.getNavMode().equals(Constants.NAV_MODE_PROMPT)) {

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -146,7 +146,14 @@ public class NewFormResponseFactory {
     }
 
     public FormSession getFormSession(SerializableFormSession serializableFormSession, CommCareSession commCareSession) throws Exception {
-        return new FormSession(serializableFormSession, restoreFactory, formSendCalloutHandler, storageFactory, commCareSession, caseSearchHelper);
+        return new FormSession(serializableFormSession,
+                restoreFactory,
+                formSendCalloutHandler,
+                storageFactory,
+                commCareSession,
+                caseSearchHelper,
+                formDefinitionService
+        );
     }
 
     private String getFormXml(String formUrl) {

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -15,8 +15,6 @@ import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.xform.util.XFormUtils;
 import org.javarosa.core.services.locale.Localization;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -52,9 +50,6 @@ public class NewFormResponseFactory {
 
     @Autowired
     private FormplayerStorageFactory storageFactory;
-
-    @Autowired
-    private CacheManager cacheManager;
 
     public NewFormResponse getResponse(NewSessionRequestBean bean, String postUrl) throws Exception {
 
@@ -123,9 +118,8 @@ public class NewFormResponseFactory {
 
         SerializableFormSession serializedSession = formEntrySession.serialize();
         formSessionService.saveSession(serializedSession);
-        // prime the form def cache for this session
-        Cache cache = this.cacheManager.getCache("form_definition");
-        cache.put(formEntrySession.getSessionId(), formEntrySession.getFormDef());
+        // cannot cache until session is saved
+        formDefinitionService.cacheFormDef(formEntrySession);
         NewFormResponse response = new NewFormResponse(
                 formTreeJson, formEntrySession.getLanguages(), serializedSession.getTitle(),
                 serializedSession.getId(), serializedSession.getVersion(),

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -73,6 +73,7 @@ public class NewFormResponseFactory {
                 bean.getRestoreAsCaseId());
 
         FormDef formDef = parseFormDef(formXml);
+        this.formDefinitionService.writeToLocalStorage(formDef);
         SerializableFormDefinition serializableFormDefinition = this.formDefinitionService
                 .getOrCreateFormDefinition(
                         bean.getSessionData().getAppId(),

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -71,7 +71,7 @@ public class NewFormResponseFactory {
                 bean.getSessionData().getAppId(),
                 bean.getRestoreAs(),
                 bean.getRestoreAsCaseId());
-        storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
+        storageFactory.registerFormDefStorage();
 
         FormDef formDef = parseFormDef(formXml);
         formDefinitionService.writeToLocalStorage(formDef);

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -84,7 +84,7 @@ public class NewFormResponseFactory {
         FormSession formSession = new FormSession(
                 sandbox,
                 serializableFormDefinition,
-                parseFormDef(formXml),
+                formDef,
                 bean.getUsername(),
                 bean.getDomain(),
                 bean.getSessionData().getData(),

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -73,6 +73,7 @@ public class NewFormResponseFactory {
                 bean.getRestoreAsCaseId());
 
         FormDef formDef = parseFormDef(formXml);
+        // TODO: setup local form storage
         this.formDefinitionService.writeToLocalStorage(formDef);
         SerializableFormDefinition serializableFormDefinition = this.formDefinitionService
                 .getOrCreateFormDefinition(

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -71,10 +71,11 @@ public class NewFormResponseFactory {
                 bean.getSessionData().getAppId(),
                 bean.getRestoreAs(),
                 bean.getRestoreAsCaseId());
+        storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
 
         FormDef formDef = parseFormDef(formXml);
-
-        SerializableFormDefinition serializableFormDefinition = this.formDefinitionService
+        formDefinitionService.writeToLocalStorage(formDef);
+        SerializableFormDefinition serializableFormDefinition = formDefinitionService
                 .getOrCreateFormDefinition(
                         bean.getSessionData().getAppId(),
                         formDef.getMainInstance().schema,
@@ -104,10 +105,6 @@ public class NewFormResponseFactory {
                 null,
                 caseSearchHelper
         );
-
-        // can only setup local storage once a form session has been created
-        this.storageFactory.configure(formSession.getSerializableSession());
-        this.formDefinitionService.writeToLocalStorage(formDef);
 
         NewFormResponse response = getResponse(formSession);
         if (bean.getNavMode() != null && bean.getNavMode().equals(Constants.NAV_MODE_PROMPT)) {

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -15,6 +15,8 @@ import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.xform.util.XFormUtils;
 import org.javarosa.core.services.locale.Localization;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -50,6 +52,9 @@ public class NewFormResponseFactory {
 
     @Autowired
     private FormplayerStorageFactory storageFactory;
+
+    @Autowired
+    private CacheManager cacheManager;
 
     public NewFormResponse getResponse(NewSessionRequestBean bean, String postUrl) throws Exception {
 
@@ -118,6 +123,9 @@ public class NewFormResponseFactory {
 
         SerializableFormSession serializedSession = formEntrySession.serialize();
         formSessionService.saveSession(serializedSession);
+        // prime the form def cache for this session
+        Cache cache = this.cacheManager.getCache("form_definition");
+        cache.put(formEntrySession.getSessionId(), formEntrySession.getFormDef());
         NewFormResponse response = new NewFormResponse(
                 formTreeJson, formEntrySession.getLanguages(), serializedSession.getTitle(),
                 serializedSession.getId(), serializedSession.getVersion(),

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -109,10 +109,8 @@ public class FormSession {
 
         this.sandbox = restoreFactory.getSandbox();
 
-        if (session.getFormDefinition() != null) {
-            this.formDef = formDefinitionService.getFormDef(
-                    session.getId(),
-                    session.getFormDefinition().getSerializedFormDef());
+        if (this.session.getFormDefinition() != null) {
+            this.formDef = formDefinitionService.getFormDef(this.session);
         } else {
             // DEPRECATED: leave to allow rollback if needed
             // Will remove once https://github.com/dimagi/formplayer/pull/1075 is safe

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -647,4 +647,8 @@ public class FormSession {
     public SerializableFormSession getSerializableSession() {
         return session;
     }
+
+    public FormDef getFormDef() {
+        return formDef;
+    }
 }

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -17,6 +17,7 @@ import org.commcare.formplayer.objects.FunctionHandler;
 import org.commcare.formplayer.objects.SerializableFormDefinition;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
+import org.commcare.formplayer.services.FormDefinitionService;
 import org.commcare.formplayer.services.FormplayerStorageFactory;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.util.Constants;
@@ -97,7 +98,8 @@ public class FormSession {
             FormSendCalloutHandler formSendCalloutHandler,
             FormplayerStorageFactory storageFactory,
             @Nullable CommCareSession commCareSession,
-            RemoteInstanceFetcher instanceFetcher) throws Exception {
+            RemoteInstanceFetcher instanceFetcher,
+            FormDefinitionService formDefinitionService) throws Exception {
 
         this.session = session;
         //We don't want ongoing form sessions to change their db state underneath in the middle,
@@ -108,7 +110,9 @@ public class FormSession {
         this.sandbox = restoreFactory.getSandbox();
 
         if (session.getFormDefinition() != null) {
-            this.formDef = FormDefStringSerializer.deserialize(session.getFormDefinition().getSerializedFormDef());
+            this.formDef = formDefinitionService.getFormDef(
+                    session.getId(),
+                    session.getFormDefinition().getSerializedFormDef());
         } else {
             // DEPRECATED: leave to allow rollback if needed
             // Will remove once https://github.com/dimagi/formplayer/pull/1075 is safe

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -328,7 +328,7 @@ public class FormDefinitionServiceTest {
         public FormplayerStorageFactory storageFactory() {
             FormplayerStorageFactory storageFactory = new FormplayerStorageFactory();
             storageFactory.configure("test", "test", "app_id", "");
-            storageFactory.getStorageManager().registerStorage(FormDef.STORAGE_KEY, FormDef.class);
+            storageFactory.registerFormDefStorage();
             return storageFactory;
         };
     }

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -119,7 +119,6 @@ public class FormDefinitionServiceTest {
         this.formXmlns = "http://openrosa.org/formdesigner/962C095E-3AB0-4D92-B9BA-08478FF94475";
         this.formVersion = "1";
         this.formDef = loadFormDef();
-        getFormDefStorage().write(this.formDef);
 
         PrototypeUtils.setupThreadLocalPrototypes();
     }
@@ -237,6 +236,7 @@ public class FormDefinitionServiceTest {
         ReflectionTestUtils.setField(formDef, "serializedFormDef", "not a form def");
         SerializableFormSession session = new SerializableFormSession(UUID.randomUUID().toString());
         session.setFormDefinition(formDef);
+        getFormDefStorage().write(this.formDef);
 
         FormDef reSerializedFormDef = this.formDefinitionService.getFormDef(session);
 
@@ -256,7 +256,8 @@ public class FormDefinitionServiceTest {
         ReflectionTestUtils.setField(formDef, "serializedFormDef", "not a form def");
         SerializableFormSession session = new SerializableFormSession(UUID.randomUUID().toString());
         session.setFormDefinition(formDef);
-
+        getFormDefStorage().write(this.formDef);
+        
         FormDef reSerializedFormDef = this.formDefinitionService.getFormDef(session);
 
         Optional<SerializableFormDefinition> cachedFormDefinition = getCachedSerializableFormDefinition(

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -177,7 +178,15 @@ public class FormDefinitionServiceTest {
         IStorageUtilityIndexed storage = this.storageFactory.getStorageManager().getStorage(FormDef.STORAGE_KEY);
         Externalizable formDef = storage.getRecordForValue("XMLNS",
                 "http://openrosa.org/formdesigner/962C095E-3AB0-4D92-B9BA-08478FF94475");
-        assertNotNull(formDef);
+        assertThat(formDef).isNotNull();
+    }
+
+    @Test
+    public void testWriteToLocalStorage_FormDefExists() {
+        IStorageUtilityIndexed storage = this.storageFactory.getStorageManager().getStorage(FormDef.STORAGE_KEY);
+        storage.write(formDef);
+        boolean valueWritten = this.formDefinitionService.writeToLocalStorage(this.formDef);
+        assertThat(valueWritten).isFalse();
     }
 
     private Optional<SerializableFormDefinition> getCachedFormDefinition(

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -172,7 +172,7 @@ public class FormDefinitionServiceTest {
     }
 
     @Test
-    public void testWrite() {
+    public void testWriteToLocalStorage() {
         this.formDefinitionService.writeToLocalStorage(this.formDef);
         IStorageUtilityIndexed storage = this.storageFactory.getStorageManager().getStorage(FormDef.STORAGE_KEY);
         Externalizable formDef = storage.getRecordForValue("XMLNS",

--- a/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/FormDefinitionServiceTest.java
@@ -200,5 +200,8 @@ public class FormDefinitionServiceTest {
         public CacheManager cacheManager() {
             return new ConcurrentMapCacheManager("form_definition");
         }
+
+        @MockBean
+        public FormplayerStorageFactory storageFactory;
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -360,6 +360,7 @@ public class BaseTestClass {
         );
 
         when(this.formDefinitionService.getFormDef(any(SerializableFormSession.class))).thenCallRealMethod();
+        when(this.formDefinitionService.cacheFormDef(any(FormSession.class))).thenCallRealMethod();
     }
 
     private void mockMenuSessionService() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -347,7 +347,6 @@ public class BaseTestClass {
                 SerializableFormDefinition serializableFormDef = new SerializableFormDefinition(
                         appId, appVersion, xmlns, serializedFormDef
                 );
-                serializableFormDef.setFormDef(((FormDef)invocation.getArguments()[3]));
                 if (serializableFormDef.getId() == null) {
                     // this is normally taken care of by Hibernate
                     ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId);

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -359,7 +359,7 @@ public class BaseTestClass {
                 anyString(), anyString(), anyString(), any(FormDef.class)
         );
 
-        when(this.formDefinitionService.getFormDef(anyString(), anyString())).thenCallRealMethod();
+        when(this.formDefinitionService.getFormDef(any(SerializableFormSession.class))).thenCallRealMethod();
     }
 
     private void mockMenuSessionService() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -99,6 +99,7 @@ import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -150,6 +151,9 @@ public class BaseTestClass {
 
     @Autowired
     protected FormDefinitionService formDefinitionService;
+
+    @Autowired
+    protected CacheManager cacheManager;
 
     @Autowired
     private MenuSessionService menuSessionService;
@@ -361,6 +365,9 @@ public class BaseTestClass {
 
         when(this.formDefinitionService.getFormDef(any(SerializableFormSession.class))).thenCallRealMethod();
         when(this.formDefinitionService.cacheFormDef(any(FormSession.class))).thenCallRealMethod();
+
+        // manually wire this in. The autowiring doesn't work here since we've made it a mock
+        ReflectionTestUtils.setField(this.formDefinitionService, "caches", cacheManager);
     }
 
     private void mockMenuSessionService() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -347,6 +347,7 @@ public class BaseTestClass {
                 SerializableFormDefinition serializableFormDef = new SerializableFormDefinition(
                         appId, appVersion, xmlns, serializedFormDef
                 );
+                serializableFormDef.setFormDef(((FormDef)invocation.getArguments()[3]));
                 if (serializableFormDef.getId() == null) {
                     // this is normally taken care of by Hibernate
                     ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId);
@@ -358,6 +359,8 @@ public class BaseTestClass {
         }).when(this.formDefinitionService).getOrCreateFormDefinition(
                 anyString(), anyString(), anyString(), any(FormDef.class)
         );
+
+        when(this.formDefinitionService.getFormDef(anyString(), anyString())).thenCallRealMethod();
     }
 
     private void mockMenuSessionService() {
@@ -1064,7 +1067,8 @@ public class BaseTestClass {
                 formSendCalloutHandlerMock,
                 storageFactoryMock,
                 getCommCareSession(serializableFormSession.getMenuSessionId()),
-                menuSessionRunnerService.getCaseSearchHelper());
+                menuSessionRunnerService.getCaseSearchHelper(),
+                formDefinitionService);
     }
 
     @Nullable

--- a/src/test/java/org/commcare/formplayer/tests/SavedFormDefTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SavedFormDefTest.java
@@ -63,8 +63,14 @@ public class SavedFormDefTest extends BaseTestClass {
 
         SerializableFormSession session = this.formSessionService.getSessionById(
                 newSessionResponse.getSessionId());
-        FormSession formSession = new FormSession(session, this.restoreFactoryMock, null,
-                this.storageFactoryMock, null, this.remoteInstanceFetcherMock);
+        FormSession formSession = new FormSession(session,
+                this.restoreFactoryMock,
+                null,
+                this.storageFactoryMock,
+                null,
+                this.remoteInstanceFetcherMock,
+                this.formDefinitionService
+        );
         assertEquals(formSession.getInstanceXml(true), session.getInstanceXml());
     }
 
@@ -80,8 +86,13 @@ public class SavedFormDefTest extends BaseTestClass {
         answerQuestionGetResult("0", "9", sessionId);
         SerializableFormSession session = this.formSessionService.getSessionById(
                 newSessionResponse.getSessionId());
-        FormSession formSession = new FormSession(session, this.restoreFactoryMock, null,
-                this.storageFactoryMock, null, this.remoteInstanceFetcherMock);
+        FormSession formSession = new FormSession(session,
+                this.restoreFactoryMock,
+                null,
+                this.storageFactoryMock,
+                null,
+                this.remoteInstanceFetcherMock,
+                this.formDefinitionService);
         SubmitResponseBean submitResponseBean = submitForm(
                 "requests/submit/submit_hidden_value_form.json", sessionId);
         assertEquals("success", submitResponseBean.getStatus());

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -161,7 +161,7 @@ public class TestContext {
 
     @Bean
     public CacheManager cacheManager() {
-        return new ConcurrentMapCacheManager("case_search");
+        return new ConcurrentMapCacheManager("case_search", "form_definition");
     }
 
     @Bean


### PR DESCRIPTION
I had to create a new PR since the previous PR was based off of a branch that will no longer be merged. See https://github.com/dimagi/formplayer/pull/1123 for any potentially missing context.

This work is a response to [Clayton's suggestion](https://github.com/dimagi/formplayer/pull/1121#issuecomment-1099297838) to target what specifically we want to optimize. In this case, our main goal is to improve answer timings since a user filling out a form should not have to deserialize a FormDef on every request. This still results in a FormDef being deserialized upon session creation, but that is less likely to experience noticeable gains than answer requests and submission are, since it is an already slower request.

6cd6bc1eb0d9df31a39fc6f17518c4b17cb5f06f is the bulk of this PR, but has a crucial missing component which is that we would not call `getFormDef` until the first answer request, which means we wouldn't be taking advantage of a cached FormDef until the second answer request.

Since we have to deserialize a FormDef upon session creation, it is best to prime the `form_definition` cache with that FormDef which is what 54aff2bfb2d56d7ccbff1c516594115220dbf762 does.

QA: https://dimagi-dev.atlassian.net/browse/QA-4079