### PR TITLE
[USH-2433] security config refactor

### DIFF
--- a/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
+++ b/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
@@ -124,16 +124,4 @@ public class WebSecurityConfig {
         filter.setRequiresAuthenticationRequestMatcher(new CommCareSessionAuthFilter.SessionAuthRequestMatcher());
         return filter;
     }
-
-    /**
-     * Temporary customization of the firewall to allow '//' in the URL.
-     * This should be removed once all 3rd party hosters have been given an opportunity
-     * to update their proxy configuration.
-     */
-    @Bean
-    public HttpFirewall allowDoubleSlashHttpFirewall() {
-        StrictHttpFirewall firewall = new StrictHttpFirewall();
-        firewall.setAllowUrlEncodedDoubleSlash(allowDoubleSlash);
-        return firewall;
-    }
 }

--- a/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
+++ b/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
@@ -1,22 +1,27 @@
 package org.commcare.formplayer.configuration;
 
+import static org.springframework.security.authorization.AuthorityAuthorizationManager.hasAuthority;
+
 import org.commcare.formplayer.auth.CommCareSessionAuthFilter;
 import org.commcare.formplayer.auth.HmacAuthFilter;
 import org.commcare.formplayer.services.FormSessionService;
 import org.commcare.formplayer.services.HqUserDetailsService;
 import org.commcare.formplayer.util.Constants;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
@@ -25,8 +30,7 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
 
 @Configuration
-@EnableWebSecurity
-public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+public class WebSecurityConfig {
     @Autowired
     private HqUserDetailsService userDetailsService;
 
@@ -39,36 +43,64 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Value("${formplayer.allowDoubleSlash:true}")
     private boolean allowDoubleSlash;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         disableDefaults(http);
 
-        // no auth required for management endpoints
-        // (these are bound to a separate HTTP port that is not publicly exposed)
-        http.authorizeRequests().requestMatchers(EndpointRequest.toAnyEndpoint()).permitAll();
+        http.authorizeHttpRequests(auth -> auth
+                // no auth required for management endpoints
+                // (these are bound to a separate HTTP port that is not publicly exposed)
+                .requestMatchers(EndpointRequest.toAnyEndpoint()).permitAll()
 
-        // not auth required
-        http
-            .authorizeRequests()
-            .antMatchers("/serverup", "/favicon.ico")
-            .permitAll();
+                // not auth required
+                .antMatchers("/serverup", "/favicon.ico").permitAll()
 
-        // relaxed auth (only require HMAC but not user details)
-        http
-            .authorizeRequests()
-            .antMatchers("/validate_form")
-            .access("isAuthenticated() or hasAuthority('" + Constants.AUTHORITY_COMMCARE + "')");
+                // validate form auth
+                .antMatchers("/validate_form").access(getFormValidationAuthManager())
 
-        // full auth required
-        http.authorizeRequests().antMatchers("/**").authenticated();
+                // full auth required for all other requests
+                .anyRequest().authenticated()
+        );
+
+        // Configure the authentication manager with a provider that will use the
+        // ``HQUserDetailsService`` to authenticate the user
+        ProviderManager authenticationManager = getAuthManager();
+        http.authenticationManager(authenticationManager);
 
         // configure auth filters
         http.addFilterAt(getHmacAuthFilter(), UsernamePasswordAuthenticationFilter.class);
-        http.addFilterAfter(sessionAuthFilter(), HmacAuthFilter.class);
+        http.addFilterAfter(getSessionAuthFilter(authenticationManager), HmacAuthFilter.class);
         http.csrf()
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .ignoringRequestMatchers(new RequestHeaderRequestMatcher(Constants.HMAC_HEADER));
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .ignoringRequestMatchers(new RequestHeaderRequestMatcher(Constants.HMAC_HEADER));
         http.cors();
+
+        return http.build();
+    }
+
+    @NotNull
+    private ProviderManager getAuthManager() {
+        PreAuthenticatedAuthenticationProvider provider = new PreAuthenticatedAuthenticationProvider();
+        provider.setPreAuthenticatedUserDetailsService(userDetailsService);
+        return new ProviderManager(provider);
+    }
+
+    /**
+     * @return AuthroizationManager to authenticate 'validate_form' requests. These requests
+     *         have relaxed auth requirements of either an authenticated user or
+     *         any user with the 'COMMCARE' authority (this gets set by HMAC auth).
+     */
+    private AuthorizationManager<RequestAuthorizationContext> getFormValidationAuthManager() {
+        // "isAuthenticated() or hasAuthority('COMMCARE')"
+        return (authentication, request) -> {
+            AuthenticatedAuthorizationManager<Object> isAuthed = AuthenticatedAuthorizationManager.authenticated();
+            AuthorizationDecision authDecision = isAuthed.check(authentication, request);
+            if (authDecision.isGranted()) {
+                return authDecision;
+            }
+            return hasAuthority(Constants.AUTHORITY_COMMCARE).check(authentication, request);
+
+        };
     }
 
     private HmacAuthFilter getHmacAuthFilter() {
@@ -86,27 +118,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         http.httpBasic().disable();
     }
 
-    public CommCareSessionAuthFilter sessionAuthFilter() throws Exception {
+    public CommCareSessionAuthFilter getSessionAuthFilter(AuthenticationManager authenticationManager) throws Exception {
         CommCareSessionAuthFilter filter = new CommCareSessionAuthFilter();
-        filter.setAuthenticationManager(authenticationManagerBean());
+        filter.setAuthenticationManager(authenticationManager);
         filter.setRequiresAuthenticationRequestMatcher(new CommCareSessionAuthFilter.SessionAuthRequestMatcher());
         return filter;
-    }
-
-    /**
-     * Configure the authentication manager with a provider that will use the
-     * ``HQUserDetailsService`` to authenticate the user.
-     */
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        PreAuthenticatedAuthenticationProvider provider = new PreAuthenticatedAuthenticationProvider();
-        provider.setPreAuthenticatedUserDetailsService(userDetailsService);
-        auth.authenticationProvider(provider);
-    }
-
-    @Override
-    public void configure(WebSecurity web) throws Exception {
-        web.httpFirewall(allowDoubleSlashHttpFirewall());
     }
 
     /**
@@ -119,11 +135,5 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         StrictHttpFirewall firewall = new StrictHttpFirewall();
         firewall.setAllowUrlEncodedDoubleSlash(allowDoubleSlash);
         return firewall;
-    }
-
-    @Bean
-    @Override
-    public AuthenticationManager authenticationManagerBean() throws Exception {
-        return super.authenticationManagerBean();
     }
 }

--- a/src/test/java/org/commcare/formplayer/auth/HmacAuthTests.java
+++ b/src/test/java/org/commcare/formplayer/auth/HmacAuthTests.java
@@ -67,9 +67,9 @@ public class HmacAuthTests {
         MockHttpServletRequestBuilder builder = getRelaxedEndpointRequestBuilder()
                 .header(Constants.HMAC_HEADER, hmac);
         this.testEndpoint(builder,
+                status().isOk(),
                 jsonPath("$.validated", is(true)),
-                jsonPath("$.problems", hasSize(0)),
-                status().isOk()
+                jsonPath("$.problems", hasSize(0))
         );
     }
 


### PR DESCRIPTION
## Technical Summary
Jira: https://dimagi-dev.atlassian.net/browse/USH-2433

Migrate Spring security setup to stop using `WebSecurityConfigurerAdapter` which has been deprecated: https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter

This also removes the support for URLs prefixed with double slash. This change was made to the proxy in March 2021: https://github.com/dimagi/commcare-cloud/pull/4584

## Safety Assurance

### Safety story
This is a pure refactor but it is a complex part of the code due to how security is configured so this will be tested on staging before being rolled out.

### Automated test coverage
There are two sets of tests that test this config: `HmacAuthTests` and `SessionAuthTests`.

### QA Plan
Mostly passive testing on staging though a few aspects will need specific testing e.g. form validation, SMS forms.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
