### PR TITLE
[USH-2498] additional logging for lock errors

### DIFF
--- a/src/main/java/org/commcare/formplayer/aspects/LockAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/LockAspect.java
@@ -143,6 +143,9 @@ public class LockAspect {
             return lock;
         } else {
             log.info(String.format("Unable to obtain lock for username %s", username));
+            userLockRegistry.logLockError(lock, String.format(
+                    "Unable to obtain lock with lock key %s. expired=%s, lockTime=%s(s)",
+                    username, lock.isExpired(), lock.timeLocked()));
             throw new LockError();
         }
     }

--- a/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
@@ -96,13 +96,18 @@ public class FormplayerLockRegistry implements LockRegistry {
             throw new InterruptedRuntimeException(e);
         }
         if (ownerThread.isAlive()) {
-            log.warn(String.format(
-                "Unable to evict thread %s owning lock with lock key %s. expired=%s, lockTime=%s(s)",
+            logLockError(lock, String.format(
+                    "Unable to evict thread %s owning lock with lock key %s. expired=%s, lockTime=%s(s)",
                     ownerThread, lock.lockKey, lock.isExpired(), lock.timeLocked()));
-            Exception e = new Exception("Unable to get expired lock, owner thread has stack trace");
-            e.setStackTrace(ownerThread.getStackTrace());
-            FormplayerSentry.captureException(new Exception(e), SentryLevel.WARNING);
         }
+    }
+
+    public void logLockError(FormplayerReentrantLock lock, String logMessage) {
+        Thread ownerThread = lock.getOwner();
+        log.warn(logMessage);
+        Exception e = new Exception("Unable to get lock, owner thread has stack trace");
+        e.setStackTrace(ownerThread.getStackTrace());
+        FormplayerSentry.captureException(new Exception(e), SentryLevel.WARNING);
     }
 
     /**

--- a/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerLockRegistry.java
@@ -80,15 +80,15 @@ public class FormplayerLockRegistry implements LockRegistry {
                 return lock;
             }
             if (lock.isExpired()) {
-                evict(lock, lockKey);
+                evict(lock);
             }
             return lock;
         }
     }
 
-    private void evict(FormplayerReentrantLock lock, Object lockKey) {
+    private void evict(FormplayerReentrantLock lock) {
         Thread ownerThread = lock.getOwner();
-        log.warn(String.format("Thread %s owns expired lock with lock key %s.", ownerThread, lockKey));
+        log.warn(String.format("Thread %s owns expired lock with lock key %s.", ownerThread, lock.lockKey));
         ownerThread.interrupt();
         try {
             ownerThread.join(5000);
@@ -98,7 +98,7 @@ public class FormplayerLockRegistry implements LockRegistry {
         if (ownerThread.isAlive()) {
             log.warn(String.format(
                 "Unable to evict thread %s owning lock with lock key %s. expired=%s, lockTime=%s(s)",
-                    ownerThread, lockKey, lock.isExpired(), lock.timeLocked()));
+                    ownerThread, lock.lockKey, lock.isExpired(), lock.timeLocked()));
             Exception e = new Exception("Unable to get expired lock, owner thread has stack trace");
             e.setStackTrace(ownerThread.getStackTrace());
             FormplayerSentry.captureException(new Exception(e), SentryLevel.WARNING);
@@ -117,7 +117,7 @@ public class FormplayerLockRegistry implements LockRegistry {
             if (!existingLock.isLocked()) {
                 return false;
             } else {
-                evict(existingLock, key);
+                evict(existingLock);
                 return true;
             }
         }


### PR DESCRIPTION
## Technical Summary
Small refactor and additional sentry events for lock errors.

Currently lock errors are not logged in Sentry at all.

## Safety Assurance

### Safety story

### Automated test coverage
Not covered by tests

### QA Plan
I did some basic testing locally.


### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
