### PR TITLE
skip case search cache on first request

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/FormplayerRemoteInstanceFetcher.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerRemoteInstanceFetcher.java
@@ -30,7 +30,7 @@ public class FormplayerRemoteInstanceFetcher implements RemoteInstanceFetcher {
             throws RemoteInstanceException {
         if (source.getSourceUri() != null) {
             try {
-                return caseSearchHelper.getExternalRoot(instanceId, (source));
+                return caseSearchHelper.getExternalRoot(instanceId, (source), false);
             } catch (XmlPullParserException | UnfullfilledRequirementsException | InvalidStructureException e) {
                 throw new RemoteInstanceException("Invalid data retrieved from remote instance " +
                         instanceId + ". If the error persists please contact your help desk.", e);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -119,7 +119,8 @@ public class MenuSessionFactory {
                                 queryScreen.getQueryDatum().getDataId(),
                                 queryScreen.getQueryDatum().useCaseTemplate(),
                                 uri.toURL(),
-                                dataBuilder.build()
+                                dataBuilder.build(),
+                                false
                             );
                             queryScreen.updateSession(searchDataInstance);
                             screen = menuSession.getNextScreen(false, false);


### PR DESCRIPTION
Always skip the case search cache when performing the search for the first time in a session. This is determined by looking at two factors:
1. Is this the last item in the list of selections?
    * Being the last item means that we aren't replaying navigation but are computing it for the first time
2. Is this a 'details screen' request
    * The only exception to # 1 is for 'details requests' which aren't treated as a navigation request so the selections remain the same

This change is intended to prevent users from seeing stale data when performing searches.

Jira: https://dimagi-dev.atlassian.net/browse/USH-2210
 