### PR TITLE
Only process entities on current page

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.beans.menus;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import org.commcare.cases.entity.Entity;
 import org.commcare.core.graph.model.GraphData;
 import org.commcare.core.graph.util.GraphException;
 import org.commcare.formplayer.util.FormplayerGraphUtil;
@@ -77,8 +78,9 @@ public class EntityDetailResponse {
             EvaluationContext ec,
             String title,
             boolean isFuzzySearchEnabled) {
-        List<EntityBean> entityList = EntityListResponse.processEntitiesForCaseList(detail,
-                references, ec, null, null, 0, isFuzzySearchEnabled);
+        List<Entity<TreeReference>> entityRefs = EntityListResponse.buildEntityList(detail, ec, references, null,
+                0, isFuzzySearchEnabled);
+        List<EntityBean> entityList = EntityListResponse.processEntitiesForCaseList(detail, entityRefs, ec, null);
         this.entities = new EntityBean[entityList.size()];
         entityList.toArray(this.entities);
         this.title = title;

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -96,7 +96,7 @@ public class EntityListResponse extends MenuBean {
             entities = processEntitiesForCaseDetail(detail, reference, ec, neededDatum);
         } else {
             Vector<TreeReference> references = nextScreen.getReferences();
-            List<EntityBean> entityList = processEntitiesForCaseList(detail, references, ec,
+            List<EntityBean> entityBeans = processEntitiesForCaseList(detail, references, ec,
                     searchText, neededDatum, sortIndex, isFuzzySearchEnabled);
 
             if (casesPerPage == 0) {
@@ -104,14 +104,14 @@ public class EntityListResponse extends MenuBean {
             }
             casesPerPage = Math.min(casesPerPage, MAX_CASES_PER_PAGE);
 
-            if (entityList.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
+            if (entityBeans.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
                 // we're doing pagination
                 setCurrentPage(offset / casesPerPage);
-                setPageCount((int)Math.ceil((double)entityList.size() / casesPerPage));
-                entityList = paginateEntities(entityList, casesPerPage, offset);
+                setPageCount((int)Math.ceil((double)entityBeans.size() / casesPerPage));
+                entityBeans = paginateEntities(entityBeans, casesPerPage, offset);
             }
-            entities = new EntityBean[entityList.size()];
-            entityList.toArray(entities);
+            entities = new EntityBean[entityBeans.size()];
+            entityBeans.toArray(entities);
         }
 
         processTitle(session);

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -104,14 +104,9 @@ public class EntityListResponse extends MenuBean {
             }
             casesPerPage = Math.min(casesPerPage, MAX_CASES_PER_PAGE);
 
-            if (entityBeans.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
-                // we're doing pagination
-                setCurrentPage(offset / casesPerPage);
-                setPageCount((int)Math.ceil((double)entityBeans.size() / casesPerPage));
-                entityBeans = getEntitiesForCurrentPage(entityBeans, casesPerPage, offset);
-            }
-            entities = new EntityBean[entityBeans.size()];
-            entityBeans.toArray(entities);
+            List<EntityBean> entitesForPage = paginateEntities(entityBeans, detail, casesPerPage, offset);
+            entities = new EntityBean[entitesForPage.size()];
+            entitesForPage.toArray(entities);
         }
 
         processTitle(session);
@@ -127,6 +122,8 @@ public class EntityListResponse extends MenuBean {
         }
         setQueryKey(session.getCommand());
     }
+
+
 
     private void processCaseTiles(Detail shortDetail) {
         DetailField[] fields = shortDetail.getFields();
@@ -188,6 +185,18 @@ public class EntityListResponse extends MenuBean {
         }
         return full;
     }
+
+    private List<EntityBean> paginateEntities(
+            List<EntityBean> entityBeans, Detail detail, int casesPerPage, int offset) {
+        if (entityBeans.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
+            // we're doing pagination
+            setCurrentPage(offset / casesPerPage);
+            setPageCount((int)Math.ceil((double)entityBeans.size() / casesPerPage));
+            return getEntitiesForCurrentPage(entityBeans, casesPerPage, offset);
+        }
+        return entityBeans;
+    }
+
 
     @Trace
     private List<EntityBean> getEntitiesForCurrentPage(List<EntityBean> matched, int casesPerPage,

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -108,7 +108,7 @@ public class EntityListResponse extends MenuBean {
                 // we're doing pagination
                 setCurrentPage(offset / casesPerPage);
                 setPageCount((int)Math.ceil((double)entityBeans.size() / casesPerPage));
-                entityBeans = paginateEntities(entityBeans, casesPerPage, offset);
+                entityBeans = getEntitiesForCurrentPage(entityBeans, casesPerPage, offset);
             }
             entities = new EntityBean[entityBeans.size()];
             entityBeans.toArray(entities);
@@ -190,7 +190,7 @@ public class EntityListResponse extends MenuBean {
     }
 
     @Trace
-    private List<EntityBean> paginateEntities(List<EntityBean> matched, int casesPerPage,
+    private List<EntityBean> getEntitiesForCurrentPage(List<EntityBean> matched, int casesPerPage,
             int offset) {
         if (offset > matched.size()) {
             throw new RuntimeException("Pagination offset " + offset +

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -104,7 +104,8 @@ public class EntityListResponse extends MenuBean {
             }
             casesPerPage = Math.min(casesPerPage, MAX_CASES_PER_PAGE);
 
-            List<Entity<TreeReference>> entitesForPage = paginateEntities(entityList, detail, casesPerPage, offset);
+            List<Entity<TreeReference>> entitesForPage = paginateEntities(entityList, detail, casesPerPage,
+                    offset);
             List<EntityBean> entityBeans = processEntitiesForCaseList(detail, entitesForPage, ec, neededDatum);
             entities = new EntityBean[entityBeans.size()];
             entityBeans.toArray(entities);
@@ -123,7 +124,6 @@ public class EntityListResponse extends MenuBean {
         }
         setQueryKey(session.getCommand());
     }
-
 
 
     private void processCaseTiles(Detail shortDetail) {
@@ -182,7 +182,7 @@ public class EntityListResponse extends MenuBean {
         return full;
     }
 
-    private  List<Entity<TreeReference>> paginateEntities(
+    private List<Entity<TreeReference>> paginateEntities(
             List<Entity<TreeReference>> entityList, Detail detail, int casesPerPage, int offset) {
         if (entityList.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
             // we're doing pagination
@@ -195,7 +195,8 @@ public class EntityListResponse extends MenuBean {
 
 
     @Trace
-    private List<Entity<TreeReference>> getEntitiesForCurrentPage(List<Entity<TreeReference>> matched, int casesPerPage,
+    private List<Entity<TreeReference>> getEntitiesForCurrentPage(List<Entity<TreeReference>> matched,
+            int casesPerPage,
             int offset) {
         if (offset > matched.size()) {
             throw new RuntimeException("Pagination offset " + offset +

--- a/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import org.commcare.formplayer.beans.menus.EntityBean;
@@ -9,13 +10,11 @@ import org.commcare.formplayer.beans.menus.EntityListResponse;
 import org.commcare.formplayer.mocks.FormPlayerPropertyManagerMock;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sqlitedb.SQLiteDB;
-import org.commcare.formplayer.utils.TestContext;
 import org.javarosa.core.services.PropertyManager;
 import org.javarosa.core.services.properties.Property;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ContextConfiguration;
 
 /**
  * Created by willpride on 5/16/16.
@@ -68,9 +67,14 @@ public class CasePaginationTests extends BaseTestClass {
         EntityListResponse entityListResponse2 =
                 sessionNavigate("requests/navigators/pagination_navigator_1.json",
                         EntityListResponse.class);
-        assert entityListResponse2.getEntities().length == 12;
+        EntityBean[] responseEntities = entityListResponse2.getEntities();
+        assert responseEntities.length == 12;
         assert entityListResponse2.getCurrentPage() == 4;
         assert entityListResponse2.getPageCount() == 5;
+
+        // check the order of entities is correct
+        assertEquals(responseEntities[0].getData()[0], "Test 1");
+        assertEquals(responseEntities[11].getData()[0], "Yoi");
 
         EntityDetailListResponse details2 =
                 getDetails("requests/get_details/pagination_navigator_details_1.json",
@@ -126,8 +130,13 @@ public class CasePaginationTests extends BaseTestClass {
         EntityListResponse entityListResponse =
                 sessionNavigate("requests/navigators/search_paginate_navigator.json",
                         EntityListResponse.class);
-        assert entityListResponse.getEntities().length == 5;
+        EntityBean[] responseEntities = entityListResponse.getEntities();
+        assert responseEntities.length == 5;
         assert entityListResponse.getPageCount() == 2;
         assert entityListResponse.getCurrentPage() == 1;
+
+        // check the order of entities is correct
+        assertEquals(responseEntities[0].getData()[0], "Test");
+        assertEquals(responseEntities[4].getData()[0], "Test123456");
     }
 }


### PR DESCRIPTION
## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-2536

[Sentry](https://sentry.io/organizations/dimagi/discover/formplayer:7db9f17eb5274a789549f46dc1bc4497/?environment=production&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project=142105&query=domain%3Aco-carecoordination-test&sort=-timestamp&statsPeriod=14d&yAxis=count%28%29)

From the sentry it looks like the owner thread is busy calculating case list fields for the screen.  This PR addresses the performance here by only calculating the entity fields for entities which are part of the current page as we don't really need to calculate fields for entities that we don't show. 

## Safety Assurance

### Safety story

- Probably affect all web apps with paginated entity lists
- Tested on staging to see nothing breaks

### Automated test coverage

We do have coverage for [pagination](https://github.com/dimagi/formplayer/blob/paginationPerformance/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java) which seem sufficient enough

### QA Plan

Not planning QA as we have good test coverage. 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
