### PR TITLE
logging / sentry changes to reduce multiple events for the same thing

### DIFF
--- a/src/main/java/org/commcare/formplayer/exceptions/FormattedApplicationConfigException.java
+++ b/src/main/java/org/commcare/formplayer/exceptions/FormattedApplicationConfigException.java
@@ -3,7 +3,7 @@ package org.commcare.formplayer.exceptions;
 /**
  * This exception is for application config exceptions that return HTML instead of text to be rendered.
  */
-public class FormattedApplicationConfigException extends RuntimeException {
+public class FormattedApplicationConfigException extends ApplicationConfigException {
     public FormattedApplicationConfigException(String message) {
         super(message);
     }

--- a/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
@@ -88,7 +88,7 @@ public class FormplayerLockRegistry implements LockRegistry {
 
     private void evict(FormplayerReentrantLock lock, Object lockKey) {
         Thread ownerThread = lock.getOwner();
-        log.error(String.format("Thread %s owns expired lock with lock key %s.", ownerThread, lockKey));
+        log.warn(String.format("Thread %s owns expired lock with lock key %s.", ownerThread, lockKey));
         ownerThread.interrupt();
         try {
             ownerThread.join(5000);
@@ -96,7 +96,7 @@ public class FormplayerLockRegistry implements LockRegistry {
             throw new InterruptedRuntimeException(e);
         }
         if (ownerThread.isAlive()) {
-            log.error(String.format(
+            log.warn(String.format(
                 "Unable to evict thread %s owning lock with lock key %s. expired=%s, lockTime=%s(s)",
                     ownerThread, lockKey, lock.isExpired(), lock.timeLocked()));
             Exception e = new Exception("Unable to get expired lock, owner thread has stack trace");

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -93,10 +93,8 @@ public class InstallService {
             installTimer.record();
             return new Pair<>(engine, newInstall);
         } catch (UnresolvedResourceException e) {
-            log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());
             throw new UnresolvedResourceRuntimeException(e);
         } catch (Exception e) {
-            log.error("Got exception " + e + " while installing reference " + reference + " at path " + sqliteDB.getDatabaseFileForDebugPurposes());
             sqliteDB.deleteDatabaseFile();
             throw e;
         }


### PR DESCRIPTION
Looking at Sentry today I noticed that there are often 2 or more events for the same 'error'. Sentry is configured to create new events for unhandled exceptions as well as for log events at the 'ERROR' level. In some cases we are logging to ERROR and also raising exceptions or manually capturing the Sentry events which is unnecessary.

I have tried to ensure that there is still useful context being output to the console while reducing the Sentry events.