### PR TITLE
disable request retries for requests made from formplayer

### DIFF
--- a/src/main/java/org/commcare/formplayer/web/client/FormplayerOkHttp3ClientHttpRequestFactory.java
+++ b/src/main/java/org/commcare/formplayer/web/client/FormplayerOkHttp3ClientHttpRequestFactory.java
@@ -1,0 +1,15 @@
+package org.commcare.formplayer.web.client;
+
+import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+
+import okhttp3.OkHttpClient;
+
+/**
+ * Custom OkHttp request factor that disables retries on connection failures.
+ */
+public class FormplayerOkHttp3ClientHttpRequestFactory extends OkHttp3ClientHttpRequestFactory {
+
+    public FormplayerOkHttp3ClientHttpRequestFactory() {
+        super(new OkHttpClient.Builder().retryOnConnectionFailure(false).build());
+    }
+}

--- a/src/main/java/org/commcare/formplayer/web/client/RestTemplateConfig.java
+++ b/src/main/java/org/commcare/formplayer/web/client/RestTemplateConfig.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URISyntaxException;
@@ -43,7 +42,7 @@ public class RestTemplateConfig {
         builder = builder
                 .setConnectTimeout(Duration.ofMillis(Constants.CONNECT_TIMEOUT))
                 .setReadTimeout(Duration.ofMillis(Constants.READ_TIMEOUT))
-                .requestFactory(OkHttp3ClientHttpRequestFactory.class);
+                .requestFactory(FormplayerOkHttp3ClientHttpRequestFactory.class);
 
         if (externalRequestMode.equals(MODE_REPLACE_HOST)) {
             log.warn(String.format("RestTemplate configured in '%s' mode", externalRequestMode));


### PR DESCRIPTION
## Technical Summary
Currently if a request for Formplayer to HQ fails due to a 'connection error' e.g. timeout, the underlying HTTP library (OkHttp) will retry the request automatically (if the request meets certain criteria e.g. it's a GET request).

We have our timeouts set quite high and none of our requests can be retried exactly since they contain a unique 'Origin' header which is only valid for 60s.

## Safety Assurance

### Safety story
I will put this on staging for basic testing.

### Automated test coverage
None

### QA Plan
Staging smoke testing

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
