### PR TITLE
Added 3-second bucket to datadog timings

### DIFF
--- a/src/main/java/org/commcare/formplayer/util/Timing.java
+++ b/src/main/java/org/commcare/formplayer/util/Timing.java
@@ -32,6 +32,8 @@ public abstract class Timing {
             return "lt_060s";
         } else if (timeInSeconds < 120) {
             return "lt_120s";
+        } else if (timeInSeconds < 180) {
+            return "lt_180s";
         } else if (timeInSeconds < 300) {
             return "lt_300s";
         } else if (timeInSeconds < 600) {

--- a/src/main/java/org/commcare/formplayer/util/Timing.java
+++ b/src/main/java/org/commcare/formplayer/util/Timing.java
@@ -24,6 +24,8 @@ public abstract class Timing {
     public static String getDurationBucket(long timeInSeconds) {
         if (timeInSeconds < 1) {
             return "lt_001s";
+        } else if (timeInSeconds < 3) {
+            return "lt_003s";
         } else if (timeInSeconds < 5) {
             return "lt_005s";
         } else if (timeInSeconds < 20) {
@@ -32,8 +34,6 @@ public abstract class Timing {
             return "lt_060s";
         } else if (timeInSeconds < 120) {
             return "lt_120s";
-        } else if (timeInSeconds < 180) {
-            return "lt_180s";
         } else if (timeInSeconds < 300) {
             return "lt_300s";
         } else if (timeInSeconds < 600) {


### PR DESCRIPTION
## Technical Summary
https://dimagi-dev.atlassian.net/browse/SUPPORT-14952

This adds a 3-second bucket for datadog duration metrics.

## Safety Assurance

### Safety story
Pretty trivial

### Automated test coverage
No

### QA Plan
No

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
