### PR TITLE
Dynamically Correct virtual instance reference

### DIFF
--- a/src/main/java/org/commcare/formplayer/objects/SerializableDataInstance.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableDataInstance.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.objects;
 
+import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.data.xml.VirtualInstances;
 import org.commcare.formplayer.util.Constants;
 import org.hibernate.annotations.CreationTimestamp;
@@ -95,10 +96,18 @@ public class SerializableDataInstance {
         if (!instanceId.equals(getInstanceId())) {
             root = TreeUtilities.renameInstance(root, instanceId);
         }
-        String refScheme = VirtualInstances.getReferenceScheme(getReference());
-        String referenceForInstanceId = VirtualInstances.getInstanceReference(refScheme, instanceId);
+        String reference = getReference();
+        String newReference;
+        if (CommCareInstanceInitializer.isNonUniqueReference(reference)) {
+            // If old reference shceme we don't wanna change anything
+            // should be removed once we migrate all instances to new unique reference scheme
+            newReference = reference;
+        } else {
+            String refScheme = VirtualInstances.getReferenceScheme(reference);
+            newReference = VirtualInstances.getInstanceReference(refScheme, instanceId);
+        }
         ExternalDataInstanceSource instanceSource = ExternalDataInstanceSource.buildVirtual(
-                        instanceId, root, referenceForInstanceId, isUseCaseTemplate(), key);
+                        instanceId, root, newReference, isUseCaseTemplate(), key);
         return instanceSource.toInstance();
     }
 }

--- a/src/main/java/org/commcare/formplayer/objects/SerializableDataInstance.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableDataInstance.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.objects;
 
+import org.commcare.data.xml.VirtualInstances;
 import org.commcare.formplayer.util.Constants;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.GenericGenerator;
@@ -94,9 +95,10 @@ public class SerializableDataInstance {
         if (!instanceId.equals(getInstanceId())) {
             root = TreeUtilities.renameInstance(root, instanceId);
         }
+        String refScheme = VirtualInstances.getReferenceScheme(getReference());
+        String referenceForInstanceId = VirtualInstances.getInstanceReference(refScheme, instanceId);
         ExternalDataInstanceSource instanceSource = ExternalDataInstanceSource.buildVirtual(
-                        instanceId, root, getReference(), isUseCaseTemplate(), key);
+                        instanceId, root, referenceForInstanceId, isUseCaseTemplate(), key);
         return instanceSource.toInstance();
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -687,11 +687,11 @@ public class BaseTestClass {
     }
 
     <T> T getDetails(String[] selections, String testName, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, null,  clazz, false);
+        return getDetails(selections, testName, null, null, clazz, false);
     }
 
     <T> T getDetails(String[] selections, String testName, QueryData queryData, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, queryData,  clazz, false);
+        return getDetails(selections, testName, null, queryData, clazz, false);
     }
 
     <T> T getDetails(String[] selections, String testName, String locale, QueryData queryData, Class<T> clazz,
@@ -715,7 +715,7 @@ public class BaseTestClass {
     }
 
     <T> T getDetailsInline(String[] selections, String testName, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, null,  clazz, true);
+        return getDetails(selections, testName, null, null, clazz, true);
     }
 
     <T> T sessionNavigate(String requestPath, Class<T> clazz) throws Exception {
@@ -1055,7 +1055,7 @@ public class BaseTestClass {
                 "instance('selected_cases')/results");
         assertEquals(evaluateXpathResponseBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
         for (int i = 0; i < expectedCases.length; i++) {
-            String xpathRef = "/result/results/value[" + (i+1) + "]";
+            String xpathRef = "/result/results/value[" + (i + 1) + "]";
             assertThat(evaluateXpathResponseBean.getOutput(), hasXpath(xpathRef, equalTo(expectedCases[i])));
         }
 

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.tests;
 
 import static org.commcare.formplayer.junit.HasXpath.hasXpath;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -1046,5 +1047,26 @@ public class BaseTestClass {
                 .as("check file extension: %s", path)
                 .anyMatch(path::endsWith);
         return true;
+    }
+
+    // Ensure that 'selected_cases' instance is populated correctly
+    protected void checkForSelectedEntitiesInstance(String sessionId, String[] expectedCases) throws Exception {
+        EvaluateXPathResponseBean evaluateXpathResponseBean = evaluateXPath(sessionId,
+                "instance('selected_cases')/results");
+        assertEquals(evaluateXpathResponseBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
+        for (int i = 0; i < expectedCases.length; i++) {
+            String xpathRef = "/result/results/value[" + (i+1) + "]";
+            assertThat(evaluateXpathResponseBean.getOutput(), hasXpath(xpathRef, equalTo(expectedCases[i])));
+        }
+
+    }
+
+    // Ensure that the instance datum is set correctly to the guid
+    protected void checkForSelectedEntitiesDatum(String sessionId, String guid) throws Exception {
+        EvaluateXPathResponseBean evaluateXpathResponseBean = evaluateXPath(sessionId,
+                "instance('commcaresession')/session/data/selected_cases");
+        assertEquals(evaluateXpathResponseBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
+        String result = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result>" + guid + "</result>\n";
+        assertEquals(evaluateXpathResponseBean.getOutput(), result);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.sun.media.jfxmedia.events.NewFrameEvent;
+
 import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
@@ -92,6 +94,17 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
         List<String> casesToBeClaimed = Arrays.asList("0156fa3e-093e-4136-b95c-01b13dae66c7",
                 "0156fa3e-093e-4136-b95c-01b13dae66c8");
         assertEquals(requestData.get("case_id"), casesToBeClaimed);
+
+        // Open a form and check the selected_values instance is correctly loaded
+        String guid = commandResponse.getSelections()[1];
+        selections = new String[]{"0", guid, "0"};
+        NewFormResponse newFormResponse = sessionNavigateWithQuery(selections,
+                APP_NAME,
+                null,
+                null,
+                NewFormResponse.class);
+        checkForSelectedEntitiesDatum(newFormResponse.getSessionId(), guid);
+        checkForSelectedEntitiesInstance(newFormResponse.getSessionId(), selectedValues);
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.sun.media.jfxmedia.events.NewFrameEvent;
-
 import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -1,25 +1,18 @@
 package org.commcare.formplayer.tests;
 
-import static org.commcare.formplayer.junit.HasXpath.hasXpath;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import org.commcare.formplayer.beans.EvaluateXPathResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
-import org.commcare.formplayer.junit.HasXpath;
 import org.commcare.formplayer.junit.RestoreFactoryAnswer;
-import org.commcare.formplayer.junit.request.EvaluateXpathRequest;
 import org.commcare.formplayer.mocks.FormPlayerPropertyManagerMock;
 import org.commcare.formplayer.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +64,7 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         selections = formResp.getSelections();
         NewFormResponse formRespUsingGuid = sessionNavigate(selections, APP, NewFormResponse.class);
         assertArrayEquals(formResp.getBreadcrumbs(), formRespUsingGuid.getBreadcrumbs());
-        checkForSelectedEntitiesDatum(formRespUsingGuid.getSessionId(), selections);
+        checkForSelectedEntitiesDatum(formRespUsingGuid.getSessionId(), selections[2]);
         checkForSelectedEntitiesInstance(formRespUsingGuid.getSessionId(), selectedValues);
     }
 
@@ -88,29 +81,6 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         } catch (Exception e) {
             fail("Session Navigation failed for pre-validated input", e);
         }
-    }
-
-
-    // Ensure that 'selected_cases' instance is populated correctly
-    private void checkForSelectedEntitiesInstance(String sessionId, String[] expectedCases) throws Exception {
-        EvaluateXPathResponseBean evaluateXpathResponseBean = evaluateXPath(sessionId,
-                "instance('selected_cases')/results");
-        assertEquals(evaluateXpathResponseBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
-        for (int i = 0; i < expectedCases.length; i++) {
-            String xpathRef = "/result/results[@id='selected_cases']/value[" + (i+1) + "]";
-            assertThat(evaluateXpathResponseBean.getOutput(), hasXpath(xpathRef, equalTo(expectedCases[i])));
-        }
-
-    }
-
-    // Ensure that the instance datum is set correctly to the guid
-    private void checkForSelectedEntitiesDatum(String sessionId, String[] selections) throws Exception {
-        EvaluateXPathResponseBean evaluateXpathResponseBean = evaluateXPath(sessionId,
-                "instance('commcaresession')/session/data/selected_cases");
-        assertEquals(evaluateXpathResponseBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
-        String guid = selections[selections.length - 1];
-        String result = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<result>" + guid + "</result>\n";
-        assertEquals(evaluateXpathResponseBean.getOutput(), result);
     }
 
     @Test
@@ -144,7 +114,7 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         assertTrue(submitResponse.getStatus().contentEquals("success"));
         NewFormResponse newFormResponse = getNextScreenForEofNavigation(submitResponse,
                 NewFormResponse.class);
-        checkForSelectedEntitiesDatum(newFormResponse.getSessionId(), newFormResponse.getSelections());
+        checkForSelectedEntitiesDatum(newFormResponse.getSessionId(), newFormResponse.getSelections()[2]);
         checkForSelectedEntitiesInstance(newFormResponse.getSessionId(), selectedValues);
     }
 

--- a/src/test/resources/archives/case_claim_with_multi_select/modules-1/forms-0.xml
+++ b/src/test/resources/archives/case_claim_with_multi_select/modules-1/forms-0.xml
@@ -9,6 +9,7 @@
 			</instance>
 			<instance src="jr://instance/casedb" id="casedb"/>
 			<instance src="jr://instance/session" id="commcaresession"/>
+			<instance id="selected_cases" src="jr://instance/selected-entities/selected_cases"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="welcome_message-label">
@@ -16,7 +17,7 @@
 					</text>
 				</translation>
 			</itext>
-		<bind calculate="instance('commcaresession')/session/data/case_id" nodeset="/data/case/@case_id"/></model>
+		</model>
 	</h:head>
 	<h:body>
 		<trigger ref="/data/welcome_message" appearance="minimal">


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/USH-2790

## Technical Summary

Corrects instance reference as per the instanceId given while reading the instance from the guid. 

## Safety Assurance

### Safety story

- We have a good coverage on unit tests around virtual instances workflows
- It's a no-op for old reference scheme which is currently used 

### Automated test coverage

PR adds tests to verify the problematic behaviour this change is targetted towards. 

### QA Plan

Will be QA'ed as part of https://dimagi-dev.atlassian.net/browse/USH-2084 in 
https://dimagi-dev.atlassian.net/browse/QA-1096


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/commcare-core/pull/1211
