### PR TITLE
don't log expected errors

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -17,6 +17,7 @@ import org.commcare.formplayer.util.NotificationLogger;
 import org.javarosa.xform.parse.XFormParseException;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.schema.JSONReporter;
+import org.javarosa.xpath.XPathException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.http.MediaType;
@@ -150,7 +151,7 @@ public class UtilController {
             parser.attachReporter(reporter);
             parser.parse();
             reporter.setPassed();
-        } catch (XFormParseException xfpe) {
+        } catch (XFormParseException | XPathException xfpe) {
             reporter.setFailed(xfpe);
         } catch (Exception e) {
             log.error("Validate Form threw exception", e);

--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -151,7 +151,6 @@ public class UtilController {
             parser.parse();
             reporter.setPassed();
         } catch (XFormParseException xfpe) {
-            log.error("Validate Form threw exception", xfpe);
             reporter.setFailed(xfpe);
         } catch (Exception e) {
             log.error("Validate Form threw exception", e);


### PR DESCRIPTION
We expect these errors from the 'validate_form' endpoint so there's no need to log them.