### PR TITLE
Sets Java source and target to version 17

### DIFF
--- a/.github/gradle.properties.ci
+++ b/.github/gradle.properties.ci
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxPermSize=256m
+org.gradle.jvmargs=-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
       - name: Setup config
         run: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Formplayer is built via [Gradle](https://spring.io/guides/gs/gradle/) (wrapper f
 See also the [dev guide](DEV_GUIDE.md) for more resources to get started.
 
 ### Dependencies
-+ Java (OpenJDK 8)
++ Java (OpenJDK 17)
 + Formplayer caches session instances via Redis
 + Formplayer stores session instances via Postgres
 + Formplayer builds SQLite database for each restored user
@@ -82,9 +82,9 @@ Run `git submodule update --init`
 
 e.g. `no suitable constructor found for OutputFormat(Document)`
 
-You're likely running the wrong version of Java. Check with `java -version` which should show `1.8`
+You're likely running the wrong version of Java. Check with `java -version` which should show `17`
 
-- Install OpenJDK 8
+- Install OpenJDK 17
 - Configure gradle to use the new Java
   - Update `~/.gradle/gradle.properties` with `org.gradle.java.home=/JDK_PATH`
   - OR run append this to gradle commands: `-Dorg.gradle.java.home=/JDK_PATH`

--- a/build.gradle
+++ b/build.gradle
@@ -191,3 +191,9 @@ jacocoTestReport {
         html.enabled true
     }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ ext {
     shedlockVersion = '4.43.0'
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 idea {
     module {


### PR DESCRIPTION
## Product Description
This PR upgrades Java to version 17.

cross-request: https://github.com/dimagi/commcare-core/pull/1198

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
These changes are going to be subjected to Regression testing by the QA team.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->
- Ensure that Java 17 is installed
- Remove any references to JVM parameters _MaxPermSize_ or _PermSize_ from the environment configuration, these usually live in the _gradle.properties_ file. These options have been [removed in Java 17](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#removed-java-options)

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
