### PR TITLE
test changes to use real cache configuration

### DIFF
--- a/src/test/java/org/commcare/formplayer/auth/HmacAuthTests.java
+++ b/src/test/java/org/commcare/formplayer/auth/HmacAuthTests.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.commcare.formplayer.application.UtilController;
+import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.configuration.WebSecurityConfig;
 import org.commcare.formplayer.request.MultipleReadRequestWrappingFilter;
 import org.commcare.formplayer.services.FormplayerLockRegistry;
@@ -38,7 +39,8 @@ import java.nio.charset.Charset;
         UtilController.class,
         TestContext.class,
         WebSecurityConfig.class,
-        MultipleReadRequestWrappingFilter.class
+        MultipleReadRequestWrappingFilter.class,
+        CacheConfiguration.class
 })
 public class HmacAuthTests {
 

--- a/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
+++ b/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.commcare.formplayer.application.UtilController;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.configuration.WebSecurityConfig;
 import org.commcare.formplayer.request.MultipleReadRequestWrappingFilter;
 import org.commcare.formplayer.services.FormplayerLockRegistry;
@@ -37,7 +38,8 @@ import javax.servlet.http.Cookie;
         UtilController.class,
         TestContext.class,
         WebSecurityConfig.class,
-        MultipleReadRequestWrappingFilter.class
+        MultipleReadRequestWrappingFilter.class,
+        CacheConfiguration.class
 })
 public class SessionAuthTests {
 

--- a/src/test/java/org/commcare/formplayer/services/MenuSessionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/MenuSessionServiceTest.java
@@ -3,6 +3,7 @@ package org.commcare.formplayer.services;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -21,8 +22,10 @@ import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -72,8 +75,10 @@ public class MenuSessionServiceTest {
     }
 
     @Test
-    public void testCacheExists() {
-        assertNotNull(cacheManager.getCache("menu_session"));
+    public void testMenuSessionCacheExists() {
+        Cache cache = cacheManager.getCache("menu_session");
+        assertNotNull(cache);
+        assertTrue(cache instanceof CaffeineCache);
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/services/MenuSessionServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/MenuSessionServiceTest.java
@@ -1,0 +1,134 @@
+package org.commcare.formplayer.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import static java.util.Optional.ofNullable;
+
+import org.commcare.formplayer.configuration.CacheConfiguration;
+import org.commcare.formplayer.exceptions.MenuNotFoundException;
+import org.commcare.formplayer.objects.SerializableMenuSession;
+import org.commcare.formplayer.repo.MenuSessionRepo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
+@EnableConfigurationProperties(value = CacheConfiguration.class)
+@TestPropertySource("classpath:application.properties")
+public class MenuSessionServiceTest {
+    @Autowired
+    MenuSessionService menuSessionService;
+
+    @Autowired
+    CacheManager cacheManager;
+
+    @Autowired
+    private MenuSessionRepo menuSessionRepo;
+
+    @BeforeEach
+    public void setUp() {
+        // the repo always returns the saved object so simulate that in the mock
+        when(menuSessionRepo.save(any())).thenAnswer(new Answer<SerializableMenuSession>() {
+            @Override
+            public SerializableMenuSession answer(InvocationOnMock invocation) throws Throwable {
+                SerializableMenuSession session = (SerializableMenuSession)invocation.getArguments()[0];
+                if (session.getId() == null) {
+                    // this is normally taken care of by Hibernate
+                    ReflectionTestUtils.setField(session, "id", UUID.randomUUID().toString());
+                }
+                return session;
+            }
+        });
+    }
+
+    @AfterEach
+    public void cleanup() {
+        cacheManager.getCache("menu_session").clear();
+    }
+
+    @Test
+    public void testCacheExists() {
+        assertNotNull(cacheManager.getCache("menu_session"));
+    }
+
+    @Test
+    public void testGetSessionById_NotFound() {
+        assertThrows(MenuNotFoundException.class,
+                () -> menuSessionService.getSessionById("123"));
+    }
+
+    @Test
+    public void testGetSessionById_cached() {
+        cacheManager.getCache("menu_session").clear();
+
+        // save a session
+        SerializableMenuSession session = new SerializableMenuSession();
+        menuSessionService.saveSession(session);
+
+        // cache is populated on save
+        assertEquals(session, getCachedSession(session.getId()).get());
+
+        // get session hits the cache (repo is mocked)
+        SerializableMenuSession fetchedSession = menuSessionService.getSessionById(session.getId());
+        assertEquals(session, fetchedSession);
+
+        // update session
+        byte[] bytes = {1, 2, 3};
+        session.setCommcareSession(bytes);
+        menuSessionService.saveSession(session);
+
+        // cache and find return updated session
+        assertEquals(bytes, getCachedSession(session.getId()).get().getCommcareSession());
+        assertEquals(bytes, menuSessionService.getSessionById(session.getId()).getCommcareSession());
+    }
+
+    private Optional<SerializableMenuSession> getCachedSession(String sessionId) {
+        return ofNullable(cacheManager.getCache("menu_session")).map(
+                c -> c.get(sessionId, SerializableMenuSession.class)
+        );
+    }
+
+    // only include the service under test and it's dependencies
+    // This should not be necessary but we're using older versions of junit and spring
+    @ComponentScan(
+            basePackageClasses = {MenuSessionService.class},
+            useDefaultFilters = false,
+            includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                    MenuSessionService.class})
+    )
+    @EnableCaching
+    @Configuration
+    public static class Config {
+
+        @MockBean
+        public MenuSessionRepo menuSessionRepo;
+
+        @MockBean
+        public JdbcTemplate jdbcTemplate;
+    }
+}

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -45,6 +45,7 @@ import org.commcare.formplayer.beans.SyncDbRequestBean;
 import org.commcare.formplayer.beans.SyncDbResponseBean;
 import org.commcare.formplayer.beans.debugger.XPathQueryItem;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
+import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.engine.FormplayerConfigEngine;
 import org.commcare.formplayer.exceptions.FormNotFoundException;
 import org.commcare.formplayer.exceptions.InstanceNotFoundException;
@@ -147,7 +148,7 @@ import lombok.extern.apachecommons.CommonsLog;
  * Created by willpride on 2/3/16.
  */
 @CommonsLog
-@ContextConfiguration(classes = TestContext.class)
+@ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
 public class BaseTestClass {
 
     private MockMvc mockFormController;

--- a/src/test/java/org/commcare/formplayer/tests/BasicEndOfFormTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/BasicEndOfFormTests.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.ContextConfiguration;
 import java.util.HashMap;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class BasicEndOfFormTests extends BaseTestClass {
 
     @BeforeEach

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationParentChildTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationParentChildTests.java
@@ -30,7 +30,6 @@ import java.util.Hashtable;
  * 'Parrent' and 'Other -> Parent`
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseClaimNavigationParentChildTests extends BaseTestClass {
 
     private static final String PARENT_CASE_ID = "192262cb-fbfa-46a4-ba91-a9d13659b0e0";

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.Hashtable;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseClaimNavigationTests extends BaseTestClass {
 
     private static final String APP_PATH = "archives/caseclaim";

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -2,6 +2,8 @@ package org.commcare.formplayer.tests;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,7 +29,9 @@ import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.Hashtable;
@@ -58,6 +62,13 @@ public class CaseClaimTests extends BaseTestClass {
     @Override
     protected String getMockRestoreFileName() {
         return "restores/caseclaim.xml";
+    }
+
+    @Test
+    public void testCaseSearchCacheExists() {
+        Cache cache = cacheManager.getCache("case_search");
+        assertNotNull(cache);
+        assertTrue(cache instanceof CaffeineCache);
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -36,7 +36,6 @@ import java.util.Hashtable;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseClaimTests extends BaseTestClass {
 
     @Autowired

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbIndexTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbIndexTests.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.ContextConfiguration;
  * @author wspride
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseDbIndexTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbModelQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbModelQueryTests.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.ContextConfiguration;
  * @author wspride
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseDbModelQueryTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbOptimizationsTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbOptimizationsTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.ContextConfiguration;
  * @author wspride
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseDbOptimizationsTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/CaseDbQueryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseDbQueryTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.ContextConfiguration;
  * @author wspride
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseDbQueryTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
@@ -21,7 +21,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Created by willpride on 5/16/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CasePaginationTests extends BaseTestClass {
     @Override
     @BeforeEach

--- a/src/test/java/org/commcare/formplayer/tests/CaseTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseTests.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
  * This test tests that we can create and delete a case via the form API
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseTests extends BaseTestClass {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/CaseTilesTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseTilesTest.java
@@ -13,7 +13,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Created by willpride on 4/14/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class CaseTilesTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/DeleteApplicationDbsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/DeleteApplicationDbsTests.java
@@ -13,7 +13,6 @@ import java.io.File;
 
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class DeleteApplicationDbsTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/DetailNodesetTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/DetailNodesetTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class DetailNodesetTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/DoubleManagementTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/DoubleManagementTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Created by willpride on 4/14/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class DoubleManagementTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/EditTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EditTest.java
@@ -16,7 +16,6 @@ import java.util.Date;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class EditTest extends BaseTestClass {
 
     private final Log log = LogFactory.getLog(EditTest.class);

--- a/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingTests.java
@@ -14,7 +14,6 @@ import org.springframework.test.context.ContextConfiguration;
 import java.util.HashMap;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class EndOfFormNavFormLinkingTests extends BaseTestClass {
 
     @BeforeEach

--- a/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndOfFormNavFormLinkingWithQueryTests.java
@@ -22,7 +22,6 @@ import org.springframework.test.context.ContextConfiguration;
 import java.util.HashMap;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class EndOfFormNavFormLinkingWithQueryTests extends BaseTestClass {
 
     @Autowired

--- a/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
  * Do launch tests for very basic session endpoint definitions
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class EndpointLaunchTest extends BaseTestClass {
 
     private final String APP_NAME = "endpoint";

--- a/src/test/java/org/commcare/formplayer/tests/Enikshay2bTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/Enikshay2bTests.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashMap;
  * Tests specific to Enikshay
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class Enikshay2bTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/EnikshayEndOfFormTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EnikshayEndOfFormTests.java
@@ -19,7 +19,6 @@ import java.util.LinkedHashMap;
  * Test that end of form navigations used by Enikshay Private application work
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class EnikshayEndOfFormTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/EnikshayTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/EnikshayTests.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Tests specific to Enikshay
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class EnikshayTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/FilterTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FilterTests.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class FilterTests extends BaseTestClass {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryTest.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class FormEntryTest extends BaseTestClass {
 
     //Integration test of form entry functions

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class FormEntryWithQueryTests extends BaseTestClass {
 
     @Autowired

--- a/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormValidatorTests.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class FormValidatorTests extends BaseTestClass {
 
     private MediaType contentType = new MediaType(MediaType.APPLICATION_XML.getType(),

--- a/src/test/java/org/commcare/formplayer/tests/GeoTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/GeoTests.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Tests for geo functionality
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class GeoTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/GetInstanceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/GetInstanceTests.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Tests for GetInstanceResponseBean
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class GetInstanceTests extends BaseTestClass {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/GroupTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/GroupTests.java
@@ -17,7 +17,6 @@ import org.springframework.test.context.ContextConfiguration;
  * expansion, selects from itemsets, conditional selects
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class GroupTests extends BaseTestClass {
 
     @BeforeEach

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -2,15 +2,13 @@ package org.commcare.formplayer.tests;
 
 import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
-import org.commcare.formplayer.utils.TestContext;
-import org.commcare.formplayer.utils.WithHqUser;
+import org.commcare.formplayer.utils.HqUserDetails;
+import org.commcare.formplayer.utils.WithHqUserSecurityContextFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.security.core.context.SecurityContextHolder;
 
-@WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class HqUserDetailsTests {
 
     @Test
@@ -40,13 +38,27 @@ public class HqUserDetailsTests {
     }
 
     @Test
-    @WithHqUser
-    public void testUserHasRole() {
-        Assertions.assertTrue(FeatureFlagChecker.isPreviewEnabled("preview_a"));
-        Assertions.assertTrue(FeatureFlagChecker.isPreviewEnabled("preview_b"));
-        Assertions.assertFalse(FeatureFlagChecker.isPreviewEnabled("preview_c"));
+    public void testFeatureFlagChecker_isToggleEnabled() {
+        WithHqUserSecurityContextFactory.setSecurityContext(
+                HqUserDetails.builder().enabledToggles(new String[]{"toggle_a", "toggle_b"}).build()
+        );
         Assertions.assertTrue(FeatureFlagChecker.isToggleEnabled("toggle_a"));
         Assertions.assertTrue(FeatureFlagChecker.isToggleEnabled("toggle_b"));
         Assertions.assertFalse(FeatureFlagChecker.isToggleEnabled("toggle_c"));
+    }
+
+    @Test
+    public void testFeatureFlagChecker_isPreviewEnabled() {
+        WithHqUserSecurityContextFactory.setSecurityContext(
+                HqUserDetails.builder().enabledPreviews(new String[]{"preview_a", "preview_b"}).build()
+        );
+        Assertions.assertTrue(FeatureFlagChecker.isPreviewEnabled("preview_a"));
+        Assertions.assertTrue(FeatureFlagChecker.isPreviewEnabled("preview_b"));
+        Assertions.assertFalse(FeatureFlagChecker.isPreviewEnabled("preview_c"));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/IndexedFixtureTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/IndexedFixtureTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class IndexedFixtureTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/InlineCaseTilesTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/InlineCaseTilesTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Created by willpride on 4/14/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class InlineCaseTilesTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/InstallTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/InstallTests.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Created by willpride on 1/14/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class InstallTests extends BaseTestClass {
 
     Log log = LogFactory.getLog(InstallTests.class);

--- a/src/test/java/org/commcare/formplayer/tests/MenuDebuggerTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/MenuDebuggerTests.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class MenuDebuggerTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -37,7 +37,6 @@ import java.util.List;
  * Tests for selecting and claiming multiple entities from case search results screen
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class MultiSelectCaseClaimTest extends BaseTestClass {
 
     private static final String APP_NAME = "case_claim_with_multi_select";

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
  * Tests Navigation involving a multi-select case list
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class MultiSelectCaseListTest extends BaseTestClass {
 
     private static final String APP = "multi_select_case_list";

--- a/src/test/java/org/commcare/formplayer/tests/NewFormTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/NewFormTests.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Created by willpride on 1/14/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class NewFormTests extends BaseTestClass {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/OqpsDateRegression.java
+++ b/src/test/java/org/commcare/formplayer/tests/OqpsDateRegression.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class OqpsDateRegression extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/ParentChildTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/ParentChildTest.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class ParentChildTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/ReassignCaseTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/ReassignCaseTest.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class ReassignCaseTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/RegressionTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/RegressionTests.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration;
  * Regression tests for fixed behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class RegressionTests extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
@@ -26,7 +26,6 @@ import javax.xml.xpath.XPathFactory;
  * Created by willpride on 1/14/16.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class RepeatTests extends BaseTestClass {
 
     @BeforeEach

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -10,6 +10,7 @@ import static java.util.Collections.singletonList;
 
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
+import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.RequestUtils;
@@ -44,7 +45,7 @@ import javax.servlet.http.HttpServletRequest;
  * Created by benrudolph on 1/19/17.
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
+@ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
 public class RestoreFactoryTest {
 
     private static final String BASE_URL = "http://localhost:8000/a/restore-domain/phone/restore/";

--- a/src/test/java/org/commcare/formplayer/tests/SavedFormDefTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SavedFormDefTest.java
@@ -21,7 +21,6 @@ import org.springframework.test.context.ContextConfiguration;
 import java.io.InputStreamReader;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class SavedFormDefTest extends BaseTestClass {
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/SchedulerTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SchedulerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration;
  * correctly
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class SchedulerTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/SmartLinkTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SmartLinkTests.java
@@ -22,7 +22,6 @@ import java.util.Hashtable;
  * Tests for smart link workflow
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class SmartLinkTests extends BaseTestClass {
 
     private static final String SMART_LINK_APP = "smart_link";

--- a/src/test/java/org/commcare/formplayer/tests/SmsFormEntryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/SmsFormEntryTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.ContextConfiguration;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class SmsFormEntryTest extends BaseTestClass {
 
     @Override

--- a/src/test/java/org/commcare/formplayer/tests/SnapshotTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SnapshotTests.java
@@ -27,7 +27,6 @@ import java.io.IOException;
  * @author ctsims
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class SnapshotTests extends BaseTestClass {
 
     @BeforeEach

--- a/src/test/java/org/commcare/formplayer/tests/SubmitTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SubmitTests.java
@@ -33,7 +33,6 @@ import java.util.Map;
  * Regression tests for submission behaviors
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class SubmitTests extends BaseTestClass {
     static Map<String, Object> answers = ImmutableMap.of("0", "name", "1", "1");
 

--- a/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
+++ b/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
@@ -27,7 +27,6 @@ import java.io.File;
  * @author ctsims
  */
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
 public class GenerateSnapshotDatabases extends BaseTestClass {
 
     //This is the destination directory for the snapshot.

--- a/src/test/java/org/commcare/formplayer/utils/HqUserDetails.java
+++ b/src/test/java/org/commcare/formplayer/utils/HqUserDetails.java
@@ -1,0 +1,50 @@
+package org.commcare.formplayer.utils;
+
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+/**
+ * This class is used to construct {@link HqUserDetailsBean} classes for use in tests.
+ * Example usage:
+ *
+ * <pre class="code">
+ *   HqUserDetails details = HqUserDetails.builder()
+ *       .username("bob")
+ *       .domain("my-domain")
+ *       .build();
+ *   HqUserDetailsBean bean = details.toBean();
+ * </pre>
+ *
+ * @see WithHqUserSecurityContextFactory
+ */
+@Builder
+@AllArgsConstructor
+public class HqUserDetails {
+    private String username;
+    private String domain;
+    private String[] domains;
+    private boolean isSuperUser;
+    private String[] enabledPreviews;
+    private String[] enabledToggles;
+
+    public HqUserDetails(WithHqUser withUser) {
+        String username = StringUtils.hasLength(withUser.username()) ? withUser.username()
+                : withUser.value();
+        Assert.notNull(username, () -> withUser
+                + " cannot have null username on both username and value properties");
+        this.username = username;
+        this.domain = withUser.domain();
+        this.domains = withUser.domains();
+        this.isSuperUser = withUser.isSuperUser();
+        this.enabledPreviews = withUser.enabledPreviews();
+        this.enabledToggles = withUser.enabledToggles();
+    }
+
+    public HqUserDetailsBean toBean() {
+        return new HqUserDetailsBean(domain, domains, username, isSuperUser, enabledToggles, enabledPreviews);
+    }
+}

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -31,8 +31,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.support.ResourceBundleMessageSource;
@@ -161,11 +159,6 @@ public class TestContext {
     @Bean
     public ArchiveFileRoot formplayerArchiveFileRoot() {
         return Mockito.spy(ArchiveFileRoot.class);
-    }
-
-    @Bean
-    public CacheManager cacheManager() {
-        return new ConcurrentMapCacheManager("case_search", "form_definition");
     }
 
     @Bean

--- a/src/test/java/org/commcare/formplayer/utils/WithHqUserSecurityContextFactory.java
+++ b/src/test/java/org/commcare/formplayer/utils/WithHqUserSecurityContextFactory.java
@@ -6,25 +6,21 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
-import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * A WithSecurityContextFactory that works with {@link WithHqUser}.
  *
  * @see WithHqUser
  */
-final class WithHqUserSecurityContextFactory implements WithSecurityContextFactory<WithHqUser> {
+public final class WithHqUserSecurityContextFactory implements WithSecurityContextFactory<WithHqUser> {
 
     @Override
     public SecurityContext createSecurityContext(WithHqUser withUser) {
-        String username = StringUtils.hasLength(withUser.username()) ? withUser.username()
-                : withUser.value();
-        Assert.notNull(username, () -> withUser
-                + " cannot have null username on both username and value properties");
-        HqUserDetailsBean principal = new HqUserDetailsBean(withUser.domain(), withUser.domains(),
-                username,
-                withUser.isSuperUser(), withUser.enabledToggles(), withUser.enabledPreviews());
+        return createSecurityContext(new HqUserDetails(withUser));
+    }
+
+    public static SecurityContext createSecurityContext(HqUserDetails details) {
+        HqUserDetailsBean principal = details.toBean();
         Authentication authentication = new PreAuthenticatedAuthenticationToken(principal,
                 "sessionId", principal.getAuthorities());
         SecurityContext context = SecurityContextHolder.createEmptyContext();
@@ -32,4 +28,8 @@ final class WithHqUserSecurityContextFactory implements WithSecurityContextFacto
         return context;
     }
 
+    public static void setSecurityContext(HqUserDetails details) {
+        SecurityContext context = createSecurityContext(details);
+        SecurityContextHolder.setContext(context);
+    }
 }

--- a/src/test/java/tests/RequestResponseLoggingFilterTest.java
+++ b/src/test/java/tests/RequestResponseLoggingFilterTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import org.apache.commons.logging.Log;
 import org.commcare.formplayer.application.RequestResponseLoggingFilter;
+import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.utils.WithHqUser;
 import org.json.JSONObject;
@@ -28,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @WebMvcTest
-@ContextConfiguration(classes = TestContext.class)
+@ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
 public class RequestResponseLoggingFilterTest {
 
     Log log = null;


### PR DESCRIPTION
A recent cache configuration refactor resulted in a broken cache configuration because test were all using mock / test only cache configurations.

This PR addresses that by making all tests use the actual cache config defined in `application.properties`. 

It also adds some tests to ensure that all cache configurations are covered.

There are a few other commits which are refactors of tests classes.

🐡 best reviewed by commit