### PR TITLE
Minor Fix for return value of new install

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -50,14 +50,12 @@ public class InstallService {
 
     @Trace
     public Pair<FormplayerConfigEngine, Boolean> configureApplication(String reference, boolean preview) throws Exception {
-        boolean newInstall = true;
         SQLiteDB sqliteDB = storageFactory.getSQLiteDB();
         log.info("Configuring application with reference " + reference +
                 " and dbPath: " + sqliteDB.getDatabaseFileForDebugPurposes() + " \n" +
                 "and storage factory \" + storageFactory");
         try {
             if (sqliteDB.databaseFileExists()) {
-                newInstall = false;
                 // If the SQLiteDB exists then this was not an update
                 // Try reusing old install, fail quietly
                 try {
@@ -91,7 +89,7 @@ public class InstallService {
             engine.initEnvironment();
             installTimer.end();
             installTimer.record();
-            return new Pair<>(engine, newInstall);
+            return new Pair<>(engine, true);
         } catch (UnresolvedResourceException e) {
             throw new UnresolvedResourceRuntimeException(e);
         } catch (Exception e) {

--- a/src/test/resources/restores/caseclaim.xml
+++ b/src/test/resources/restores/caseclaim.xml
@@ -225,7 +225,7 @@
         <create>
             <case_type>child_case</case_type>
             <case_name>The Dark Knight</case_name>
-            <owner_id>4bc2b147d2e03808b69351c6373defa0</owner_id>
+            <owner_id>47ef5ea3cc348fb6538702449c855dcd</owner_id>
         </create>
         <update>
             <date_opened>2021-02-03</date_opened>


### PR DESCRIPTION
## Technical Summary

When we fail to use the old ccz installation due to an [exception](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/services/InstallService.java#L70), we wipe out the old App DB and reinstall the ccz. Though we were not resetting `newInstall` to `true` and it was getting returned as `false` which doesn't seem right. 

The `newInstall` flag is used to do an [incremental sync](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/session/MenuSession.java#L122) later on in the function call chain. So this change will result into a  sync in cases when we we can't use the old App DB which seems like the right thing to happen.

## Safety Assurance

### Safety story

Local testing and it's a code path that is already in use for new app installs. Also putting it on staging for passive testing. 

### Automated test coverage

None. 

### QA Plan

No QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
