### PR TITLE
Sk/test refactor

### DIFF
--- a/src/test/java/org/commcare/formplayer/junit/FormDefSessionServiceExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/FormDefSessionServiceExtension.kt
@@ -16,7 +16,6 @@ import org.springframework.cache.CacheManager
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.util.ReflectionTestUtils
 import java.io.IOException
-import java.util.*
 
 /**
  * Junit extension that configures the mock FormDefinitionService
@@ -33,7 +32,8 @@ class FormDefSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
     private var currentFormDefinitionId = 1L
 
     override fun beforeAll(context: ExtensionContext) {
-        formDefinitionService = SpringExtension.getApplicationContext(context).getBean(FormDefinitionService::class.java)
+        formDefinitionService =
+            SpringExtension.getApplicationContext(context).getBean(FormDefinitionService::class.java)
         cacheManager = SpringExtension.getApplicationContext(context).getBean(CacheManager::class.java)
 
         // manually wire this in. The autowiring doesn't work here since we've made it a mock
@@ -43,32 +43,36 @@ class FormDefSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
     override fun beforeEach(context: ExtensionContext?) {
         formDefinitionMap.clear()
 
-        Mockito.doAnswer(Answer { invocation ->
-            val appId = invocation.arguments[0] as String
-            val appVersion = invocation.arguments[1] as String
-            val xmlns = invocation.arguments[2] as String
-            for (tmp in formDefinitionMap.values) {
-                if (tmp.appId == appId && tmp.formXmlns == xmlns && tmp.formVersion == appVersion) {
-                    return@Answer tmp
+        Mockito.doAnswer(
+            Answer { invocation ->
+                val appId = invocation.arguments[0] as String
+                val appVersion = invocation.arguments[1] as String
+                val xmlns = invocation.arguments[2] as String
+                for (tmp in formDefinitionMap.values) {
+                    if (tmp.appId == appId && tmp.formXmlns == xmlns && tmp.formVersion == appVersion) {
+                        return@Answer tmp
+                    }
                 }
+                // else create a new one
+                val serializedFormDef: String? = try {
+                    FormDefStringSerializer.serialize(invocation.arguments[3] as FormDef)
+                } catch (ex: IOException) {
+                    "could not serialize provided form def"
+                }
+                val serializableFormDef = SerializableFormDefinition(
+                    appId, appVersion, xmlns, serializedFormDef
+                )
+                if (serializableFormDef.id == null) {
+                    // this is normally taken care of by Hibernate
+                    ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId)
+                    currentFormDefinitionId++
+                }
+                formDefinitionMap[serializableFormDef.id] = serializableFormDef
+                serializableFormDef
             }
-            // else create a new one
-            val serializedFormDef: String? = try {
-                FormDefStringSerializer.serialize(invocation.arguments[3] as FormDef)
-            } catch (ex: IOException) {
-                "could not serialize provided form def"
-            }
-            val serializableFormDef = SerializableFormDefinition(
-                appId, appVersion, xmlns, serializedFormDef
-            )
-            if (serializableFormDef.id == null) {
-                // this is normally taken care of by Hibernate
-                ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId)
-                currentFormDefinitionId++
-            }
-            formDefinitionMap[serializableFormDef.id] = serializableFormDef
-            serializableFormDef
-        }).`when`(this.formDefinitionService).getOrCreateFormDefinition(
+        ).`when`(
+            this.formDefinitionService
+        ).getOrCreateFormDefinition(
             ArgumentMatchers.anyString(),
             ArgumentMatchers.anyString(),
             ArgumentMatchers.anyString(),
@@ -77,14 +81,14 @@ class FormDefSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
             )
         )
 
-        Mockito.`when`<FormDef>(
+        Mockito.`when`(
             this.formDefinitionService.getFormDef(
                 ArgumentMatchers.any(
                     SerializableFormSession::class.java
                 )
             )
         ).thenCallRealMethod()
-        Mockito.`when`<FormDef>(
+        Mockito.`when`(
             this.formDefinitionService.cacheFormDef(
                 ArgumentMatchers.any(
                     FormSession::class.java

--- a/src/test/java/org/commcare/formplayer/junit/FormDefSessionServiceExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/FormDefSessionServiceExtension.kt
@@ -1,0 +1,95 @@
+package org.commcare.formplayer.junit
+
+import org.commcare.formplayer.objects.SerializableFormDefinition
+import org.commcare.formplayer.objects.SerializableFormSession
+import org.commcare.formplayer.services.FormDefinitionService
+import org.commcare.formplayer.session.FormSession
+import org.commcare.formplayer.util.serializer.FormDefStringSerializer
+import org.javarosa.core.model.FormDef
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.stubbing.Answer
+import org.springframework.cache.CacheManager
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.util.ReflectionTestUtils
+import java.io.IOException
+import java.util.*
+
+/**
+ * Junit extension that configures the mock FormDefinitionService
+ *
+ * Setup mocking for the FormDefinitionService that allows saving and retrieving form definitions.
+ * The 'persisted' definitions are cleared at the start of each test.
+ */
+class FormDefSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
+
+    private lateinit var formDefinitionService: FormDefinitionService
+    private lateinit var cacheManager: CacheManager
+
+    private val formDefinitionMap: MutableMap<Long, SerializableFormDefinition> = HashMap()
+    private var currentFormDefinitionId = 1L
+
+    override fun beforeAll(context: ExtensionContext) {
+        formDefinitionService = SpringExtension.getApplicationContext(context).getBean(FormDefinitionService::class.java)
+        cacheManager = SpringExtension.getApplicationContext(context).getBean(CacheManager::class.java)
+
+        // manually wire this in. The autowiring doesn't work here since we've made it a mock
+        ReflectionTestUtils.setField(this.formDefinitionService, "caches", cacheManager)
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        formDefinitionMap.clear()
+
+        Mockito.doAnswer(Answer { invocation ->
+            val appId = invocation.arguments[0] as String
+            val appVersion = invocation.arguments[1] as String
+            val xmlns = invocation.arguments[2] as String
+            for (tmp in formDefinitionMap.values) {
+                if (tmp.appId == appId && tmp.formXmlns == xmlns && tmp.formVersion == appVersion) {
+                    return@Answer tmp
+                }
+            }
+            // else create a new one
+            val serializedFormDef: String? = try {
+                FormDefStringSerializer.serialize(invocation.arguments[3] as FormDef)
+            } catch (ex: IOException) {
+                "could not serialize provided form def"
+            }
+            val serializableFormDef = SerializableFormDefinition(
+                appId, appVersion, xmlns, serializedFormDef
+            )
+            if (serializableFormDef.id == null) {
+                // this is normally taken care of by Hibernate
+                ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId)
+                currentFormDefinitionId++
+            }
+            formDefinitionMap[serializableFormDef.id] = serializableFormDef
+            serializableFormDef
+        }).`when`(this.formDefinitionService).getOrCreateFormDefinition(
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.anyString(),
+            ArgumentMatchers.any(
+                FormDef::class.java
+            )
+        )
+
+        Mockito.`when`<FormDef>(
+            this.formDefinitionService.getFormDef(
+                ArgumentMatchers.any(
+                    SerializableFormSession::class.java
+                )
+            )
+        ).thenCallRealMethod()
+        Mockito.`when`<FormDef>(
+            this.formDefinitionService.cacheFormDef(
+                ArgumentMatchers.any(
+                    FormSession::class.java
+                )
+            )
+        ).thenCallRealMethod()
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/FormSessionServiceExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/FormSessionServiceExtension.kt
@@ -14,7 +14,7 @@ import org.springframework.test.util.ReflectionTestUtils
 import java.util.*
 
 /**
- * Junit extension that configures the mock FormDefinitionService
+ * Junit extension that configures the mock FormSessionService
  *
  * Setup mocking for the FormSessionService that allows saving and retrieving sessions.
  * The 'persisted' sessions are cleared at the start of each test.

--- a/src/test/java/org/commcare/formplayer/junit/FormSessionServiceExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/FormSessionServiceExtension.kt
@@ -1,0 +1,64 @@
+package org.commcare.formplayer.junit
+
+import org.commcare.formplayer.exceptions.FormNotFoundException
+import org.commcare.formplayer.objects.SerializableFormSession
+import org.commcare.formplayer.services.FormSessionService
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.mockito.stubbing.Answer
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.util.ReflectionTestUtils
+import java.util.*
+
+/**
+ * Junit extension that configures the mock FormDefinitionService
+ *
+ * Setup mocking for the FormSessionService that allows saving and retrieving sessions.
+ * The 'persisted' sessions are cleared at the start of each test.
+ */
+class FormSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
+
+    private lateinit var formSessionService: FormSessionService
+    val sessionMap: MutableMap<String, SerializableFormSession> = HashMap()
+
+    override fun beforeAll(context: ExtensionContext) {
+        formSessionService = SpringExtension.getApplicationContext(context).getBean(FormSessionService::class.java)
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        sessionMap.clear()
+
+        Mockito.doAnswer { invocation ->
+            val session = invocation.arguments[0] as SerializableFormSession
+            if (session.id == null) {
+                // this is normally taken care of by Hibernate
+                ReflectionTestUtils.setField(session, "id", UUID.randomUUID().toString())
+            }
+            sessionMap[session.id] = session
+            session
+        }.`when`(formSessionService).saveSession(
+            ArgumentMatchers.any(
+                SerializableFormSession::class.java
+            )
+        )
+
+        Mockito.`when`(formSessionService.getSessionById(ArgumentMatchers.anyString()))
+            .thenAnswer(
+                Answer { invocation ->
+                    val key = invocation.arguments[0] as String
+                    if (sessionMap.containsKey(key)) {
+                        return@Answer sessionMap[key]
+                    }
+                    throw FormNotFoundException(key)
+                })
+
+        Mockito.doAnswer { invocation ->
+            val key = invocation.arguments[0] as String
+            sessionMap.remove(key)
+            null
+        }.`when`(formSessionService).deleteSessionById(ArgumentMatchers.anyString())
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/FormSessionServiceExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/FormSessionServiceExtension.kt
@@ -11,7 +11,7 @@ import org.mockito.Mockito
 import org.mockito.stubbing.Answer
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.util.ReflectionTestUtils
-import java.util.*
+import java.util.UUID
 
 /**
  * Junit extension that configures the mock FormSessionService
@@ -22,7 +22,7 @@ import java.util.*
 class FormSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
 
     private lateinit var formSessionService: FormSessionService
-    val sessionMap: MutableMap<String, SerializableFormSession> = HashMap()
+    private val sessionMap: MutableMap<String, SerializableFormSession> = HashMap()
 
     override fun beforeAll(context: ExtensionContext) {
         formSessionService = SpringExtension.getApplicationContext(context).getBean(FormSessionService::class.java)
@@ -53,7 +53,8 @@ class FormSessionServiceExtension : BeforeAllCallback, BeforeEachCallback {
                         return@Answer sessionMap[key]
                     }
                     throw FormNotFoundException(key)
-                })
+                }
+            )
 
         Mockito.doAnswer { invocation ->
             val key = invocation.arguments[0] as String

--- a/src/test/java/org/commcare/formplayer/junit/FormSessionTest.java
+++ b/src/test/java/org/commcare/formplayer/junit/FormSessionTest.java
@@ -1,0 +1,18 @@
+package org.commcare.formplayer.junit;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith({
+        InitializeStaticsExtension.class,
+        FormDefSessionServiceExtension.class,
+        FormSessionServiceExtension.class,
+})
+public @interface FormSessionTest {
+}

--- a/src/test/java/org/commcare/formplayer/junit/FormSessionTest.java
+++ b/src/test/java/org/commcare/formplayer/junit/FormSessionTest.java
@@ -7,6 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Convenience annotation for applying Junit extensions needed when testing
+ * form sessions.
+ */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith({

--- a/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
+++ b/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
@@ -10,6 +10,9 @@ import org.javarosa.core.services.locale.LocalizerManager;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+/**
+ * Perform initialization of static utils.
+ */
 public class InitializeStaticsExtension implements BeforeEachCallback {
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {

--- a/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
+++ b/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
@@ -21,7 +21,6 @@ public class InitializeStaticsExtension implements BeforeEachCallback {
                 "jr://springfile/formplayer_translatable_strings.txt");
 
         PrototypeUtils.setupThreadLocalPrototypes();
-        new SQLiteProperties().setDataDir("testdbs/");
 
         DateUtils.setTimezoneProvider(new MockTimezoneProvider());
     }

--- a/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
+++ b/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
@@ -1,0 +1,29 @@
+package org.commcare.formplayer.junit;
+
+import org.commcare.formplayer.application.SQLiteProperties;
+import org.commcare.formplayer.engine.ClasspathFileRoot;
+import org.commcare.formplayer.util.PrototypeUtils;
+import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.reference.ReferenceManager;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.services.locale.LocalizerManager;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class InitializeStaticsExtension implements BeforeEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        LocalizerManager.setUseThreadLocalStrategy(true);
+        Localization.getGlobalLocalizerAdvanced().addAvailableLocale("default");
+        Localization.setLocale("default");
+        ReferenceManager.instance().addReferenceFactory(new ClasspathFileRoot());
+        Localization.registerLanguageReference("default",
+                "jr://springfile/formplayer_translatable_strings.txt");
+
+        PrototypeUtils.setupThreadLocalPrototypes();
+        new SQLiteProperties().setDataDir("testdbs/");
+
+        DateUtils.setTimezoneProvider(new MockTimezoneProvider());
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
+++ b/src/test/java/org/commcare/formplayer/junit/InitializeStaticsExtension.java
@@ -7,7 +7,6 @@ import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.LocalizerManager;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 

--- a/src/test/java/org/commcare/formplayer/junit/Installer.kt
+++ b/src/test/java/org/commcare/formplayer/junit/Installer.kt
@@ -1,0 +1,107 @@
+package org.commcare.formplayer.junit
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.commcare.formplayer.auth.DjangoAuth
+import org.commcare.formplayer.beans.InstallRequestBean
+import org.commcare.formplayer.beans.menus.CommandListResponseBean
+import org.commcare.formplayer.services.FormplayerStorageFactory
+import org.commcare.formplayer.services.MenuSessionFactory
+import org.commcare.formplayer.services.MenuSessionRunnerService
+import org.commcare.formplayer.services.RestoreFactory
+import org.commcare.formplayer.session.MenuSession
+import org.commcare.formplayer.util.SessionUtils
+import org.commcare.formplayer.utils.CheckedSupplier
+import org.commcare.formplayer.utils.FileUtils
+import org.commcare.modern.util.Pair
+import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import java.io.IOException
+import java.io.StringReader
+
+class Installer(
+    private val restoreFactory: RestoreFactory,
+    private val storageFactory: FormplayerStorageFactory,
+    private val menuSessionFactory: MenuSessionFactory,
+    private val menuSessionRunnerService: MenuSessionRunnerService
+    ) {
+
+    /**
+     * This function performs an app install outside of the request cycle. In order to do that
+     * successfully it mimics behaviour in the UserRestoreAspect and the AppInstallAspect.
+     *
+     * @param requestPath path to JSON file with InstallRequestBean content as well as
+     * 'installReference'
+     */
+    @Throws(Exception::class)
+    fun doInstall(requestPath: String): CommandListResponseBean? {
+        val refAndBean = getInstallReferenceAndBean(
+            requestPath,
+            InstallRequestBean::class.java
+        )
+        val bean = refAndBean.second
+        storageFactory.configure(bean)
+        restoreFactory.configure(bean, DjangoAuth("key"))
+        if (bean.isMustRestore) {
+            restoreFactory.performTimedSync()
+        }
+        val install = CheckedSupplier {
+            val menuSession: MenuSession = menuSessionFactory.buildSession(
+                bean.username,
+                bean.domain,
+                bean.appId,
+                bean.locale,
+                bean.oneQuestionPerScreen,
+                bean.restoreAs,
+                bean.preview
+            )
+            menuSessionRunnerService.getNextMenu(menuSession) as CommandListResponseBean
+        }
+        return mockInstallReference(install, refAndBean.first)
+    }
+
+    companion object {
+        private val mapper = ObjectMapper()
+
+        /**
+         * Utility method to extract the 'installReference' field from test JSON files and map the
+         * remaining JSON fields to the given bean type.
+         *
+         * @param requestPath classpath relative path to JSON file
+         * @param clazz       Bean class map JSON to
+         * @return Pair of 'installReference' and deserialized JSON bean
+         * @throws IOException
+         */
+        @JvmStatic
+        @Throws(IOException::class)
+        fun <T> getInstallReferenceAndBean(requestPath: String, clazz: Class<T>): Pair<String, T> {
+            val root: JsonNode = mapper.readTree(
+                StringReader(FileUtils.getFile(this.javaClass, requestPath))
+            )
+            val installReference = (root as ObjectNode).remove("installReference").asText()
+            val beanContent: String = mapper.writeValueAsString(root)
+            val bean = mapper.readValue(beanContent, clazz)
+            return Pair(installReference, bean)
+        }
+
+        @JvmStatic
+        @Throws(Exception::class)
+        fun <T> mockInstallReference(supplier: CheckedSupplier<T>, installReference: String): T {
+            val answer: Answer<*> = Answer { invocation: InvocationOnMock ->
+                val method = invocation.method
+                // only mock the `resolveInstallReference` method
+                if ("resolveInstallReference" == method.name) {
+                    return@Answer installReference
+                } else {
+                    return@Answer invocation.callRealMethod()
+                }
+            }
+            Mockito.mockStatic(SessionUtils::class.java, answer).use {
+                    _ -> return supplier.get()
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/junit/Installer.kt
+++ b/src/test/java/org/commcare/formplayer/junit/Installer.kt
@@ -21,12 +21,15 @@ import org.mockito.stubbing.Answer
 import java.io.IOException
 import java.io.StringReader
 
+/**
+ * Utility for performing app installs in tests.
+ */
 class Installer(
     private val restoreFactory: RestoreFactory,
     private val storageFactory: FormplayerStorageFactory,
     private val menuSessionFactory: MenuSessionFactory,
     private val menuSessionRunnerService: MenuSessionRunnerService
-    ) {
+) {
 
     /**
      * This function performs an app install outside of the request cycle. In order to do that
@@ -98,10 +101,9 @@ class Installer(
                     return@Answer invocation.callRealMethod()
                 }
             }
-            Mockito.mockStatic(SessionUtils::class.java, answer).use {
-                    _ -> return supplier.get()
+            Mockito.mockStatic(SessionUtils::class.java, answer).use { _ ->
+                return supplier.get()
             }
         }
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/junit/MockTimezoneProvider.java
+++ b/src/test/java/org/commcare/formplayer/junit/MockTimezoneProvider.java
@@ -1,0 +1,17 @@
+package org.commcare.formplayer.junit;
+
+import org.javarosa.core.model.utils.TimezoneProvider;
+
+public class MockTimezoneProvider extends TimezoneProvider {
+
+    private int offsetMillis;
+
+    public void setOffset(int offset) {
+        this.offsetMillis = offset;
+    }
+
+    @Override
+    public int getTimezoneOffsetMillis() {
+        return offsetMillis;
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/MockTimezoneProvider.java
+++ b/src/test/java/org/commcare/formplayer/junit/MockTimezoneProvider.java
@@ -2,6 +2,9 @@ package org.commcare.formplayer.junit;
 
 import org.javarosa.core.model.utils.TimezoneProvider;
 
+/**
+ * Mock timezone provider
+ */
 public class MockTimezoneProvider extends TimezoneProvider {
 
     private int offsetMillis;

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryAnswer.java
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryAnswer.java
@@ -6,6 +6,9 @@ import org.mockito.stubbing.Answer;
 import java.io.FileInputStream;
 import java.io.InputStream;
 
+/**
+ * Mockito answer for mocking restores.
+ */
 public class RestoreFactoryAnswer implements Answer {
     private String mRestoreFile;
 

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryAnswer.java
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryAnswer.java
@@ -1,0 +1,20 @@
+package org.commcare.formplayer.junit;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+public class RestoreFactoryAnswer implements Answer {
+    private String mRestoreFile;
+
+    public RestoreFactoryAnswer(String restoreFile) {
+        mRestoreFile = restoreFile;
+    }
+
+    @Override
+    public InputStream answer(InvocationOnMock invocation) throws Throwable {
+        return new FileInputStream("src/test/resources/" + mRestoreFile);
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
@@ -35,7 +35,7 @@ class RestoreFactoryExtension(
     private val username: String,
     private val domain: String,
     private val asUser: String?,
-    private val restorePath: String = "test_restore.xml") : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+    var restorePath: String = "test_restore.xml") : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
 
     lateinit var restoreFactory: RestoreFactory
     private val sessionSelectionsCache: MutableSet<String> = HashSet()
@@ -44,7 +44,7 @@ class RestoreFactoryExtension(
         private var username: String = "username",
         private var domain: String = "domain",
         private var asUser: String? = null,
-        private var restorePath: String? = null,
+        private var restorePath: String = "test_restore.xml",
     ) {
         fun withUser(username: String) = apply {this.username = username}
         fun withDomain(domain: String) = apply {this.domain = domain}
@@ -58,17 +58,17 @@ class RestoreFactoryExtension(
         }
     }
 
-    override fun beforeAll(context: ExtensionContext?) {
+    override fun beforeAll(context: ExtensionContext) {
         restoreFactory = SpringExtension.getApplicationContext(context).getBean(RestoreFactory::class.java)
     }
 
-    override fun beforeEach(context: ExtensionContext?) {
+    override fun beforeEach(context: ExtensionContext) {
         reset()
         restoreFactory.configure(username, domain, asUser, DjangoAuth("test"))
         configureMock()
     }
 
-    override fun afterEach(context: ExtensionContext?) {
+    override fun afterEach(context: ExtensionContext) {
         reset()
     }
 

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
@@ -34,24 +34,26 @@ import kotlin.collections.HashSet
 class RestoreFactoryExtension(
     private val username: String,
     private val domain: String,
-    private val asUser: String?) : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+    private val asUser: String?,
+    private val restorePath: String = "test_restore.xml") : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
 
     lateinit var restoreFactory: RestoreFactory
     private val sessionSelectionsCache: MutableSet<String> = HashSet()
-
-    var restorePath: String = "test_restore.xml"
 
     class builder @JvmOverloads constructor(
         private var username: String = "username",
         private var domain: String = "domain",
         private var asUser: String? = null,
+        private var restorePath: String? = null,
     ) {
         fun withUser(username: String) = apply {this.username = username}
         fun withDomain(domain: String) = apply {this.domain = domain}
         fun withAsUser(asUser: String) = apply {this.asUser = asUser}
+        fun withRestorePath(restorePath: String) = apply {this.restorePath = restorePath}
+
         fun build(): RestoreFactoryExtension {
             return RestoreFactoryExtension(
-                username, domain, asUser
+                username, domain, asUser, restorePath
             )
         }
     }

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
@@ -12,7 +12,6 @@ import org.mockito.Mockito
 import org.mockito.Mockito.doAnswer
 import org.mockito.invocation.InvocationOnMock
 import org.springframework.test.context.junit.jupiter.SpringExtension
-import java.util.*
 import kotlin.collections.HashSet
 
 /**
@@ -35,7 +34,8 @@ class RestoreFactoryExtension(
     private val username: String,
     private val domain: String,
     private val asUser: String?,
-    var restorePath: String = "test_restore.xml") : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+    var restorePath: String = "test_restore.xml"
+) : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
 
     lateinit var restoreFactory: RestoreFactory
     private val sessionSelectionsCache: MutableSet<String> = HashSet()
@@ -46,10 +46,10 @@ class RestoreFactoryExtension(
         private var asUser: String? = null,
         private var restorePath: String = "test_restore.xml",
     ) {
-        fun withUser(username: String) = apply {this.username = username}
-        fun withDomain(domain: String) = apply {this.domain = domain}
-        fun withAsUser(asUser: String) = apply {this.asUser = asUser}
-        fun withRestorePath(restorePath: String) = apply {this.restorePath = restorePath}
+        fun withUser(username: String) = apply { this.username = username }
+        fun withDomain(domain: String) = apply { this.domain = domain }
+        fun withAsUser(asUser: String) = apply { this.asUser = asUser }
+        fun withRestorePath(restorePath: String) = apply { this.restorePath = restorePath }
 
         fun build(): RestoreFactoryExtension {
             return RestoreFactoryExtension(

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
@@ -1,0 +1,116 @@
+package org.commcare.formplayer.junit
+
+import org.commcare.formplayer.auth.DjangoAuth
+import org.commcare.formplayer.services.RestoreFactory
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.Mockito
+import org.mockito.Mockito.doAnswer
+import org.mockito.invocation.InvocationOnMock
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.util.*
+import kotlin.collections.HashSet
+
+/**
+ * Junit extension to configure the restore factory
+ *
+ * This extension can be registered programmatically as described in the Junit documentation:
+ * https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic.
+ *
+ * Usage example:
+ * <pre>
+ * class ExampleTest {
+ *
+ *   @RegisterExtension
+ *   static RestoreFactoryExtension restoreExt = RestoreFactoryExtension.builder()
+ *       .withUser("username").withDomain("test").build();
+ * }
+ * </pre>
+ */
+class RestoreFactoryExtension(
+    private val username: String,
+    private val domain: String,
+    private val asUser: String?) : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+
+    lateinit var restoreFactory: RestoreFactory
+    private val sessionSelectionsCache: MutableSet<String> = HashSet()
+
+    var restorePath: String = "test_restore.xml"
+
+    class builder @JvmOverloads constructor(
+        private var username: String = "username",
+        private var domain: String = "domain",
+        private var asUser: String? = null,
+    ) {
+        fun withUser(username: String) = apply {this.username = username}
+        fun withDomain(domain: String) = apply {this.domain = domain}
+        fun withAsUser(asUser: String) = apply {this.asUser = asUser}
+        fun build(): RestoreFactoryExtension {
+            return RestoreFactoryExtension(
+                username, domain, asUser
+            )
+        }
+    }
+
+    override fun beforeAll(context: ExtensionContext?) {
+        restoreFactory = SpringExtension.getApplicationContext(context).getBean(RestoreFactory::class.java)
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        reset()
+        restoreFactory.configure(username, domain, asUser, DjangoAuth("test"))
+        configureMock()
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        reset()
+    }
+
+    fun reset() {
+        sessionSelectionsCache.clear()
+        restoreFactory.sqLiteDB.closeConnection()
+    }
+
+    fun configureMock() {
+        mockGetRestoreXml()
+        mockIsRestoreXmlExpired()
+        mockCacheSessionSelections()
+        mockIsConfirmedSelections()
+    }
+
+    private fun mockIsConfirmedSelections() {
+        doAnswer { invocation: InvocationOnMock ->
+            val selections = invocation.arguments[0] as Array<String>
+            sessionSelectionsCache.contains(java.lang.String.join("|", *selections))
+        }.`when`(restoreFactory).isConfirmedSelection(
+            ArgumentMatchers.any(
+                Array<String>::class.java
+            )
+        )
+    }
+
+    private fun mockCacheSessionSelections() {
+        doAnswer { invocation: InvocationOnMock ->
+            val selections = invocation.arguments[0] as Array<String>
+            sessionSelectionsCache.add(java.lang.String.join("|", *selections))
+            null
+        }.`when`(restoreFactory).cacheSessionSelections(
+            ArgumentMatchers.any(
+                Array<String>::class.java
+            )
+        )
+    }
+
+    private fun mockIsRestoreXmlExpired() {
+        Mockito.doReturn(false).`when`(restoreFactory).isRestoreXmlExpired
+    }
+
+    private fun mockGetRestoreXml() {
+        val answer = RestoreFactoryAnswer(restorePath)
+        doAnswer(answer).`when`(restoreFactory).getRestoreXml(anyBoolean())
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/StorageFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/StorageFactoryExtension.kt
@@ -28,7 +28,8 @@ class StorageFactoryExtension(
     private val domain: String,
     private val appId: String,
     private val asUser: String?,
-    private val asCaseId: String?) : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+    private val asCaseId: String?
+) : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
 
     private lateinit var storageFactory: FormplayerStorageFactory
 
@@ -39,18 +40,17 @@ class StorageFactoryExtension(
         private var asUser: String? = null,
         private var asCaseId: String? = null,
     ) {
-        fun withUser(username: String) = apply {this.username = username}
-        fun withDomain(domain: String) = apply {this.domain = domain}
-        fun withAppId(appId: String) = apply {this.appId = appId}
-        fun withAsUser(asUser: String) = apply {this.asUser = asUser}
-        fun withCase(asCaseId: String) = apply {this.asCaseId = asCaseId}
+        fun withUser(username: String) = apply { this.username = username }
+        fun withDomain(domain: String) = apply { this.domain = domain }
+        fun withAppId(appId: String) = apply { this.appId = appId }
+        fun withAsUser(asUser: String) = apply { this.asUser = asUser }
+        fun withCase(asCaseId: String) = apply { this.asCaseId = asCaseId }
         fun build(): StorageFactoryExtension {
             return StorageFactoryExtension(
                 username, domain, appId, asUser, asCaseId
             )
         }
     }
-
 
     override fun beforeAll(context: ExtensionContext) {
         storageFactory = SpringExtension.getApplicationContext(context).getBean(FormplayerStorageFactory::class.java)

--- a/src/test/java/org/commcare/formplayer/junit/StorageFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/StorageFactoryExtension.kt
@@ -1,0 +1,66 @@
+package org.commcare.formplayer.junit
+
+import org.commcare.formplayer.services.FormplayerStorageFactory
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+/**
+ * Junit extension to configure the storage factory
+ *
+ * This extension can be registered programmatically as described in the Junit documentation:
+ * https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic.
+ *
+ * Usage example:
+ * <pre>
+ * class ExampleTest {
+ *
+ *   @RegisterExtension
+ *   static StorageFactoryExtension storageExt = StorageFactoryExtension.builder()
+ *       .withUser("username").withDomain("test").build();
+ * }
+ * </pre>
+ */
+class StorageFactoryExtension(
+    private val username: String,
+    private val domain: String,
+    private val appId: String,
+    private val asUser: String?,
+    private val asCaseId: String?) : BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+
+    private lateinit var storageFactory: FormplayerStorageFactory
+
+    class builder @JvmOverloads constructor(
+        private var username: String = "username",
+        private var domain: String = "domain",
+        private var appId: String = "123",
+        private var asUser: String? = null,
+        private var asCaseId: String? = null,
+    ) {
+        fun withUser(username: String) = apply {this.username = username}
+        fun withDomain(domain: String) = apply {this.domain = domain}
+        fun withAppId(appId: String) = apply {this.appId = appId}
+        fun withAsUser(asUser: String) = apply {this.asUser = asUser}
+        fun withCase(asCaseId: String) = apply {this.asCaseId = asCaseId}
+        fun build(): StorageFactoryExtension {
+            return StorageFactoryExtension(
+                username, domain, appId, asUser, asCaseId
+            )
+        }
+    }
+
+
+    override fun beforeAll(context: ExtensionContext) {
+        storageFactory = SpringExtension.getApplicationContext(context).getBean(FormplayerStorageFactory::class.java)
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        storageFactory.configure(username, domain, appId, asUser, asCaseId)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        storageFactory.sqLiteDB.closeConnection()
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
@@ -1,0 +1,49 @@
+package org.commcare.formplayer.junit.request
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.commcare.formplayer.beans.NewFormResponse
+import org.commcare.formplayer.beans.NewSessionRequestBean
+import org.commcare.formplayer.util.Constants
+import org.commcare.formplayer.utils.FileUtils
+import org.commcare.formplayer.web.client.WebClient
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import javax.servlet.http.Cookie
+
+/**
+ * Request class for making a mock request that starts a new form session.
+ */
+class NewFormRequest(private val mockMvc: MockMvc, private val webClientMock: WebClient, private val formPath: String) {
+
+    private val mapper = ObjectMapper()
+
+    fun request(requestPath: String): Response<NewFormResponse> {
+        val requestPayload = FileUtils.getFile(this.javaClass, requestPath)
+        val newSessionRequestBean = mapper.readValue(
+            requestPayload,
+            NewSessionRequestBean::class.java
+        )
+        return requestWithBean(newSessionRequestBean)
+    }
+
+    fun requestWithBean(requestBean: NewSessionRequestBean): Response<NewFormResponse> {
+        Mockito.`when`(webClientMock.get(ArgumentMatchers.anyString()))
+            .thenReturn(FileUtils.getFile(this.javaClass, formPath))
+
+        val response = mockMvc.perform(
+            post("/" + Constants.URL_NEW_SESSION)
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user("user"))
+                .content(mapper.writeValueAsString(requestBean))
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+        return Response(mapper, response, NewFormResponse::class)
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
@@ -18,7 +18,11 @@ import javax.servlet.http.Cookie
 /**
  * Request class for making a mock request that starts a new form session.
  */
-class NewFormRequest(private val mockMvc: MockMvc, private val webClientMock: WebClient, private val formPath: String) {
+class NewFormRequest(
+    private val mockMvc: MockMvc,
+    private val webClientMock: WebClient,
+    private val formPath: String
+) {
 
     private val mapper = ObjectMapper()
 
@@ -45,5 +49,4 @@ class NewFormRequest(private val mockMvc: MockMvc, private val webClientMock: We
         ).andExpect(MockMvcResultMatchers.status().isOk)
         return Response(mapper, response, NewFormResponse::class)
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/Response.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/Response.kt
@@ -11,14 +11,15 @@ import kotlin.reflect.KClass
  * Wrapper class for MockMVC responses that gives access ot the response bean as well as the
  * ResultActions object.
  */
-class Response<T : Any> (
-    private val mapper: ObjectMapper, val response: ResultActions, private val kClass: KClass<T>
-    ) : ResultActions {
+class Response<T : Any>(
+    private val mapper: ObjectMapper,
+    val response: ResultActions,
+    private val kClass: KClass<T>
+) : ResultActions {
 
     fun bean(): T {
         return mapper.readValue(
-            response.andReturn().response.contentAsString,
-            kClass.java
+            response.andReturn().response.contentAsString, kClass.java
         )
     }
 
@@ -31,6 +32,6 @@ class Response<T : Any> (
     }
 
     override fun andReturn(): MvcResult {
-        return response.andReturn();
+        return response.andReturn()
     }
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/Response.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/Response.kt
@@ -1,0 +1,36 @@
+package org.commcare.formplayer.junit.request
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.test.web.servlet.MvcResult
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.ResultHandler
+import org.springframework.test.web.servlet.ResultMatcher
+import kotlin.reflect.KClass
+
+/**
+ * Wrapper class for MockMVC responses that gives access ot the response bean as well as the
+ * ResultActions object.
+ */
+class Response<T : Any> (
+    private val mapper: ObjectMapper, val response: ResultActions, private val kClass: KClass<T>
+    ) : ResultActions {
+
+    fun bean(): T {
+        return mapper.readValue(
+            response.andReturn().response.contentAsString,
+            kClass.java
+        )
+    }
+
+    override fun andExpect(matcher: ResultMatcher): ResultActions {
+        return response.andExpect(matcher)
+    }
+
+    override fun andDo(handler: ResultHandler): ResultActions {
+        return response.andDo(handler)
+    }
+
+    override fun andReturn(): MvcResult {
+        return response.andReturn();
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -1,0 +1,41 @@
+package org.commcare.formplayer.junit.request
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.commcare.formplayer.beans.SubmitRequestBean
+import org.commcare.formplayer.beans.SubmitResponseBean
+import org.commcare.formplayer.util.Constants
+import org.commcare.formplayer.utils.FileUtils
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import javax.servlet.http.Cookie
+
+/**
+ * Request class for making a mock request submits a form.
+ */
+class SubmitFormRequest(private val mockMvc: MockMvc) {
+
+    private val mapper = ObjectMapper()
+
+    fun request(requestPath: String, sessionId: String): Response<SubmitResponseBean> {
+        val requestPayload = FileUtils.getFile(this.javaClass, requestPath)
+        val bean = mapper.readValue(requestPayload, SubmitRequestBean::class.java)
+        bean.sessionId = sessionId
+        return requestWithBean(bean)
+    }
+
+    fun requestWithBean(requestBean: SubmitRequestBean): Response<SubmitResponseBean> {
+        val response = mockMvc.perform(
+            post("/" + Constants.URL_SUBMIT_FORM)
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user("user"))
+                .content(mapper.writeValueAsString(requestBean))
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+        return Response(mapper, response, SubmitResponseBean::class)
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -37,5 +37,4 @@ class SubmitFormRequest(private val mockMvc: MockMvc) {
         ).andExpect(MockMvcResultMatchers.status().isOk)
         return Response(mapper, response, SubmitResponseBean::class)
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
@@ -38,5 +38,4 @@ class SyncDbRequest(private val mockMvc: MockMvc, private val restoreFactory: Re
         ).andExpect(MockMvcResultMatchers.status().isOk)
         return Response(mapper, response, SyncDbResponseBean::class)
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
@@ -1,0 +1,42 @@
+package org.commcare.formplayer.junit.request
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.commcare.formplayer.beans.SyncDbRequestBean
+import org.commcare.formplayer.beans.SyncDbResponseBean
+import org.commcare.formplayer.services.RestoreFactory
+import org.commcare.formplayer.util.Constants
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import javax.servlet.http.Cookie
+
+/**
+ * Request class for making a mock syncdb request
+ */
+class SyncDbRequest(private val mockMvc: MockMvc, private val restoreFactory: RestoreFactory) {
+
+    private val mapper = ObjectMapper()
+
+    fun request(): Response<SyncDbResponseBean> {
+        val bean = SyncDbRequestBean()
+        bean.domain = restoreFactory.domain
+        bean.username = restoreFactory.username
+        bean.restoreAs = restoreFactory.asUsername
+        return requestWithBean(bean)
+    }
+
+    fun requestWithBean(requestBean: SyncDbRequestBean): Response<SyncDbResponseBean> {
+        val response = mockMvc.perform(
+            post("/" + Constants.URL_SYNC_DB)
+                .contentType(MediaType.APPLICATION_JSON)
+                .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user("user"))
+                .content(mapper.writeValueAsString(requestBean))
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+        return Response(mapper, response, SyncDbResponseBean::class)
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -2,16 +2,13 @@ package org.commcare.formplayer.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.assertj.core.api.Assertions;
 import org.commcare.core.interfaces.RemoteInstanceFetcher;
@@ -75,14 +72,11 @@ import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.services.SubmitService;
 import org.commcare.formplayer.services.VirtualDataInstanceService;
 import org.commcare.formplayer.session.FormSession;
-import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
-import org.commcare.formplayer.util.SessionUtils;
 import org.commcare.formplayer.util.serializer.SessionSerializer;
-import org.commcare.formplayer.utils.CheckedSupplier;
 import org.commcare.formplayer.utils.FileUtils;
 import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.web.client.WebClient;
@@ -91,7 +85,6 @@ import org.commcare.session.CommCareSession;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.utils.TimezoneProvider;
 import org.javarosa.core.reference.ReferenceHandler;
 import org.javarosa.core.services.locale.LocalizerManager;
 import org.jetbrains.annotations.NotNull;
@@ -101,7 +94,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
@@ -123,19 +115,13 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import javax.servlet.http.Cookie;
@@ -285,6 +271,8 @@ public class BaseTestClass {
 
         mockMenuSessionService();
         mockVirtualDataInstanceService();
+
+        new SQLiteProperties().setDataDir("testdbs/");
     }
 
     private void setupRestoreFactoryMock() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -52,6 +52,7 @@ import org.commcare.formplayer.junit.Installer;
 import org.commcare.formplayer.junit.RestoreFactoryExtension;
 import org.commcare.formplayer.junit.request.NewFormRequest;
 import org.commcare.formplayer.junit.request.SubmitFormRequest;
+import org.commcare.formplayer.junit.request.SyncDbRequest;
 import org.commcare.formplayer.objects.QueryData;
 import org.commcare.formplayer.objects.SerializableDataInstance;
 import org.commcare.formplayer.objects.SerializableFormSession;
@@ -559,16 +560,13 @@ public class BaseTestClass {
                 SubmitResponseBean.class);
     }
 
-    protected SyncDbResponseBean syncDb() throws Exception {
+    protected SyncDbResponseBean syncDb() {
         SyncDbRequestBean syncDbRequestBean = new SyncDbRequestBean();
         syncDbRequestBean.setDomain(restoreFactoryMock.getDomain());
         syncDbRequestBean.setUsername(restoreFactoryMock.getUsername());
         syncDbRequestBean.setRestoreAs(restoreFactoryMock.getAsUsername());
-        return generateMockQuery(ControllerType.UTIL,
-                RequestType.POST,
-                Constants.URL_SYNC_DB,
-                syncDbRequestBean,
-                SyncDbResponseBean.class);
+        restoreFactoryMock.configure(syncDbRequestBean, new DjangoAuth("derp"));
+        return new SyncDbRequest(mockUtilController, restoreFactoryMock).requestWithBean(syncDbRequestBean).bean();
     }
 
     NotificationMessage deleteApplicationDbs() throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -51,6 +51,8 @@ import org.commcare.formplayer.exceptions.InstanceNotFoundException;
 import org.commcare.formplayer.exceptions.MenuNotFoundException;
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
 import org.commcare.formplayer.junit.FormSessionTest;
+import org.commcare.formplayer.junit.request.NewFormRequest;
+import org.commcare.formplayer.junit.request.SubmitFormRequest;
 import org.commcare.formplayer.objects.QueryData;
 import org.commcare.formplayer.objects.SerializableDataInstance;
 import org.commcare.formplayer.objects.SerializableFormSession;
@@ -557,30 +559,23 @@ public class BaseTestClass {
         String requestPayload = FileUtils.getFile(this.getClass(), requestPath);
         NewSessionRequestBean newSessionRequestBean = mapper.readValue(requestPayload,
                 NewSessionRequestBean.class);
-        when(restoreFactoryMock.getUsername())
-                .thenReturn(newSessionRequestBean.getUsername());
-        when(restoreFactoryMock.getDomain())
-                .thenReturn(newSessionRequestBean.getDomain());
-        return generateMockQuery(ControllerType.FORM,
-                RequestType.POST,
-                Constants.URL_NEW_SESSION,
-                newSessionRequestBean,
-                NewFormResponse.class);
+        restoreFactoryMock.configure(newSessionRequestBean, new DjangoAuth("derp"));
+        return new NewFormRequest(mockFormController, webClientMock, formPath)
+                .requestWithBean(newSessionRequestBean)
+                .bean();
     }
 
     SubmitResponseBean submitForm(String sessionId) throws Exception {
-        return submitForm(new HashMap<String, Object>(), sessionId);
+        return submitForm(new HashMap<>(), sessionId);
     }
 
     SubmitResponseBean submitForm(String requestPath, String sessionId) throws Exception {
         SubmitRequestBean submitRequestBean = mapper.readValue
                 (FileUtils.getFile(this.getClass(), requestPath), SubmitRequestBean.class);
         submitRequestBean.setSessionId(sessionId);
-        return generateMockQuery(ControllerType.FORM_SUBMISSION,
-                RequestType.POST,
-                Constants.URL_SUBMIT_FORM,
-                submitRequestBean,
-                SubmitResponseBean.class);
+        restoreFactoryMock.configure(submitRequestBean, new DjangoAuth("123"));
+        return new SubmitFormRequest(mockFormSubmissionController)
+                .requestWithBean(submitRequestBean).bean();
     }
 
 

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -271,8 +271,6 @@ public class BaseTestClass {
 
         mockMenuSessionService();
         mockVirtualDataInstanceService();
-
-        new SQLiteProperties().setDataDir("testdbs/");
     }
 
     private void setupRestoreFactoryMock() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -50,12 +50,9 @@ import org.commcare.formplayer.engine.FormplayerConfigEngine;
 import org.commcare.formplayer.exceptions.InstanceNotFoundException;
 import org.commcare.formplayer.exceptions.MenuNotFoundException;
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
-import org.commcare.formplayer.junit.FormDefSessionServiceExtension;
-import org.commcare.formplayer.junit.FormSessionServiceExtension;
-import org.commcare.formplayer.junit.InitializeStaticsExtension;
+import org.commcare.formplayer.junit.FormSessionTest;
 import org.commcare.formplayer.objects.QueryData;
 import org.commcare.formplayer.objects.SerializableDataInstance;
-import org.commcare.formplayer.objects.SerializableFormDefinition;
 import org.commcare.formplayer.objects.SerializableFormSession;
 import org.commcare.formplayer.objects.SerializableMenuSession;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
@@ -80,7 +77,6 @@ import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
 import org.commcare.formplayer.util.SessionUtils;
-import org.commcare.formplayer.util.serializer.FormDefStringSerializer;
 import org.commcare.formplayer.util.serializer.SessionSerializer;
 import org.commcare.formplayer.utils.CheckedSupplier;
 import org.commcare.formplayer.utils.FileUtils;
@@ -88,7 +84,6 @@ import org.commcare.formplayer.utils.TestContext;
 import org.commcare.formplayer.web.client.WebClient;
 import org.commcare.modern.util.Pair;
 import org.commcare.session.CommCareSession;
-import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
@@ -99,7 +94,6 @@ import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -149,11 +143,7 @@ import lombok.extern.apachecommons.CommonsLog;
  */
 @CommonsLog
 @ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
-@ExtendWith({
-        InitializeStaticsExtension.class,
-        FormSessionServiceExtension.class,
-        FormDefSessionServiceExtension.class,
-})
+@FormSessionTest
 public class BaseTestClass {
 
     private MockMvc mockFormController;

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -1025,20 +1025,6 @@ public class BaseTestClass {
         return mapper.readValue(jsonString, clazz);
     }
 
-    public class MockTimezoneProvider extends TimezoneProvider {
-
-        private int offsetMillis;
-
-        public void setOffset(int offset) {
-            this.offsetMillis = offset;
-        }
-
-        @Override
-        public int getTimezoneOffsetMillis() {
-            return offsetMillis;
-        }
-    }
-
     /**
      * Utility method to extract the 'installReference' field from test JSON files and map the
      * remaining JSON fields to the given bean type.

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -51,6 +51,7 @@ import org.commcare.formplayer.exceptions.FormNotFoundException;
 import org.commcare.formplayer.exceptions.InstanceNotFoundException;
 import org.commcare.formplayer.exceptions.MenuNotFoundException;
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
+import org.commcare.formplayer.junit.InitializeStaticsExtension;
 import org.commcare.formplayer.objects.QueryData;
 import org.commcare.formplayer.objects.SerializableDataInstance;
 import org.commcare.formplayer.objects.SerializableFormDefinition;
@@ -77,7 +78,6 @@ import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
-import org.commcare.formplayer.util.PrototypeUtils;
 import org.commcare.formplayer.util.SessionUtils;
 import org.commcare.formplayer.util.serializer.FormDefStringSerializer;
 import org.commcare.formplayer.util.serializer.SessionSerializer;
@@ -91,15 +91,14 @@ import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.TreeElement;
-import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.model.utils.TimezoneProvider;
 import org.javarosa.core.reference.ReferenceHandler;
-import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.LocalizerManager;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -149,6 +148,7 @@ import lombok.extern.apachecommons.CommonsLog;
  */
 @CommonsLog
 @ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
+@ExtendWith(InitializeStaticsExtension.class)
 public class BaseTestClass {
 
     private MockMvc mockFormController;
@@ -286,13 +286,6 @@ public class BaseTestClass {
         mapper = new ObjectMapper();
         storageFactoryMock.getSQLiteDB().closeConnection();
         restoreFactoryMock.getSQLiteDB().closeConnection();
-        PrototypeUtils.setupThreadLocalPrototypes();
-        LocalizerManager.setUseThreadLocalStrategy(true);
-        Localization.getGlobalLocalizerAdvanced().addAvailableLocale("default");
-        Localization.setLocale("default");
-        new SQLiteProperties().setDataDir(getDatabaseFolderRoot());
-        MockTimezoneProvider tzProvider = new MockTimezoneProvider();
-        DateUtils.setTimezoneProvider(tzProvider);
 
         mockFormSessionService();
         mockFormDefinitionService();

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -272,6 +272,9 @@ public class BaseTestClass {
 
         mockMenuSessionService();
         mockVirtualDataInstanceService();
+
+        // this shouldn't be needed here (see TestContext) but tests fail without it
+        new SQLiteProperties().setDataDir("testdbs/");
     }
 
     private void setupRestoreFactoryMock() {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -50,6 +50,7 @@ import org.commcare.formplayer.engine.FormplayerConfigEngine;
 import org.commcare.formplayer.exceptions.InstanceNotFoundException;
 import org.commcare.formplayer.exceptions.MenuNotFoundException;
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
+import org.commcare.formplayer.junit.FormDefSessionServiceExtension;
 import org.commcare.formplayer.junit.FormSessionServiceExtension;
 import org.commcare.formplayer.junit.InitializeStaticsExtension;
 import org.commcare.formplayer.objects.QueryData;
@@ -148,7 +149,11 @@ import lombok.extern.apachecommons.CommonsLog;
  */
 @CommonsLog
 @ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
-@ExtendWith({InitializeStaticsExtension.class, FormSessionServiceExtension.class})
+@ExtendWith({
+        InitializeStaticsExtension.class,
+        FormSessionServiceExtension.class,
+        FormDefSessionServiceExtension.class,
+})
 public class BaseTestClass {
 
     private MockMvc mockFormController;
@@ -250,7 +255,6 @@ public class BaseTestClass {
 
     protected ObjectMapper mapper;
 
-    final Map<Long, SerializableFormDefinition> formDefinitionMap = new HashMap<>();
     final Map<String, SerializableMenuSession> menuSessionMap = new HashMap<>();
     final Map<String, SerializableDataInstance> serializableDataInstanceMap = new HashMap();
     final Set<String> sessionSelectionsCache = new HashSet<>();
@@ -286,7 +290,6 @@ public class BaseTestClass {
         storageFactoryMock.getSQLiteDB().closeConnection();
         restoreFactoryMock.getSQLiteDB().closeConnection();
 
-        mockFormDefinitionService();
         mockMenuSessionService();
         mockVirtualDataInstanceService();
     }
@@ -307,54 +310,6 @@ public class BaseTestClass {
             String[] selections = (String[])invocation.getArguments()[0];
             return sessionSelectionsCache.contains(String.join("|", selections));
         }).when(restoreFactoryMock).isConfirmedSelection(any(String[].class));
-    }
-
-    /*
-     * Setup mocking for the FormDefinitionService that allows saving and retrieving form definitions.
-     * The 'persisted' definitions are cleared at the start of each test.
-     */
-    private void mockFormDefinitionService() {
-        formDefinitionMap.clear();
-        currentFormDefinitionId = 1L;
-        doAnswer(new Answer<SerializableFormDefinition>() {
-            @Override
-            public SerializableFormDefinition answer(InvocationOnMock invocation) throws Throwable {
-                String appId = ((String)invocation.getArguments()[0]);
-                String appVersion = ((String)invocation.getArguments()[1]);
-                String xmlns = ((String)invocation.getArguments()[2]);
-                for (SerializableFormDefinition tmp : formDefinitionMap.values()) {
-                    if (tmp.getAppId().equals(appId) && tmp.getFormXmlns().equals(xmlns)
-                            && tmp.getFormVersion().equals(appVersion)) {
-                        return tmp;
-                    }
-                }
-                // else create a new one
-                String serializedFormDef;
-                try {
-                    serializedFormDef = FormDefStringSerializer.serialize(((FormDef)invocation.getArguments()[3]));
-                } catch (IOException ex) {
-                    serializedFormDef = "could not serialize provided form def";
-                }
-                SerializableFormDefinition serializableFormDef = new SerializableFormDefinition(
-                        appId, appVersion, xmlns, serializedFormDef
-                );
-                if (serializableFormDef.getId() == null) {
-                    // this is normally taken care of by Hibernate
-                    ReflectionTestUtils.setField(serializableFormDef, "id", currentFormDefinitionId);
-                    currentFormDefinitionId++;
-                }
-                formDefinitionMap.put(serializableFormDef.getId(), serializableFormDef);
-                return serializableFormDef;
-            }
-        }).when(this.formDefinitionService).getOrCreateFormDefinition(
-                anyString(), anyString(), anyString(), any(FormDef.class)
-        );
-
-        when(this.formDefinitionService.getFormDef(any(SerializableFormSession.class))).thenCallRealMethod();
-        when(this.formDefinitionService.cacheFormDef(any(FormSession.class))).thenCallRealMethod();
-
-        // manually wire this in. The autowiring doesn't work here since we've made it a mock
-        ReflectionTestUtils.setField(this.formDefinitionService, "caches", cacheManager);
     }
 
     private void mockVirtualDataInstanceService() {

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -19,6 +19,7 @@ import org.commcare.cases.model.Case;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
 import org.commcare.formplayer.beans.menus.QueryResponseBean;
+import org.commcare.formplayer.junit.RestoreFactoryAnswer;
 import org.commcare.formplayer.objects.QueryData;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;

--- a/src/test/java/org/commcare/formplayer/tests/SnapshotTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/SnapshotTests.java
@@ -34,7 +34,7 @@ public class SnapshotTests extends BaseTestClass {
         try {
             File destDirectory = new File(getDatabaseFolderRoot());
 
-            FileUtils.copyDirectory(new File(GenerateSnapshotDatabases.snapshotDbDirectory)
+            FileUtils.copyDirectory(new File("src/test/resources/snapshot/")
                     , destDirectory);
         } catch (IOException exception) {
             exception.printStackTrace();

--- a/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
+++ b/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
@@ -3,12 +3,26 @@ package org.commcare.formplayer.utils;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.commcare.formplayer.application.SQLiteProperties;
+import org.commcare.formplayer.application.UtilController;
+import org.commcare.formplayer.configuration.CacheConfiguration;
+import org.commcare.formplayer.junit.Installer;
+import org.commcare.formplayer.junit.RestoreFactoryExtension;
+import org.commcare.formplayer.junit.request.SyncDbRequest;
 import org.commcare.formplayer.sandbox.SqlSandboxUtils;
-import org.commcare.formplayer.tests.BaseTestClass;
-import org.junit.jupiter.api.BeforeEach;
+import org.commcare.formplayer.services.FormplayerLockRegistry;
+import org.commcare.formplayer.services.FormplayerStorageFactory;
+import org.commcare.formplayer.services.MenuSessionFactory;
+import org.commcare.formplayer.services.MenuSessionRunnerService;
+import org.commcare.formplayer.services.RestoreFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
 
 import java.io.File;
 
@@ -27,31 +41,36 @@ import java.io.File;
  * @author ctsims
  */
 @WebMvcTest
-public class GenerateSnapshotDatabases extends BaseTestClass {
+@ContextConfiguration(classes={TestContext.class, CacheConfiguration.class})
+@Import({UtilController.class})
+@TestPropertySource(properties={"sqlite.dataDir=src/test/resources/snapshot/"})
+public class GenerateSnapshotDatabases {
 
-    //This is the destination directory for the snapshot.
-    public static String snapshotDbDirectory = "src/test/resources/snapshot/";
+    static String a = "src/test/resources/snapshot/";
 
-    @Override
-    @BeforeEach
-    public void setUp() throws Exception {
-        super.setUp();
-        configureRestoreFactory("snapshot", "snapshot_test");
-    }
+    @Autowired
+    private MockMvc mockMvc;
 
-    protected String getDatabaseFolderRoot() {
-        return snapshotDbDirectory;
-    }
+    @Autowired
+    private RestoreFactory restoreFactory;
 
-    @Override
-    protected boolean removeDatabaseFoldersAfterTests() {
-        return false;
-    }
+    @Autowired
+    private FormplayerStorageFactory storageFactory;
 
-    @Override
-    protected String getMockRestoreFileName() {
-        return "sandbox_reference/user_restore.xml";
-    }
+    @Autowired
+    private MenuSessionFactory menuSessionFactory;
+
+    @Autowired
+    private MenuSessionRunnerService menuSessionRunnerService;
+
+    @MockBean
+    private FormplayerLockRegistry lockRegistry;
+
+    @RegisterExtension
+    static RestoreFactoryExtension restoreFactoryExt = new RestoreFactoryExtension.builder()
+            .withUser("snapshot_test").withDomain("snapshot")
+            .withRestorePath("sandbox_reference/user_restore.xml")
+            .build();
 
     @Test
     public void testCreateSnapshot() throws Exception {
@@ -63,8 +82,13 @@ public class GenerateSnapshotDatabases extends BaseTestClass {
             if (new File(SQLiteProperties.getDataDir()).exists()) {
                 fail("Couldn't remove existing snapshot assets");
             }
-            syncDb();
-            doInstall("sandbox_reference/snapshot.json");
+            new SyncDbRequest(mockMvc, restoreFactory).request();
+            new Installer(
+                    restoreFactory,
+                    storageFactory,
+                    menuSessionFactory,
+                    menuSessionRunnerService
+            ).doInstall("sandbox_reference/snapshot.json");
         }
     }
 

--- a/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
+++ b/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import org.commcare.formplayer.application.SQLiteProperties;
 import org.commcare.formplayer.application.UtilController;
 import org.commcare.formplayer.configuration.CacheConfiguration;
+import org.commcare.formplayer.junit.InitializeStaticsExtension;
 import org.commcare.formplayer.junit.Installer;
 import org.commcare.formplayer.junit.RestoreFactoryExtension;
 import org.commcare.formplayer.junit.request.SyncDbRequest;
@@ -15,6 +16,7 @@ import org.commcare.formplayer.services.MenuSessionFactory;
 import org.commcare.formplayer.services.MenuSessionRunnerService;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -44,6 +46,7 @@ import java.io.File;
 @ContextConfiguration(classes={TestContext.class, CacheConfiguration.class})
 @Import({UtilController.class})
 @TestPropertySource(properties={"sqlite.dataDir=src/test/resources/snapshot/"})
+@ExtendWith(InitializeStaticsExtension.class)
 public class GenerateSnapshotDatabases {
 
     static String a = "src/test/resources/snapshot/";

--- a/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
+++ b/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
@@ -43,9 +43,9 @@ import java.io.File;
  * @author ctsims
  */
 @WebMvcTest
-@ContextConfiguration(classes={TestContext.class, CacheConfiguration.class})
+@ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
 @Import({UtilController.class})
-@TestPropertySource(properties={"sqlite.dataDir=src/test/resources/snapshot/"})
+@TestPropertySource(properties = {"sqlite.dataDir=src/test/resources/snapshot/"})
 @ExtendWith(InitializeStaticsExtension.class)
 public class GenerateSnapshotDatabases {
 

--- a/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
+++ b/src/test/java/org/commcare/formplayer/utils/GenerateSnapshotDatabases.java
@@ -49,8 +49,6 @@ import java.io.File;
 @ExtendWith(InitializeStaticsExtension.class)
 public class GenerateSnapshotDatabases {
 
-    static String a = "src/test/resources/snapshot/";
-
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
+++ b/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
@@ -8,8 +8,8 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Multimap;
 
+import org.commcare.formplayer.junit.RestoreFactoryAnswer;
 import org.commcare.formplayer.services.RestoreFactory;
-import org.commcare.formplayer.tests.BaseTestClass;
 import org.commcare.formplayer.web.client.WebClient;
 import org.mockito.Mockito;
 import org.mockito.verification.VerificationMode;
@@ -45,7 +45,7 @@ public class MockRequestUtils {
      */
     public VerifiedMock mockRestore(String restoreFile) {
         Mockito.reset(restoreFactoryMock);
-        BaseTestClass.RestoreFactoryAnswer answer = new BaseTestClass.RestoreFactoryAnswer(restoreFile);
+        RestoreFactoryAnswer answer = new RestoreFactoryAnswer(restoreFile);
         Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
 
         return () -> {

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -54,7 +54,9 @@ public class TestContext {
 
     @Bean
     public SQLiteProperties sQLiteProperties() {
-        return new SQLiteProperties();
+        SQLiteProperties sqLiteProperties = new SQLiteProperties();
+        sqLiteProperties.setDataDir("testdbs/");
+        return sqLiteProperties;
     }
 
     @Bean

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -53,7 +53,7 @@ public class TestContext {
     }
 
     @Bean
-    public SQLiteProperties sQLiteProperties() {
+    public SQLiteProperties sqliteProperties() {
         SQLiteProperties sqLiteProperties = new SQLiteProperties();
         sqLiteProperties.setDataDir("testdbs/");
         return sqLiteProperties;

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.utils;
 
 import com.timgroup.statsd.StatsDClient;
 
+import org.commcare.formplayer.application.SQLiteProperties;
 import org.commcare.formplayer.installers.FormplayerInstallerFactory;
 import org.commcare.formplayer.mocks.MockLockRegistry;
 import org.commcare.formplayer.mocks.TestInstallService;
@@ -49,6 +50,11 @@ public class TestContext {
 
     public TestContext() {
         MockitoAnnotations.openMocks(this);
+    }
+
+    @Bean
+    public SQLiteProperties sQLiteProperties() {
+        return new SQLiteProperties();
     }
 
     @Bean


### PR DESCRIPTION
Easiest reviewed by commit

## Technical Summary
Our current controller tests mock the controller manually which does work but has some limitations (e.g. properties don't work https://github.com/dimagi/formplayer/pull/1209#discussion_r965834890).

See https://github.com/dimagi/formplayer/pull/1227/files#diff-a037efdee62087635e2f354d4f79a00fa76ec31beaabc7a2bcdbbbfe2aad389d for a test that actually uses this.

This PR makes a start to bring out tests inline with Spring testing patterns.

The primary change is to stop mocking the controllers and allow Spring to set them up:

```
@WebMvcTest
@ContextConfiguration(classes = [TestContext::class, CacheConfiguration::class])
@Import(FormController::class, FormSubmissionController::class)
class MediaCaptureTest {
```

This test uses the `@Import` annotation to bring the controllers under test into the web app context and have them configured by Sprint (technically you should be able to pass the controllers directly to the `@WebMvcTest` annotation but for some reason that isn't working).

The dependencies for the controllers (e.g. FormSessionService) are provided by the context classes passed to `@ContextConfiguration`.

With this setup all that's needed is configuring other mocks like `RestoreFactory`.

**Configuring mocks**
To handle this I've tried a different approach rather than having a very large base class that does all the setup. I've split the mock setup into separate classes for each mock and made them into Junit5 extensions which can be used to annotate the test class.

This allows us to keep the mock setup compartmentalised and also makes it possible to use only those that are needed for a test.

For convenience we can bundle a number of extension together using an annotation which I've done here (see `FormSessionTest`).

I have not attempted to change any other tests but I have replaced relevant parts of the `BaseTestClass` with the new mock setup classes to reduce code duplication.

**Making requests**
The other thing that I've done is to extract the code which makes the mock MVC requests into their own classes instead of using the generic methods in the base class which are complex and hard to follow. See the `org.commcare.formplayer.junit.request` package.


## Safety Assurance

### Safety story
Only affects tests

### QA Plan
If the build passes

### Special deploy instructions
- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
