### PR TITLE
Avoid clearing App DB when clearing user data

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -98,7 +98,7 @@ public class UtilController {
                 requestBean.getDomain(),
                 requestBean.getUsername(),
                 requestBean.getRestoreAs()
-        ).deleteDatabaseFolder();
+        ).deleteDatabaseFile();
         NotificationMessage notificationMessage = new NotificationMessage(message, false, NotificationMessage.Tag.clear_data);
         notificationLogger.logNotification(notificationMessage, request);
         return notificationMessage;


### PR DESCRIPTION
## Technical Summary

We were Calling `deleteDatabaseFolder` for clear user data requests which deletes the parent folder for the User DB file. This parent folder also contains the App DB for CC App. This doesn't seem like intentional behaviour to clear App DBs when requesting delete for user data, therefore I think it's more apt to just call `deleteDatabaseFile` instead of `deleteDatabaseFolder`. 

Making this change although results in having no direct way to make users clear App DB in case of any bugs.  Although projects should still be able to release new updates on their app for FP users to refresh their App DBs.

## Safety Assurance

### Safety story

It should not result into any functional change for users except that FP will not request CC app again after clear user data. 

### Automated test coverage

None

### QA Plan

Not planning QA but would leave on staging for some time before merging.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
