### PR TITLE
Drop `formxml` column on form sessions

### DIFF
--- a/src/main/java/org/commcare/formplayer/db/migration/V25__drop_formxml_column.java
+++ b/src/main/java/org/commcare/formplayer/db/migration/V25__drop_formxml_column.java
@@ -1,0 +1,17 @@
+package org.commcare.formplayer.db.migration;
+
+import java.util.Arrays;
+
+
+/**
+ * The formxml column has been replaced by the form_definition table/foreign key
+ */
+public class V25__drop_formxml_column extends BaseFormplayerMigration {
+    @Override
+    public Iterable<String> getSqlStatements() {
+        return Arrays.asList(
+                "ALTER TABLE formplayer_sessions DROP COLUMN formxml"
+        );
+    }
+}
+

--- a/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableFormSession.java
@@ -58,10 +58,6 @@ public class SerializableFormSession implements Serializable {
     private boolean oneQuestionPerScreen;
 
     @Setter
-    @Column(name = "formxml", updatable = false)
-    private String formXml;
-
-    @Setter
     @Column(name = "instancexml")
     private String instanceXml;
 

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -244,7 +244,6 @@ public class FormSessionRepoTest {
                 ImmutableMap.of("count", functionHandlers)
         );
         session.setInstanceXml("xml");
-        session.setFormXml("form xml");
         return session;
     }
 }


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-13595

This column has been replaced with the `form_definition` table via a foreign key, and therefore is no longer needed. Ideally, we will apply this migration but first need to ensure it will not result in excessive disruption for users when rolling out to environments with lots of form sessions. I briefly tested on staging and didn't see any difference between a regular deploy and this, but there are also only 33 form sessions on staging. Next plan is to create a bunch locally and test that way.