### PR TITLE
[USH-2498] skip fixture sync in case claim sync

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -497,7 +497,7 @@ public class MenuSessionRunnerService {
             throw new SyncRestoreException("Unknown error performing case claim", e);
         }
         if (shouldSync) {
-            restoreFactory.performTimedSync(false, false, false);
+            restoreFactory.performTimedSync(false, true, false);
             menuSession.getSessionWrapper().clearVolatiles();
         }
     }


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2498

## Technical Summary
After performing a successful case claim FP will do a sync to get the updated cases. During this sync it seems unnecessary to also include fixtures.

I have disabled this for all users but we could make it configurable with a FF or custom app property.

## Safety Assurance

### Safety story
In terms of code safety this is already used elsewhere.

I have confirmed with USH delivery team that this should not be an issue from a project workflow point of view (USH being the main users of web apps and case claim).

### Automated test coverage
None

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
