### PR TITLE
Invalid offset fix for Cast List Pagination

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -186,7 +186,6 @@ public class EntityListResponse extends MenuBean {
             List<Entity<TreeReference>> entityList, Detail detail, int casesPerPage, int offset) {
         if (entityList.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
             // we're doing pagination
-            setCurrentPage(offset / casesPerPage);
             setPageCount((int)Math.ceil((double)entityList.size() / casesPerPage));
             return getEntitiesForCurrentPage(entityList, casesPerPage, offset);
         }
@@ -199,9 +198,10 @@ public class EntityListResponse extends MenuBean {
             int casesPerPage,
             int offset) {
         if (offset > matched.size()) {
-            throw new RuntimeException("Pagination offset " + offset +
-                    " exceeded case list length: " + matched.size());
+            // Set the offset to last page
+            offset = casesPerPage * (getPageCount() - 1);
         }
+        setCurrentPage(offset / casesPerPage);
 
         int end = offset + casesPerPage;
         int length = casesPerPage;

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -186,17 +186,16 @@ public class EntityListResponse extends MenuBean {
             List<Entity<TreeReference>> entityList, Detail detail, int casesPerPage, int offset) {
         if (entityList.size() > casesPerPage && !(detail.getNumEntitiesToDisplayPerRow() > 1)) {
             // we're doing pagination
-            setPageCount((int)Math.ceil((double)entityList.size() / casesPerPage));
             return getEntitiesForCurrentPage(entityList, casesPerPage, offset);
         }
         return entityList;
     }
 
-
     @Trace
     private List<Entity<TreeReference>> getEntitiesForCurrentPage(List<Entity<TreeReference>> matched,
             int casesPerPage,
             int offset) {
+        setPageCount((int)Math.ceil((double)matched.size() / casesPerPage));
         if (offset > matched.size()) {
             // Set the offset to last page
             offset = casesPerPage * (getPageCount() - 1);
@@ -209,7 +208,6 @@ public class EntityListResponse extends MenuBean {
             end = matched.size();
             length = end - offset;
         }
-        setPageCount((int)Math.ceil((double)matched.size() / casesPerPage));
         matched = matched.subList(offset, offset + length);
         return matched;
     }

--- a/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
@@ -139,4 +139,23 @@ public class CasePaginationTests extends BaseTestClass {
         assertEquals(responseEntities[0].getData()[0], "Test");
         assertEquals(responseEntities[4].getData()[0], "Test123456");
     }
+
+
+    // test with an offset greater that case list size
+    @Test
+    public void testInvalidOffsetPagination() throws Exception {
+        EntityListResponse entityListResponse =
+                sessionNavigate("requests/navigators/invalid_offset_paginate_navigator.json",
+                        EntityListResponse.class);
+        EntityBean[] responseEntities = entityListResponse.getEntities();
+        assert responseEntities.length == 5;
+        assert entityListResponse.getPageCount() == 2;
+
+        // We should be on the last page with offset > case list size
+        assert entityListResponse.getCurrentPage() == 1;
+
+        // check the order of entities is correct
+        assertEquals(responseEntities[0].getData()[0], "Test");
+        assertEquals(responseEntities[4].getData()[0], "Test123456");
+    }
 }

--- a/src/test/resources/requests/navigators/invalid_offset_paginate_navigator.json
+++ b/src/test/resources/requests/navigators/invalid_offset_paginate_navigator.json
@@ -1,0 +1,11 @@
+{
+  "username": "loaduser",
+  "password": "loadpass",
+  "domain": "loaddomain",
+  "app_id": "loadappid",
+  "selections": [2, 1],
+  "search_text": "t",
+  "offset": 1000,
+  "cases_per_page": 15,
+  "installReference": "archives/basic.ccz"
+}


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

Currently when offset is greater than case list size we were crashing with the [exception](https://sentry.io/organizations/dimagi/issues/3677557689/?project=142105&query=is%3Aunresolved). I am not sure why it happens but it seems reasonable to reset offset to the last page when it's off the bounds like this. 

## Safety Assurance

### Automated test coverage

Added an automated test to test for this particular case

### QA Plan

No QA


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
