### PR TITLE
drop error log to info

### DIFF
--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -241,8 +241,8 @@ public class FormSession {
         try {
             formEntryController.setLanguage(session.getInitLang());
         } catch (UnregisteredLocaleException e) {
-            log.error("Couldn't find locale " + session.getInitLang()
-                    + " for user " + session.getUsername());
+            log.info("Couldn't find form locale '" + session.getInitLang()
+                    + "' for user " + session.getUsername());
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/util/SessionUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/SessionUtils.java
@@ -40,12 +40,8 @@ public class SessionUtils {
             return;
         }
         Localizer localizer = Localization.getGlobalLocalizerAdvanced();
-        for (String availabile : localizer.getAvailableLocales()) {
-            if (locale.equals(availabile)) {
-                localizer.setLocale(locale);
-
-                return;
-            }
+        if (localizer.hasLocale(locale)) {
+            localizer.setLocale(locale);
         }
     }
 


### PR DESCRIPTION
We hit this almost 10K times per day and it's not a genuine error so dropping from 'error' to 'info'.

The user's locale is set in the settings in CommCare and often doesn't match the locale's available in the app.

Also included is a small simplification to the `SessionUtils.setLocale` method.