### PR TITLE
add state hash to restore URL

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -7,6 +7,7 @@ import io.sentry.SentryLevel;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.cases.util.InvalidCaseGraphException;
 import org.commcare.core.parse.ParseUtils;
 import org.commcare.formplayer.api.process.FormRecordProcessorHelper;
@@ -663,6 +664,11 @@ public class RestoreFactory {
         if (syncToken != null && !"".equals(syncToken)) {
             params.put("since", syncToken);
         }
+        String caseStateHash = getCaseDbHash();
+        if (!caseStateHash.isEmpty()) {
+            params.put("state", caseStateHash);
+        }
+
         if (asUsername != null) {
             String asUserParam = asUsername;
             if (!asUsername.contains("@")) {
@@ -685,6 +691,14 @@ public class RestoreFactory {
                 .put("domain", this.domain)
                 .build();
         return builder.buildAndExpand(templateVars).toUri();
+    }
+
+    public String getCaseDbHash() {
+        String hash = CaseDBUtils.computeCaseDbHash(getSqlSandbox().getCaseStorage());
+        if (hash.isEmpty()) {
+            return "";
+        }
+        return String.format("ccsh:%s", hash);
     }
 
     /**

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -618,10 +618,13 @@ public class RestoreFactory {
     }
 
     public URI getRestoreUrl(boolean skipFixtures) {
-        if (caseId != null) {
-            return getCaseRestoreUrl();
-        }
-        return getUserRestoreUrl(skipFixtures);
+        // TODO: remove timing once the state hash rollout is complete
+        return categoryTimingHelper.timed(Constants.TimingCategories.BUILD_RESTORE_URL, () -> {
+            if (caseId != null) {
+                return getCaseRestoreUrl();
+            }
+            return getUserRestoreUrl(skipFixtures);
+        });
     }
 
     private HttpHeaders getHmacHeader(URI url) {

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.services;
 
+import static org.commcare.formplayer.util.Constants.TOGGLE_INCLUDE_STATE_HASH;
+
 import datadog.trace.api.Trace;
 import com.google.common.collect.ImmutableMap;
 import com.timgroup.statsd.StatsDClient;
@@ -13,6 +15,7 @@ import org.commcare.core.parse.ParseUtils;
 import org.commcare.formplayer.api.process.FormRecordProcessorHelper;
 import org.commcare.formplayer.auth.HqAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
+import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
 import org.commcare.formplayer.engine.FormplayerTransactionParserFactory;
 import org.commcare.formplayer.exceptions.AsyncRetryException;
 import org.commcare.formplayer.exceptions.SQLiteRuntimeException;
@@ -59,7 +62,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Collections;
@@ -68,7 +70,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Factory that determines the correct URL endpoint based on domain, host, and username/asUsername,
@@ -664,9 +665,12 @@ public class RestoreFactory {
         if (syncToken != null && !"".equals(syncToken)) {
             params.put("since", syncToken);
         }
-        String caseStateHash = getCaseDbHash();
-        if (!caseStateHash.isEmpty()) {
-            params.put("state", caseStateHash);
+
+        if (FeatureFlagChecker.isToggleEnabled(TOGGLE_INCLUDE_STATE_HASH)) {
+            String caseStateHash = getCaseDbHash();
+            if (!caseStateHash.isEmpty()) {
+                params.put("state", caseStateHash);
+            }
         }
 
         if (asUsername != null) {

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -173,6 +173,7 @@ public class Constants {
 
     public static final String TOGGLE_DETAILED_TAGGING = "DETAILED_TAGGING";
     public static final String TOGGLE_SESSION_ENDPOINTS = "SESSION_ENDPOINTS";
+    public static final String TOGGLE_INCLUDE_STATE_HASH = "FORMPLAYER_INCLUDE_STATE_HASH";
 
     public static final String AUTHORITY_COMMCARE = "COMMCARE";
 }

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -147,6 +147,7 @@ public class Constants {
         public static final String PROCESS_ANSWER = "process_answer";
         public static final String UPDATE_SESSION = "update_session";
         public static final String COMPILE_RESPONSE = "compile_response";
+        public static final String BUILD_RESTORE_URL = "build_restore_url";
     }
 
     // Requests

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -1,5 +1,15 @@
 package org.commcare.formplayer.tests;
 
+import static org.commcare.formplayer.util.Constants.TOGGLE_INCLUDE_STATE_HASH;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import static java.util.Collections.singletonList;
+
 import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
@@ -28,23 +38,13 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static java.util.Collections.singletonList;
-
-import static org.commcare.formplayer.util.Constants.TOGGLE_INCLUDE_STATE_HASH;
-import static org.commcare.formplayer.util.Constants.TOGGLE_SESSION_ENDPOINTS;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Created by benrudolph on 1/19/17.

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -1,13 +1,6 @@
 package org.commcare.formplayer.tests;
 
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-
-import static java.util.Collections.singletonList;
-
+import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.configuration.CacheConfiguration;
@@ -23,6 +16,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,13 +27,20 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.servlet.http.HttpServletRequest;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by benrudolph on 1/19/17.
@@ -198,6 +199,30 @@ public class RestoreFactoryTest {
                         "&as=asUser%40restore-domain.commcarehq.org",
                 restoreFactorySpy.getUserRestoreUrl(false).toString()
         );
+    }
+
+    @Test
+    public void testGetUserRestoreUrlWithSinceParam() {
+        try (MockedStatic<CaseDBUtils> mockUtils = Mockito.mockStatic(CaseDBUtils.class)) {
+            mockUtils.when(() -> CaseDBUtils.computeCaseDbHash(any())).thenReturn("123");
+            assertEquals(
+                    BASE_URL + "?version=2.0" +
+                            "&device_id=WebAppsLogin" +
+                            "&state=ccsh%3A123",
+                    restoreFactorySpy.getUserRestoreUrl(false).toString()
+            );
+        }
+    }
+
+    @Test
+    public void testGetUserRestoreUrlEmptyStateHash() {
+        try (MockedStatic<CaseDBUtils> mockUtils = Mockito.mockStatic(CaseDBUtils.class)) {
+            mockUtils.when(() -> CaseDBUtils.computeCaseDbHash(any())).thenReturn("");
+            assertEquals(
+                    BASE_URL + "?version=2.0&device_id=WebAppsLogin",
+                    restoreFactorySpy.getUserRestoreUrl(false).toString()
+            );
+        }
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -8,6 +8,7 @@ import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.RequestUtils;
 import org.commcare.formplayer.utils.TestContext;
+import org.commcare.formplayer.utils.WithHqUser;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
@@ -35,6 +36,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.util.Collections.singletonList;
+
+import static org.commcare.formplayer.util.Constants.TOGGLE_INCLUDE_STATE_HASH;
+import static org.commcare.formplayer.util.Constants.TOGGLE_SESSION_ENDPOINTS;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -202,7 +206,8 @@ public class RestoreFactoryTest {
     }
 
     @Test
-    public void testGetUserRestoreUrlWithSinceParam() {
+    @WithHqUser(enabledToggles = {TOGGLE_INCLUDE_STATE_HASH})
+    public void testGetUserRestoreUrlWithStateHash() {
         try (MockedStatic<CaseDBUtils> mockUtils = Mockito.mockStatic(CaseDBUtils.class)) {
             mockUtils.when(() -> CaseDBUtils.computeCaseDbHash(any())).thenReturn("123");
             assertEquals(
@@ -215,6 +220,19 @@ public class RestoreFactoryTest {
     }
 
     @Test
+    public void testGetUserRestoreUrlWithStateHash_toggleOff() {
+        try (MockedStatic<CaseDBUtils> mockUtils = Mockito.mockStatic(CaseDBUtils.class)) {
+            mockUtils.when(() -> CaseDBUtils.computeCaseDbHash(any())).thenReturn("123");
+            assertEquals(
+                    BASE_URL + "?version=2.0" +
+                            "&device_id=WebAppsLogin",
+                    restoreFactorySpy.getUserRestoreUrl(false).toString()
+            );
+        }
+    }
+
+    @Test
+    @WithHqUser(enabledToggles = {TOGGLE_INCLUDE_STATE_HASH})
     public void testGetUserRestoreUrlEmptyStateHash() {
         try (MockedStatic<CaseDBUtils> mockUtils = Mockito.mockStatic(CaseDBUtils.class)) {
             mockUtils.when(() -> CaseDBUtils.computeCaseDbHash(any())).thenReturn("");


### PR DESCRIPTION
## Technical Summary
This adds the state hash to the restore URL. This should allow better validation that HQ and formplayer are aligned on the users case DB state.

Initially any errors will only be logged to avoid breaking changes (see https://github.com/dimagi/commcare-hq/pull/32089).

The intention is to surface sync bugs sooner so that they can be fixed.

## Safety Assurance

### Safety story
Once the HQ PR is deployed this should be safe since a state hash mismatch will still not result in an error.

The only question I have is related to the performance of computing the state hash. Is that something we should be concerned about? Perhaps @shubham1g5 @ctsims have more insight.

### Automated test coverage
Tests added to make sure a blank state hash is not included and a non-blank one is included correctly

### QA Plan
None

### Special deploy instructions
- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
