### PR TITLE
Jt/ush 2683 custom text for case list empty state

### DIFF
--- a/scripts/staging.yaml
+++ b/scripts/staging.yaml
@@ -49,10 +49,10 @@
 
 trunk: master
 name: autostaging
-branches:
+# branches:
 #   - java-17-update # Ahmad Dec 13
 submodules:
   libs/commcare:
     trunk: formplayer
-    branches:
+#     branches:
 #       - java-17-update # Ahmad Dec 13

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -526,7 +526,8 @@ public class EntityListResponse extends MenuBean {
         try {
             noItemsTextString = detail.getNoItemsText().evaluate();
         } catch (NoLocalizedTextException | NullPointerException e) {
-            noItemsTextString = "List is empty.";
+            String noItemsTextStringLegacy = "List is empty.";
+            return noItemsTextStringLegacy;
         }
         return noItemsTextString;
     }

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -517,7 +517,7 @@ public class EntityListResponse extends MenuBean {
         this.noItemsText = noItemsText;
     }
 
-    public String getNoItemsText(){
+    public String getNoItemsText() {
         return noItemsText;
     }
 

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -21,6 +21,7 @@ import org.commcare.util.screen.EntityScreen;
 import org.commcare.util.screen.MultiSelectEntityScreen;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.TreeReference;
+import org.javarosa.core.util.NoLocalizedTextException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,6 +45,7 @@ public class EntityListResponse extends MenuBean {
     private int numEntitiesPerRow;
     private boolean useUniformUnits;
     private int[] sortIndices;
+    private String noItemsText;
 
     private int pageCount;
     private int currentPage;
@@ -109,6 +111,7 @@ public class EntityListResponse extends MenuBean {
             List<EntityBean> entityBeans = processEntitiesForCaseList(entitesForPage, ec, neededDatum);
             entities = new EntityBean[entityBeans.size()];
             entityBeans.toArray(entities);
+            setNoItemsText(getNoItemsTextLocaleString(detail));
         }
 
         processTitle(session);
@@ -406,6 +409,7 @@ public class EntityListResponse extends MenuBean {
     @Override
     public String toString() {
         return "EntityListResponse [Title= " + getTitle() +
+                ", noItemsText=" + getNoItemsText() +
                 ", styles=" + Arrays.toString(styles) +
                 ", action=" + Arrays.toString(actions) +
                 ", parent=" + super.toString() +
@@ -507,5 +511,23 @@ public class EntityListResponse extends MenuBean {
 
     public void setMaxSelectValue(int maxSelectValue) {
         this.maxSelectValue = maxSelectValue;
+    }
+
+    private void setNoItemsText(String noItemsText) {
+        this.noItemsText = noItemsText;
+    }
+
+    public String getNoItemsText(){
+        return noItemsText;
+    }
+
+    private String getNoItemsTextLocaleString(Detail detail) {
+        String noItemsTextString;
+        try {
+            noItemsTextString = detail.getNoItemsText().evaluate();
+        } catch (NoLocalizedTextException | NullPointerException e) {
+            noItemsTextString = "List is empty.";
+        }
+        return noItemsTextString;
     }
 }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Related to HQ PR: https://github.com/dimagi/commcare-hq/pull/32491

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Spec](https://docs.google.com/document/d/1HXlCmBW19lsCfGIidZkge0LMI1m7c20wPgzp8uAZbL8/edit#heading=h.gkfaicygwvet)
[USH-2683](https://dimagi-dev.atlassian.net/browse/USH-2683?focusedCommentId=243779&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-243779)
## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Manual testing on local env. Will also go through QA.
Existing apps have `noItemsText` set as null resulting in error and returning default value.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

[QA Ticket](https://dimagi-dev.atlassian.net/browse/QA-4726?atlOrigin=eyJpIjoiMGU2YjRiZDM2YzAxNDI1MmFjYWYwMWMxNTRlMjVlZTkiLCJwIjoiaiJ9)
### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

When [HQ PR ](https://github.com/dimagi/commcare-hq/pull/32338) is deployed, future app builds will consist of a `no_items_text` node which will need to be correctly handled if this PR is reverted.
### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[USH-2683]: https://dimagi-dev.atlassian.net/browse/USH-2683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ