### PR TITLE
More optimisations for Entity list performance

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
@@ -80,7 +80,7 @@ public class EntityDetailResponse {
             boolean isFuzzySearchEnabled) {
         List<Entity<TreeReference>> entityRefs = EntityListResponse.buildEntityList(detail, ec, references, null,
                 0, isFuzzySearchEnabled);
-        List<EntityBean> entityList = EntityListResponse.processEntitiesForCaseList(detail, entityRefs, ec, null);
+        List<EntityBean> entityList = EntityListResponse.processEntitiesForCaseList(entityRefs, ec, null);
         this.entities = new EntityBean[entityList.size()];
         entityList.toArray(this.entities);
         this.title = title;

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -154,7 +154,7 @@ public class EntityListResponse extends MenuBean {
 
     private static EntityBean[] processEntitiesForCaseDetail(Detail detail, TreeReference reference,
             EvaluationContext ec, EntityDatum neededDatum) {
-        return new EntityBean[]{processEntity(detail, reference, ec, neededDatum)};
+        return new EntityBean[]{evalEntity(detail, reference, ec, neededDatum)};
     }
 
     @Trace
@@ -271,6 +271,7 @@ public class EntityListResponse extends MenuBean {
         }
     }
 
+    // Converts the Given Entity to EntityBean
     @Trace
     private static EntityBean toEntityBean(Entity<TreeReference> entity,
             EvaluationContext ec, EntityDatum neededDatum) {
@@ -297,8 +298,9 @@ public class EntityListResponse extends MenuBean {
         }
     }
 
+    // Evaluates detail fields for the given entity reference and returns it as EntityBean
     @Trace
-    private static EntityBean processEntity(Detail detail, TreeReference treeReference,
+    private static EntityBean evalEntity(Detail detail, TreeReference treeReference,
             EvaluationContext ec, EntityDatum neededDatum) {
         EvaluationContext context = new EvaluationContext(ec, treeReference);
         detail.populateEvaluationContextVariables(context);

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -276,8 +276,7 @@ public class EntityListResponse extends MenuBean {
             EvaluationContext ec, EntityDatum neededDatum) {
         Object[] entityData = entity.getData();
         Object[] data = new Object[entityData.length];
-        String id = neededDatum == null ? "" : EntityScreen.getReturnValueFromSelection(
-                entity.getElement(), neededDatum, ec);
+        String id = getEntityId(entity.getElement(), neededDatum, ec);
         EntityBean ret = new EntityBean(id);
         for (int i = 0; i < entityData.length; i++) {
             data[i] = processData(entityData[i]);
@@ -305,8 +304,7 @@ public class EntityListResponse extends MenuBean {
         detail.populateEvaluationContextVariables(context);
         DetailField[] fields = detail.getFields();
         Object[] data = new Object[fields.length];
-        String id = neededDatum == null ? "" : EntityScreen.getReturnValueFromSelection(
-                treeReference, neededDatum, ec);
+        String id = getEntityId(treeReference, neededDatum, ec);
         EntityBean ret = new EntityBean(id);
         int i = 0;
         for (DetailField field : fields) {
@@ -316,6 +314,11 @@ public class EntityListResponse extends MenuBean {
         }
         ret.setData(data);
         return ret;
+    }
+
+    private static String getEntityId(TreeReference treeReference, EntityDatum neededDatum, EvaluationContext ec) {
+        return neededDatum == null ? "" : EntityScreen.getReturnValueFromSelection(
+                treeReference, neededDatum, ec);
     }
 
     private static Style[] processStyles(Detail detail) {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -310,17 +310,8 @@ public class EntityListResponse extends MenuBean {
         EntityBean ret = new EntityBean(id);
         int i = 0;
         for (DetailField field : fields) {
-            Object o;
-            o = field.getTemplate().evaluate(context);
-            if (o instanceof GraphData) {
-                try {
-                    data[i] = FormplayerGraphUtil.getHtml((GraphData)o, "").replace("\"", "'");
-                } catch (GraphException e) {
-                    data[i] = "<html><body>Error loading graph " + e + "</body></html>";
-                }
-            } else {
-                data[i] = o;
-            }
+            Object o = field.getTemplate().evaluate(context);
+            data[i] = processData(o);
             i++;
         }
         ret.setData(data);


### PR DESCRIPTION
## Technical Summary

We were calculating the display properties for Entities on the current page twice. Once as part of [buildEntityList](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java#L225) and then again while [processEntity](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java#L287) to build a `EntityBean`. This PR changes the code to directly take use of `Entity` object evaluated fields to build the `EntityBean`

## Safety Assurance

### Safety story

Mostly relying on unit test coverage

### Automated test coverage

A good number of navigation tests touches and tests over `EntityListResponse`

### QA Plan

None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
