### PR TITLE
[WIP] Unchain creation and persistence of session objects from ordering

### DIFF
--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -25,6 +25,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -96,12 +97,13 @@ public class FormSessionRepoTest {
     @Test
     public void testGetListView_Ordering() {
         // create and save 3 sessions, reverse order of creation, extract IDs
-        Iterator<String> sessionIdIterator = Stream.of(getSession(), getSession(),
-                getSession()).map((session) -> {
+        List<SerializableFormSession> sessions = Arrays.asList(getSession(), getSession(),
+                getSession());
+        for(SerializableFormSession session: sessions)
             formSessionRepo.save(session);
-            return session;
-        }).map(SerializableFormSession::getId).collect(Collectors.toCollection(LinkedList::new))
-                .descendingIterator();
+
+        Iterator<String> sessionIdIterator = sessions.stream().map(SerializableFormSession::getId)
+                .collect(Collectors.toCollection(LinkedList::new)).descendingIterator();
         ArrayList<String> sessionIds = Lists.newArrayList(sessionIdIterator);
 
         List<FormSessionListView> userSessions =

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -99,8 +99,9 @@ public class FormSessionRepoTest {
         // create and save 3 sessions, reverse order of creation, extract IDs
         List<SerializableFormSession> sessions = Arrays.asList(getSession(), getSession(),
                 getSession());
-        for(SerializableFormSession session: sessions)
+        for (SerializableFormSession session: sessions) {
             formSessionRepo.save(session);
+        }
 
         Iterator<String> sessionIdIterator = sessions.stream().map(SerializableFormSession::getId)
                 .collect(Collectors.toCollection(LinkedList::new)).descendingIterator();

--- a/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
+++ b/src/test/java/org/commcare/formplayer/repo/FormSessionRepoTest.java
@@ -99,7 +99,7 @@ public class FormSessionRepoTest {
         // create and save 3 sessions, reverse order of creation, extract IDs
         List<SerializableFormSession> sessions = Arrays.asList(getSession(), getSession(),
                 getSession());
-        for (SerializableFormSession session: sessions) {
+        for (SerializableFormSession session : sessions) {
             formSessionRepo.save(session);
         }
 


### PR DESCRIPTION
## Product Description
This PR aims to reduce the flakiness of the FormSessionRepoTest.testGetListView_Ordering test. This test involves sorting session objects by their creation date, and it fails when there are matching dates as the order becomes somewhat unpredictable. It is worth noting that the test can still fail but it shouldn't be frequent and if it becomes relevant, another way to solve this could be to add another field to the ordering criteria.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story
This change consisted in unchaining the creation, persistence and sorting of the objects, which was previously done with a single stream, using a List.
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
