### PR TITLE
Dynamic required Conditions + Custom Required Messaging

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
@@ -174,6 +174,7 @@ public class DisplayElement {
         return error;
     }
 
+    @JsonGetter(value = "required_msg")
     @Nullable
     public String getRequiredMsg() {
         return requiredMsg;

--- a/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
@@ -46,6 +46,9 @@ public class DisplayElement {
     @Nullable
     private String error;
 
+    @Nullable
+    private String requiredMsg;
+
     public DisplayElement() {
     }
 
@@ -63,8 +66,8 @@ public class DisplayElement {
     public DisplayElement(DisplayUnit displayUnit, EvaluationContext ec, String id,
             @Nullable String input,
             @Nullable String receive, @Nullable String hidden, @Nullable String value,
-            @Nullable String[] itemsetChoices, boolean allowBlankValue, XPathExpression required,
-            String error) {
+            @Nullable String[] itemsetChoices, boolean allowBlankValue, boolean required,
+            String requiredMsg, String error) {
         this.id = id;
         this.text = displayUnit.getText().evaluate(ec);
         if (displayUnit.getImageURI() != null) {
@@ -83,9 +86,8 @@ public class DisplayElement {
             this.hint = displayUnit.getHintText().evaluate(ec);
         }
         this.allowBlankValue = allowBlankValue;
-        if (required != null) {
-            this.required = (boolean) required.eval(ec);
-        }
+        this.required = required;
+        this.requiredMsg = requiredMsg;
         this.error = error;
     }
 
@@ -170,5 +172,10 @@ public class DisplayElement {
     @Nullable
     public String getError() {
         return error;
+    }
+
+    @Nullable
+    public String getRequiredMsg() {
+        return requiredMsg;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -68,13 +68,7 @@ public class QueryResponseBean extends MenuBean {
                 choiceLabels = ItemSetUtils.getChoiceLabels(queryPromptItem.getItemsetBinding());
             }
 
-            String requiredMessage = null;
-            QueryPromptCondition required = queryPromptItem.getRequired();
-            if (required != null && required.getMessage() !=null) {
-                requiredMessage = queryPromptItem.getRequired().getMessage().evaluate(
-                        session.getEvaluationContext());
-            }
-
+            String requiredMessage = queryPromptItem.getRequiredMessage(session.getEvaluationContext());
             boolean isRequired = requiredPrompts.containsKey(key) && requiredPrompts.get(key);
             displays[count] = new DisplayElement(queryPromptItem.getDisplay(),
                     session.getEvaluationContext(),

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -1,11 +1,9 @@
 package org.commcare.formplayer.beans.menus;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import com.fasterxml.jackson.annotation.JsonSetter;
-
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.QueryPrompt;
+import org.commcare.suite.model.QueryPromptCondition;
 import org.commcare.util.screen.QueryScreen;
 import org.javarosa.core.model.utils.ItemSetUtils;
 import org.javarosa.core.util.OrderedHashtable;
@@ -38,6 +36,7 @@ public class QueryResponseBean extends MenuBean {
         OrderedHashtable<String, QueryPrompt> queryPromptMap = queryScreen.getUserInputDisplays();
         Hashtable<String, String> currentAnswers = queryScreen.getCurrentAnswers();
         Hashtable<String, String> errors = queryScreen.getErrors();
+        Hashtable<String, Boolean> requiredPrompts = queryScreen.getRequiredPrompts();
         displays = new DisplayElement[queryPromptMap.size()];
         int count = 0;
         for (String key : Collections.list(queryPromptMap.keys())) {
@@ -69,6 +68,14 @@ public class QueryResponseBean extends MenuBean {
                 choiceLabels = ItemSetUtils.getChoiceLabels(queryPromptItem.getItemsetBinding());
             }
 
+            String requiredMessage = null;
+            QueryPromptCondition required = queryPromptItem.getRequired();
+            if (required != null && required.getMessage() !=null) {
+                requiredMessage = queryPromptItem.getRequired().getMessage().evaluate(
+                        session.getEvaluationContext());
+            }
+
+            boolean isRequired = requiredPrompts.containsKey(key) && requiredPrompts.get(key);
             displays[count] = new DisplayElement(queryPromptItem.getDisplay(),
                     session.getEvaluationContext(),
                     key,
@@ -78,7 +85,8 @@ public class QueryResponseBean extends MenuBean {
                     currentAnswer,
                     choiceLabels,
                     queryPromptItem.isAllowBlankValue(),
-                    queryPromptItem.getRequired(),
+                    isRequired,
+                    requiredMessage,
                     errors.get(key)
                     );
             count++;

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -186,7 +186,6 @@ public class MenuSessionRunnerService {
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, caseListName);
             Sentry.setTag(Constants.MODULE_NAME_TAG, caseListName);
         } else if (nextScreen instanceof FormplayerQueryScreen) {
-            ((FormplayerQueryScreen)nextScreen).refreshItemSetChoices();
             String queryKey = menuSession.getSessionWrapper().getCommand();
             if (queryData != null) {
                 answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData.getInputs(queryKey));
@@ -430,7 +429,6 @@ public class MenuSessionRunnerService {
             QueryData queryData,
             boolean replay, boolean forceManualAction, boolean skipCache)
             throws CommCareSessionException {
-        queryScreen.refreshItemSetChoices();
         String queryKey = menuSession.getSessionWrapper().getCommand();
         boolean forceManualSearch = queryData != null && queryData.isForceManualSearch(queryKey);
 

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -320,8 +320,6 @@ public class CaseClaimTests extends BaseTestClass {
     @Test
     public void testQueryPromptRequired() throws Exception {
         QueryData queryData = new QueryData();
-        Hashtable<String, String> inputs = new Hashtable<>();
-        queryData.setInputs("search_command.m1", inputs);
         queryData.setForceManualSearch("search_command.m1", true);
 
         // forceManualAction true when default Search on should result in query screen
@@ -334,7 +332,7 @@ public class CaseClaimTests extends BaseTestClass {
         // test old required attr
 
         assertTrue(queryResponseBean.getDisplays()[0].isRequired());
-        assertEquals(queryResponseBean.getDisplays()[0].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
+//        assertEquals(queryResponseBean.getDisplays()[0].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
         assertTrue(queryResponseBean.getDisplays()[1].isRequired());
         assertEquals(queryResponseBean.getDisplays()[1].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
         assertFalse(queryResponseBean.getDisplays()[2].isRequired());
@@ -348,7 +346,9 @@ public class CaseClaimTests extends BaseTestClass {
         assertTrue(queryResponseBean.getDisplays()[4].getRequiredMsg().contentEquals(expectedMessage));
 
         // dynamic condition, inputting age should make dob not required
+        Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("age", "12");
+        queryData.setInputs("search_command.m1", inputs);
         queryResponseBean = sessionNavigateWithQuery(
                 new String[]{"1", "action 1"},
                 "caseclaim",

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -23,6 +23,7 @@ import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.FileUtils;
 import org.commcare.formplayer.utils.TestContext;
+import org.commcare.suite.model.QueryPrompt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -322,12 +323,13 @@ public class CaseClaimTests extends BaseTestClass {
                 QueryResponseBean.class);
 
         // test old required attr
+
         assertTrue(queryResponseBean.getDisplays()[0].isRequired());
-        assertNull(queryResponseBean.getDisplays()[0].getRequiredMsg());
+        assertEquals(queryResponseBean.getDisplays()[0].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
         assertTrue(queryResponseBean.getDisplays()[1].isRequired());
-        assertNull(queryResponseBean.getDisplays()[1].getRequiredMsg());
+        assertEquals(queryResponseBean.getDisplays()[1].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
         assertFalse(queryResponseBean.getDisplays()[2].isRequired());
-        assertNull(queryResponseBean.getDisplays()[2].getRequiredMsg());
+        assertEquals(queryResponseBean.getDisplays()[2].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
 
         // test new required node, both age and dob is required without any input
         String expectedMessage = "One of age or DOB is required";
@@ -344,6 +346,7 @@ public class CaseClaimTests extends BaseTestClass {
                 queryData,
                 QueryResponseBean.class);
         assertFalse(queryResponseBean.getDisplays()[4].isRequired());
+        assertTrue(queryResponseBean.getDisplays()[4].getRequiredMsg().contentEquals(expectedMessage));
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -282,7 +282,7 @@ public class CaseClaimTests extends BaseTestClass {
         // test old required attr
 
         assertTrue(queryResponseBean.getDisplays()[0].isRequired());
-//        assertEquals(queryResponseBean.getDisplays()[0].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
+        assertEquals(queryResponseBean.getDisplays()[0].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
         assertTrue(queryResponseBean.getDisplays()[1].isRequired());
         assertEquals(queryResponseBean.getDisplays()[1].getRequiredMsg(), QueryPrompt.DEFAULT_REQUIRED_ERROR);
         assertFalse(queryResponseBean.getDisplays()[2].isRequired());

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -337,7 +337,7 @@ public class CaseClaimTests extends BaseTestClass {
         assertTrue(queryResponseBean.getDisplays()[4].getRequiredMsg().contentEquals(expectedMessage));
 
         // dynamic condition, inputting age should make dob not required
-        inputs.put("age","12");
+        inputs.put("age", "12");
         queryResponseBean = sessionNavigateWithQuery(
                 new String[]{"1", "action 1"},
                 "caseclaim",

--- a/src/test/resources/archives/caseclaim/default/app_strings.txt
+++ b/src/test/resources/archives/caseclaim/default/app_strings.txt
@@ -39,3 +39,6 @@ search_property.m1.district=District
 search_property.m1.hint=This is a hint
 search_property.m1.age=Age
 search_property.m1.age.validation=age should be greater than 18
+search_property.m1.age.required=One of age or DOB is required
+search_property.m1.dob=Date of Birth
+search_property.m1.dob.required=One of age or DOB is required

--- a/src/test/resources/archives/caseclaim/suite.xml
+++ b/src/test/resources/archives/caseclaim/suite.xml
@@ -313,11 +313,28 @@
               <locale id="search_property.m1.age.validation"/>
             </text>
           </validation>
+          <required test="count(instance('my-search-input')/input/field[@name='dob']) = 0 or instance('my-search-input')/input/field[@name='dob']=''">
+            <text>
+              <locale id="search_property.m1.age.required"/>
+            </text>
+          </required>
           <display>
             <text>
               <locale id="search_property.m1.age"/>
             </text>
           </display>
+        </prompt>
+        <prompt key="dob" required="false()">
+          <display>
+            <text>
+              <locale id="search_property.m1.dob"/>
+            </text>
+          </display>
+          <required test="count(instance('my-search-input')/input/field[@name='age']) = 0 or instance('my-search-input')/input/field[@name='age']=''">
+            <text>
+              <locale id="search_property.m1.dob.required"/>
+            </text>
+          </required>
         </prompt>
       </query>
       <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case']" value="./@case_id" detail-select="m0_search_short" detail-confirm="m1_case_long"/>

--- a/src/test/resources/archives/caseclaim/suite.xml
+++ b/src/test/resources/archives/caseclaim/suite.xml
@@ -324,7 +324,7 @@
             </text>
           </display>
         </prompt>
-        <prompt key="dob" required="false()">
+        <prompt key="dob">
           <display>
             <text>
               <locale id="search_property.m1.dob"/>


### PR DESCRIPTION
https://github.com/dimagi/commcare-core/pull/1139

Adds a new attribute `required_msg` to the Formplayer query response to support custom error messaging. This would be `null` when there is no custom message. 

````
{
  "displays": [
    {
      "text": "age",
      "id": "age",
       …,
      "required_msg":  "One of Age or DOB is required"
    }
  ],
  "type": "query"
}
````

[QA ticket](https://dimagi-dev.atlassian.net/browse/QA-4342)