### PR TITLE
use query data in debugger endpoints

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/DebuggerController.java
+++ b/src/main/java/org/commcare/formplayer/application/DebuggerController.java
@@ -89,7 +89,8 @@ public class DebuggerController extends AbstractBaseController {
             HttpServletRequest request) throws Exception {
 
         MenuSession menuSession = getMenuSessionFromBean(debuggerMenuRequest);
-        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, debuggerMenuRequest.getSelections());
+        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(
+                menuSession, debuggerMenuRequest.getSelections(), debuggerMenuRequest.getQueryData());
         logNotification(responseBean.getNotification(), request);
 
         return new MenuDebuggerContentResponseBean(
@@ -109,7 +110,9 @@ public class DebuggerController extends AbstractBaseController {
                                                        @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
                                                        HttpServletRequest request) throws Exception {
         MenuSession menuSession = getMenuSessionFromBean(evaluateXPathRequestBean);
-        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(menuSession, evaluateXPathRequestBean.getSelections());
+        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(
+                menuSession, evaluateXPathRequestBean.getSelections(),
+                evaluateXPathRequestBean.getQueryData());
         logNotification(responseBean.getNotification(), request);
 
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -215,8 +215,8 @@ public class MenuSessionRunnerService {
 
     @Trace
     public BaseResponseBean advanceSessionWithSelections(MenuSession menuSession,
-            String[] selections) throws Exception {
-        return advanceSessionWithSelections(menuSession, selections, null, null,
+            String[] selections, QueryData queryData) throws Exception {
+        return advanceSessionWithSelections(menuSession, selections, null, queryData,
                 0, null, 0, false, 0, null, null);
     }
 
@@ -773,7 +773,7 @@ public class MenuSessionRunnerService {
 
         // reset session and play it back with derived selections
         menuSession.resetSession();
-        return advanceSessionWithSelections(menuSession, selections);
+        return advanceSessionWithSelections(menuSession, selections, null);
     }
 
     public CaseSearchHelper getCaseSearchHelper() {


### PR DESCRIPTION
Companion to https://github.com/dimagi/commcare-hq/pull/31687 which passes query data to FP. These changes will use the query data when replaying the session to ensure correct session state.