### PR TITLE
move plugin versions to gradle.properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: 'adopt'
       - name: Setup config
         run: |
-          cp .github/gradle.properties.ci gradle.properties
+          cp .github/gradle.properties.ci $HOME/gradle.properties
       - name: Copy Test Resources
         uses: gradle/gradle-build-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ local.properties
 *.swp
 __pycache__
 dbs/*
-gradle.properties
 .java-version
 .python-version
 scripts/*.pyc

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ buildscript {
 }
 
 plugins {
-    id 'org.springframework.boot' version '2.7.3'
-    id "com.gorylenko.gradle-git-properties" version "2.4.1"
-    id "io.freefair.lombok" version "6.5.1"
-    id 'org.jetbrains.kotlin.jvm' version '1.7.10'
-    id 'org.jetbrains.kotlin.plugin.spring' version '1.7.10'
+    id 'org.springframework.boot'
+    id "com.gorylenko.gradle-git-properties"
+    id "io.freefair.lombok"
+    id 'org.jetbrains.kotlin.jvm'
+    id 'org.jetbrains.kotlin.plugin.spring'
 }
 
 springBoot {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+sprintBootPluginVersion=2.7.3
+gradleGitPropertiesPluginVersion=2.4.1
+lombokPluginVersion=6.5.1
+kotlinPluginVersion=1.7.10

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,3 @@
-include ':commcare'
-project(':commcare').projectDir = new File('libs/commcare')
-rootProject.name = 'formplayer'
 pluginManagement {
     plugins {
         id 'org.springframework.boot' version "${sprintBootPluginVersion}"
@@ -10,3 +7,6 @@ pluginManagement {
         id 'org.jetbrains.kotlin.plugin.spring' version "${kotlinPluginVersion}"
     }
 }
+include ':commcare'
+project(':commcare').projectDir = new File('libs/commcare')
+rootProject.name = 'formplayer'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,12 @@
 include ':commcare'
 project(':commcare').projectDir = new File('libs/commcare')
 rootProject.name = 'formplayer'
+pluginManagement {
+    plugins {
+        id 'org.springframework.boot' version "${sprintBootPluginVersion}"
+        id "com.gorylenko.gradle-git-properties" version "${gradleGitPropertiesPluginVersion}"
+        id "io.freefair.lombok" version "${lombokPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm' version "${kotlinPluginVersion}"
+        id 'org.jetbrains.kotlin.plugin.spring' version "${kotlinPluginVersion}"
+    }
+}


### PR DESCRIPTION
## Technical Summary

The main reason for this is to allow multiple plugin e.g. kotlin
to use the same version

https://github.com/dimagi/formplayer/pull/1231
https://github.com/dimagi/formplayer/pull/1232

## Safety Assurance

### Safety story
build change only, no code change

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
