### PR TITLE
Handles noItemsText in HQ if null passed to commcare-core

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -526,8 +526,7 @@ public class EntityListResponse extends MenuBean {
         try {
             noItemsTextString = detail.getNoItemsText().evaluate();
         } catch (NoLocalizedTextException | NullPointerException e) {
-            String noItemsTextStringLegacy = "List is empty.";
-            return noItemsTextStringLegacy;
+            return null;
         }
         return noItemsTextString;
     }


### PR DESCRIPTION
## Product Description
Related to HQ PR: https://github.com/dimagi/commcare-hq/pull/32552
and previous Formplayer PR: https://github.com/dimagi/formplayer/pull/1309

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Same as described in https://github.com/dimagi/formplayer/pull/1309
New to this PR: [USH-2869](https://dimagi-dev.atlassian.net/browse/USH-2869)
## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Manual testing on local env and staging. Existing apps and those with Feature Flag off or Commcare version < 2.53 will return null to HQ. HQ then handles null accordingly.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
No new automated tests.
### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Will go through QA.


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
