### PR TITLE
xpath mock request for testing

### DIFF
--- a/src/test/java/org/commcare/formplayer/junit/HasXPath.java
+++ b/src/test/java/org/commcare/formplayer/junit/HasXPath.java
@@ -1,0 +1,117 @@
+package org.commcare.formplayer.junit;
+
+import static org.hamcrest.Condition.matched;
+import static org.hamcrest.Condition.notMatched;
+
+import static javax.xml.xpath.XPathConstants.STRING;
+
+import org.hamcrest.Condition;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+
+import java.io.ByteArrayInputStream;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+/**
+ * Applies a Matcher to a given XML String, specified by an XPath expression.
+ */
+public class HasXPath extends TypeSafeDiagnosingMatcher<String> {
+
+    private final Matcher<String> valueMatcher;
+    private final String xpathString;
+    private final XPathExpression compiledXPath;
+
+    private static final Condition.Step<Object,String> NODE_EXISTS = nodeExists();
+
+    private HasXPath(String xPathExpression, Matcher<String> valueMatcher) {
+        this.compiledXPath = compiledXPath(xPathExpression, null);
+        this.xpathString = xPathExpression;
+        this.valueMatcher = valueMatcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(String item, Description mismatch) {
+        return evaluated(item, mismatch)
+                .and(NODE_EXISTS)
+                .matching(valueMatcher);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("an XML document string with XPath ").appendText(xpathString);
+        if (valueMatcher != null) {
+            description.appendText(" ").appendDescriptionOf(valueMatcher);
+        }
+    }
+
+    /**
+     * Creates a matcher of {@link java.lang.String}s that matches when the examined string has a value at the
+     * specified <code>xPath</code> that satisfies the specified <code>valueMatcher</code>.
+     * For example:
+     * <pre>assertThat(xmlString, hasXPath("/root/something[2]/cheese", equalTo("Cheddar")))</pre>
+     *
+     * @param xPath
+     *     the target xpath
+     * @param valueMatcher
+     *     matcher for the value at the specified xpath
+     */
+    public static Matcher<String> hasXPath(String xPath, Matcher<String> valueMatcher) {
+        return new HasXPath(xPath, valueMatcher);
+    }
+
+    private Condition<Object> evaluated(String item, Description mismatch) {
+        Document document;
+        try {
+            document = parseXml(item);
+        } catch (Exception e) {
+            mismatch.appendText(e.getMessage());
+            return notMatched();
+        }
+
+        try {
+            return matched(compiledXPath.evaluate(document, STRING), mismatch);
+        } catch (XPathExpressionException e) {
+            mismatch.appendText(e.getMessage());
+        }
+        return notMatched();
+    }
+
+    private static XPathExpression compiledXPath(String xPathExpression, NamespaceContext namespaceContext) {
+        try {
+            final XPath xPath = XPathFactory.newInstance().newXPath();
+            if (namespaceContext != null) {
+                xPath.setNamespaceContext(namespaceContext);
+            }
+            return xPath.compile(xPathExpression);
+        } catch (XPathExpressionException e) {
+            throw new IllegalArgumentException("Invalid XPath : " + xPathExpression, e);
+        }
+    }
+
+    private static Condition.Step<Object, String> nodeExists() {
+        return (value, mismatch) -> {
+            if (value == null) {
+                mismatch.appendText("xpath returned no results.");
+                return notMatched();
+            }
+            return matched(String.valueOf(value), mismatch);
+        };
+    }
+
+    protected Document parseXml(String xml) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder documentBuilder = factory.newDocumentBuilder();
+        InputSource inputSource = new InputSource(new ByteArrayInputStream(xml.getBytes()));
+        return documentBuilder.parse(inputSource);
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/HasXpath.java
+++ b/src/test/java/org/commcare/formplayer/junit/HasXpath.java
@@ -25,16 +25,16 @@ import javax.xml.xpath.XPathFactory;
 /**
  * Applies a Matcher to a given XML String, specified by an XPath expression.
  */
-public class HasXPath extends TypeSafeDiagnosingMatcher<String> {
+public class HasXpath extends TypeSafeDiagnosingMatcher<String> {
 
     private final Matcher<String> valueMatcher;
     private final String xpathString;
-    private final XPathExpression compiledXPath;
+    private final XPathExpression compiledXpath;
 
-    private static final Condition.Step<Object,String> NODE_EXISTS = nodeExists();
+    private static final Condition.Step<Object, String> NODE_EXISTS = nodeExists();
 
-    private HasXPath(String xPathExpression, Matcher<String> valueMatcher) {
-        this.compiledXPath = compiledXPath(xPathExpression, null);
+    private HasXpath(String xPathExpression, Matcher<String> valueMatcher) {
+        this.compiledXpath = compiledXpath(xPathExpression, null);
         this.xpathString = xPathExpression;
         this.valueMatcher = valueMatcher;
     }
@@ -65,8 +65,8 @@ public class HasXPath extends TypeSafeDiagnosingMatcher<String> {
      * @param valueMatcher
      *     matcher for the value at the specified xpath
      */
-    public static Matcher<String> hasXPath(String xPath, Matcher<String> valueMatcher) {
-        return new HasXPath(xPath, valueMatcher);
+    public static Matcher<String> hasXpath(String xPath, Matcher<String> valueMatcher) {
+        return new HasXpath(xPath, valueMatcher);
     }
 
     private Condition<Object> evaluated(String item, Description mismatch) {
@@ -79,14 +79,14 @@ public class HasXPath extends TypeSafeDiagnosingMatcher<String> {
         }
 
         try {
-            return matched(compiledXPath.evaluate(document, STRING), mismatch);
+            return matched(compiledXpath.evaluate(document, STRING), mismatch);
         } catch (XPathExpressionException e) {
             mismatch.appendText(e.getMessage());
         }
         return notMatched();
     }
 
-    private static XPathExpression compiledXPath(String xPathExpression, NamespaceContext namespaceContext) {
+    private static XPathExpression compiledXpath(String xPathExpression, NamespaceContext namespaceContext) {
         try {
             final XPath xPath = XPathFactory.newInstance().newXPath();
             if (namespaceContext != null) {

--- a/src/test/java/org/commcare/formplayer/junit/request/EvaluateXpathRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/EvaluateXpathRequest.kt
@@ -1,0 +1,43 @@
+package org.commcare.formplayer.junit.request
+
+import org.commcare.formplayer.beans.EvaluateXPathRequestBean
+import org.commcare.formplayer.beans.EvaluateXPathResponseBean
+import org.commcare.formplayer.objects.SerializableFormSession
+import org.commcare.formplayer.services.FormSessionService
+import org.commcare.formplayer.util.Constants
+import org.commcare.formplayer.utils.FileUtils
+import org.springframework.test.web.servlet.MockMvc
+
+/**
+ * Request class for making a mock 'evaluate-xpath' request
+ */
+class EvaluateXpathRequest(
+    mockMvc: MockMvc,
+    private val sessionId: String,
+    private val xpath: String,
+    private val formSessionService: FormSessionService
+) : MockRequest<EvaluateXPathRequestBean, EvaluateXPathResponseBean>(
+    mockMvc, Constants.URL_EVALUATE_XPATH, EvaluateXPathResponseBean::class
+) {
+
+    fun request(): Response<EvaluateXPathResponseBean> {
+        val bean = mapper.readValue(
+            FileUtils.getFile(this.javaClass, "requests/evaluate_xpath/evaluate_xpath.json"),
+            EvaluateXPathRequestBean::class.java
+        )
+        bean.sessionId = sessionId
+        bean.xpath = xpath
+        bean.debugOutputLevel = Constants.BASIC_NO_TRACE
+
+        populateFromSession(bean)
+        return requestWithBean(bean)
+    }
+
+    private fun populateFromSession(bean: EvaluateXPathRequestBean): EvaluateXPathRequestBean {
+        val session: SerializableFormSession = formSessionService.getSessionById(sessionId)
+        bean.username = session.username
+        bean.domain = session.domain
+        bean.sessionId = sessionId
+        return bean
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/MockRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/MockRequest.kt
@@ -1,0 +1,44 @@
+package org.commcare.formplayer.junit.request
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.commcare.formplayer.util.Constants
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import javax.servlet.http.Cookie
+import kotlin.reflect.KClass
+
+/**
+ * Base class for mock requests
+ */
+open class MockRequest<B, T : Any>(
+    private val mockMvc: MockMvc,
+    private val requestPath: String,
+    private val kClass: KClass<T>
+) {
+
+    internal val mapper = ObjectMapper()
+    open val defaultExpectations = arrayOf(MockMvcResultMatchers.status().isOk)
+
+    open fun requestWithBean(requestBean: B): Response<T> {
+        var path = requestPath
+        if (!path.startsWith("/")) {
+            path = "/$path"
+        }
+        val requestBuilder = getRequestBuilder(path, requestBean)
+        val response = mockMvc.perform(requestBuilder).andExpectAll(*defaultExpectations)
+        return Response(mapper, response, kClass)
+    }
+
+    open fun getRequestBuilder(requestPath: String, requestBean: B): MockHttpServletRequestBuilder {
+        return post(requestPath)
+            .contentType(MediaType.APPLICATION_JSON)
+            .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
+            .with(SecurityMockMvcRequestPostProcessors.csrf())
+            .with(SecurityMockMvcRequestPostProcessors.user("user"))
+            .content(mapper.writeValueAsString(requestBean))
+    }
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
@@ -1,6 +1,5 @@
 package org.commcare.formplayer.junit.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.commcare.formplayer.beans.NewFormResponse
 import org.commcare.formplayer.beans.NewSessionRequestBean
 import org.commcare.formplayer.util.Constants
@@ -8,23 +7,18 @@ import org.commcare.formplayer.utils.FileUtils
 import org.commcare.formplayer.web.client.WebClient
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito
-import org.springframework.http.MediaType
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
-import javax.servlet.http.Cookie
 
 /**
  * Request class for making a mock request that starts a new form session.
  */
 class NewFormRequest(
-    private val mockMvc: MockMvc,
+    mockMvc: MockMvc,
     private val webClientMock: WebClient,
     private val formPath: String
+    ) : MockRequest<NewSessionRequestBean, NewFormResponse>(
+    mockMvc, Constants.URL_NEW_SESSION, NewFormResponse::class
 ) {
-
-    private val mapper = ObjectMapper()
 
     fun request(requestPath: String): Response<NewFormResponse> {
         val requestPayload = FileUtils.getFile(this.javaClass, requestPath)
@@ -35,18 +29,9 @@ class NewFormRequest(
         return requestWithBean(newSessionRequestBean)
     }
 
-    fun requestWithBean(requestBean: NewSessionRequestBean): Response<NewFormResponse> {
+    override fun requestWithBean(requestBean: NewSessionRequestBean): Response<NewFormResponse> {
         Mockito.`when`(webClientMock.get(ArgumentMatchers.anyString()))
             .thenReturn(FileUtils.getFile(this.javaClass, formPath))
-
-        val response = mockMvc.perform(
-            post("/" + Constants.URL_NEW_SESSION)
-                .contentType(MediaType.APPLICATION_JSON)
-                .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf())
-                .with(SecurityMockMvcRequestPostProcessors.user("user"))
-                .content(mapper.writeValueAsString(requestBean))
-        ).andExpect(MockMvcResultMatchers.status().isOk)
-        return Response(mapper, response, NewFormResponse::class)
+        return super.requestWithBean(requestBean)
     }
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -1,40 +1,22 @@
 package org.commcare.formplayer.junit.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.commcare.formplayer.beans.SubmitRequestBean
 import org.commcare.formplayer.beans.SubmitResponseBean
 import org.commcare.formplayer.util.Constants
 import org.commcare.formplayer.utils.FileUtils
-import org.springframework.http.MediaType
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
-import javax.servlet.http.Cookie
 
 /**
  * Request class for making a mock request submits a form.
  */
-class SubmitFormRequest(private val mockMvc: MockMvc) {
-
-    private val mapper = ObjectMapper()
+class SubmitFormRequest(mockMvc: MockMvc) : MockRequest<SubmitRequestBean, SubmitResponseBean>(
+    mockMvc, Constants.URL_SUBMIT_FORM, SubmitResponseBean::class
+) {
 
     fun request(requestPath: String, sessionId: String): Response<SubmitResponseBean> {
         val requestPayload = FileUtils.getFile(this.javaClass, requestPath)
         val bean = mapper.readValue(requestPayload, SubmitRequestBean::class.java)
         bean.sessionId = sessionId
         return requestWithBean(bean)
-    }
-
-    fun requestWithBean(requestBean: SubmitRequestBean): Response<SubmitResponseBean> {
-        val response = mockMvc.perform(
-            post("/" + Constants.URL_SUBMIT_FORM)
-                .contentType(MediaType.APPLICATION_JSON)
-                .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf())
-                .with(SecurityMockMvcRequestPostProcessors.user("user"))
-                .content(mapper.writeValueAsString(requestBean))
-        ).andExpect(MockMvcResultMatchers.status().isOk)
-        return Response(mapper, response, SubmitResponseBean::class)
     }
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
@@ -1,23 +1,20 @@
 package org.commcare.formplayer.junit.request
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.commcare.formplayer.beans.SyncDbRequestBean
 import org.commcare.formplayer.beans.SyncDbResponseBean
 import org.commcare.formplayer.services.RestoreFactory
 import org.commcare.formplayer.util.Constants
-import org.springframework.http.MediaType
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers
-import javax.servlet.http.Cookie
 
 /**
  * Request class for making a mock syncdb request
  */
-class SyncDbRequest(private val mockMvc: MockMvc, private val restoreFactory: RestoreFactory) {
-
-    private val mapper = ObjectMapper()
+class SyncDbRequest(
+    mockMvc: MockMvc,
+    private val restoreFactory: RestoreFactory
+    ) : MockRequest<SyncDbRequestBean, SyncDbResponseBean>(
+    mockMvc, Constants.URL_SYNC_DB, SyncDbResponseBean::class
+) {
 
     fun request(): Response<SyncDbResponseBean> {
         val bean = SyncDbRequestBean()
@@ -25,17 +22,5 @@ class SyncDbRequest(private val mockMvc: MockMvc, private val restoreFactory: Re
         bean.username = restoreFactory.username
         bean.restoreAs = restoreFactory.asUsername
         return requestWithBean(bean)
-    }
-
-    fun requestWithBean(requestBean: SyncDbRequestBean): Response<SyncDbResponseBean> {
-        val response = mockMvc.perform(
-            post("/" + Constants.URL_SYNC_DB)
-                .contentType(MediaType.APPLICATION_JSON)
-                .cookie(Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
-                .with(SecurityMockMvcRequestPostProcessors.csrf())
-                .with(SecurityMockMvcRequestPostProcessors.user("user"))
-                .content(mapper.writeValueAsString(requestBean))
-        ).andExpect(MockMvcResultMatchers.status().isOk)
-        return Response(mapper, response, SyncDbResponseBean::class)
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.tests;
 
+import static org.commcare.formplayer.junit.HasXPath.hasXPath;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -7,6 +9,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -663,11 +666,12 @@ public class BaseTestClass {
      */
     protected void checkXpath(String sessionId, String xpath, String expectedValue)
             throws Exception {
-        EvaluateXPathResponseBean evaluateXpathResponseBean = evaluateXPath(sessionId, xpath);
-        assertEquals(Constants.ANSWER_RESPONSE_STATUS_POSITIVE, evaluateXpathResponseBean.getStatus());
-        String result = String.format(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result>%s</result>\n", expectedValue);
-        assertEquals(result, evaluateXpathResponseBean.getOutput());
+        new EvaluateXpathRequest(mockDebuggerController, sessionId, xpath, formSessionService)
+                .request()
+                .andExpectAll(
+                        jsonPath("status", equalTo(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)),
+                        jsonPath("output", hasXPath("/result", equalTo(expectedValue)))
+                );
     }
 
     <T> T getDetails(String requestPath, Class<T> clazz) throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -24,7 +24,6 @@ import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.beans.ChangeLocaleRequestBean;
 import org.commcare.formplayer.beans.DeleteApplicationDbsRequestBean;
 import org.commcare.formplayer.beans.EvaluateXPathMenuRequestBean;
-import org.commcare.formplayer.beans.EvaluateXPathRequestBean;
 import org.commcare.formplayer.beans.EvaluateXPathResponseBean;
 import org.commcare.formplayer.beans.FormEntryNavigationResponseBean;
 import org.commcare.formplayer.beans.FormEntryResponseBean;
@@ -50,6 +49,7 @@ import org.commcare.formplayer.installers.FormplayerInstallerFactory;
 import org.commcare.formplayer.junit.FormSessionTest;
 import org.commcare.formplayer.junit.Installer;
 import org.commcare.formplayer.junit.RestoreFactoryExtension;
+import org.commcare.formplayer.junit.request.EvaluateXpathRequest;
 import org.commcare.formplayer.junit.request.NewFormRequest;
 import org.commcare.formplayer.junit.request.SubmitFormRequest;
 import org.commcare.formplayer.junit.request.SyncDbRequest;
@@ -622,21 +622,9 @@ public class BaseTestClass {
     }
 
     EvaluateXPathResponseBean evaluateXPath(String sessionId, String xPath) throws Exception {
-        EvaluateXPathRequestBean evaluateXPathRequestBean = mapper.readValue(
-                FileUtils.getFile(this.getClass(), "requests/evaluate_xpath/evaluate_xpath.json"),
-                EvaluateXPathRequestBean.class
-        );
-        populateFromSession(evaluateXPathRequestBean, sessionId);
-        evaluateXPathRequestBean.setSessionId(sessionId);
-        evaluateXPathRequestBean.setXpath(xPath);
-        evaluateXPathRequestBean.setDebugOutputLevel(Constants.BASIC_NO_TRACE);
-        return generateMockQuery(
-                ControllerType.DEBUGGER,
-                RequestType.POST,
-                Constants.URL_EVALUATE_XPATH,
-                evaluateXPathRequestBean,
-                EvaluateXPathResponseBean.class
-        );
+        return new EvaluateXpathRequest(mockDebuggerController, sessionId, xPath, formSessionService)
+                .request()
+                .bean();
     }
 
     EvaluateXPathResponseBean evaluateMenuXpath(String requestPath) throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -1,6 +1,6 @@
 package org.commcare.formplayer.tests;
 
-import static org.commcare.formplayer.junit.HasXPath.hasXPath;
+import static org.commcare.formplayer.junit.HasXpath.hasXpath;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -670,7 +670,7 @@ public class BaseTestClass {
                 .request()
                 .andExpectAll(
                         jsonPath("status", equalTo(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)),
-                        jsonPath("output", hasXPath("/result", equalTo(expectedValue)))
+                        jsonPath("output", hasXpath("/result", equalTo(expectedValue)))
                 );
     }
 


### PR DESCRIPTION
## Technical Summary

This was prompted by https://github.com/dimagi/formplayer/pull/1285. In order to do better matching of XML responses there are 2 changes:

1. Create a new 'mock request' class for the `evaluate-xpath` request.
    This migrates that request to the new 'framework' and makes it possible to use
    result matchers on the response.
    
2. Create a Hamcrest Matcher for doing xpath matching on strings (the existing ones only operate on XML documents)

## Safety Assurance

### Safety story
Only impacts unit tests.


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
