### PR TITLE
[USH-2523] limit the scope of the 'isDetailsSelection' to the selections it applies to

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -267,13 +267,18 @@ public class MenuSessionRunnerService {
             String selection = selections[i - 1];
 
             boolean inputValidated = restoreFactory.isConfirmedSelection(Arrays.copyOfRange(selections, 0, i));
-            boolean isDetailScreen = detailSelection != null;
 
-            // minimal entity screens are only safe if there will be no further selection
+            // A details request applies to the last entity screen which accounts for the last 2 selections:
+            // [..., command, case selection]
+            boolean isInDetailSelectionRange = i >= selections.length - 1;
+            boolean isDetailSelection = detailSelection != null && isInDetailSelectionRange;
+
+            // minimal entity screens are only safe if there will be no further selection,
             // and we do not need the case detail
-            boolean needsFullEntityScreen = isDetailScreen || i != selections.length;
+            boolean isLastSelection = i != selections.length;
+            boolean needsFullEntityScreen = isLastSelection || isDetailSelection;
             boolean gotNextScreen = menuSession.handleInput(selection, needsFullEntityScreen, inputValidated,
-                    true, selectedValues, isDetailScreen);
+                    true, selectedValues, isDetailSelection);
             if (!gotNextScreen) {
                 notificationMessage = new NotificationMessage(
                         "Overflowed selections with selection " + selection + " at index " + i,
@@ -285,7 +290,7 @@ public class MenuSessionRunnerService {
             Screen nextScreen;
             try {
                 nextScreen = autoAdvanceSession(menuSession, selection, nextInput, queryData,
-                        needsFullEntityScreen, inputValidated, forceManualAction, isDetailScreen);
+                        needsFullEntityScreen, inputValidated, forceManualAction, isDetailSelection);
             } catch (CommCareSessionException e) {
                 notificationMessage = new NotificationMessage(e.getMessage(), true, NotificationMessage.Tag.query);
                 break;


### PR DESCRIPTION
Jira: https://dimagi-dev.atlassian.net/browse/USH-2523

This is an alternative approach to https://github.com/dimagi/formplayer/pull/1244


## Technical Summary

A details request only applies to the last entity screen which accounts for the last 2 selections: [...., command, detail selection]

This changes the value of `isDetailSelection` to only be True for the last and 2nd last selections in the list. This var is only used to determine how the Entity screen is initialized. I expect that this should results in some improvement to performance when there are multiple entity screens in the session.

## Safety Assurance

### Safety story
This aught to be safe given that this only applies to details requests which come after a normal case list request. The logic here is that both those requests should behave the same if the entity screen is not the current one. The bug in the ticket is because the details request was behaving differently.

### Automated test coverage
TODO

### QA Plan
TODO

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
