### PR TITLE
update readme for mac specific issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Download submodule dependencies
 
     $ git submodule update --init --recursive
 
+Mac users will need to comment out references to micrometer in the following files:
+
+    build.gradle
+
+    src/main/java/org/commcare/formplayer/application/WebAppContext.java
+
 To make properties file:
 
     $ cp config/application.example.properties config/application.properties  # Update properties as necessary (the defaults are fine for running locally)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Download submodule dependencies
 
     $ git submodule update --init --recursive
 
-Mac users will need to comment out references to micrometer in the following files:
+Mac users may need to comment out references to micrometer in the following files in order to run formplayer:
 
     build.gradle
 


### PR DESCRIPTION

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Mac users running formplayer outside of Docker (all mac users?) need to remove references to `micrometer` to run formplayer locally. I was reminded of this when helping new devs setup their environments. 

## Safety Assurance
Just a readme change
### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA
### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->


- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
