### PR TITLE
set action mode as true when we are in autoLaunch or input is action

### DIFF
--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -165,6 +165,11 @@ public class MenuSession implements HereFunctionHandlerListener {
                 EntityScreen entityScreen = (EntityScreen)screen;
                 boolean autoLaunch = entityScreen.getAutoLaunchAction() != null && allowAutoLaunch;
                 addBreadcrumb = !autoLaunch;
+
+                if (input.startsWith("action ") || autoLaunch){
+                    entityScreen.enableActionMode();
+                }
+
                 if (input.startsWith("action ") || (autoLaunch) || !inputValidated) {
                     screen.init(sessionWrapper);
                     if (screen.shouldBeSkipped()) {


### PR DESCRIPTION
## Technical Summary

Look at https://github.com/dimagi/commcare-core/pull/1153

### Automated test coverage

We have good number of tests covering case search workflows (See [CaseClaimNavigationTests](https://github.com/dimagi/formplayer/blob/master/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java) and [CaseClaimNavigationParentChildTests](https://github.com/dimagi/formplayer/blob/master/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationParentChildTests.java)

### QA Plan

Plans to get this through a Formplayer regression QA (ticket TBD)


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.


### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-requested: https://github.com/dimagi/commcare-core/pull/1153
