### PR TITLE
[USH-2620] improved 'back' navigation after form submissions

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -56,7 +56,6 @@ public class MenuController extends AbstractBaseController {
                     sessionNavigationBean.getSearchText(),
                     sessionNavigationBean.getSortIndex(),
                     sessionNavigationBean.getCasesPerPage(),
-                    sessionNavigationBean.getSmartLinkTemplate(),
                     sessionNavigationBean.getSelectedValues()
             );
             logNotification(baseResponseBean.getNotification(),request);
@@ -82,7 +81,6 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSmartLinkTemplate(),
                 sessionNavigationBean.getSelectedValues()
         );
         logNotification(baseResponseBean.getNotification(),request);
@@ -140,7 +138,6 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSmartLinkTemplate(),
                 sessionNavigationBean.getSelectedValues()
         );
         logNotification(response.getNotification(), request);

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -56,7 +56,8 @@ public class MenuController extends AbstractBaseController {
                     sessionNavigationBean.getSearchText(),
                     sessionNavigationBean.getSortIndex(),
                     sessionNavigationBean.getCasesPerPage(),
-                    sessionNavigationBean.getSelectedValues()
+                    sessionNavigationBean.getSelectedValues(),
+                    null
             );
             logNotification(baseResponseBean.getNotification(),request);
             // See if we have a persistent case tile to expand
@@ -81,7 +82,8 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSelectedValues()
+                sessionNavigationBean.getSelectedValues(),
+                null
         );
         logNotification(baseResponseBean.getNotification(),request);
 
@@ -138,7 +140,8 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),
                 sessionNavigationBean.getCasesPerPage(),
-                sessionNavigationBean.getSelectedValues()
+                sessionNavigationBean.getSelectedValues(),
+                sessionNavigationBean.getFormSessionId()
         );
         logNotification(response.getNotification(), request);
         return setLocationNeeds(response, menuSession);

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -24,7 +24,6 @@ public class SessionNavigationBean extends InstallRequestBean {
     private boolean isPersistent;
     private int sortIndex;
     private int casesPerPage;
-    private String smartLinkTemplate;
     private String[] selectedValues;
 
     public String[] getSelections() {
@@ -107,16 +106,6 @@ public class SessionNavigationBean extends InstallRequestBean {
 
     public void setIsPersistent(boolean persistent) {
         isPersistent = persistent;
-    }
-
-    @JsonGetter(value = "smart_link_template")
-    public String getSmartLinkTemplate() {
-        return smartLinkTemplate;
-    }
-
-    @JsonSetter(value = "smart_link_template")
-    public void setSmartLinkTemplate(String smartLinkTemplate) {
-        this.smartLinkTemplate = smartLinkTemplate;
     }
 
     public int getSortIndex() {

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -20,7 +20,6 @@ public class SessionNavigationBean extends InstallRequestBean {
     private HashMap<String, String> endpointArgs;
     private String searchText;
     private String geoLocation;
-    private String menuSessionId;
     private QueryData queryData;
     private boolean isPersistent;
     private int sortIndex;
@@ -38,7 +37,7 @@ public class SessionNavigationBean extends InstallRequestBean {
 
     @Override
     public String toString() {
-        return "SessionNavigationBean [id= " + menuSessionId +
+        return "SessionNavigationBean [" +
                 ", selections=" + Arrays.toString(selections) +
                 ", parent=" + super.toString() +
                 ", queryData" + queryData + "]";
@@ -80,16 +79,6 @@ public class SessionNavigationBean extends InstallRequestBean {
     @JsonSetter(value = "search_text")
     public void setSearchText(String searchText) {
         this.searchText = searchText;
-    }
-
-    @JsonGetter(value = "menu_session_id")
-    public String getMenuSessionId() {
-        return menuSessionId;
-    }
-
-    @JsonSetter(value = "menu_session_id")
-    public void setMenuSessionId(String menuSessionId) {
-        this.menuSessionId = menuSessionId;
     }
 
     @JsonGetter(value = "query_data")

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -26,6 +26,12 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int casesPerPage;
     private String[] selectedValues;
 
+    /**
+     * Form session ID used to prevent attempts to navigate into a form session
+     * e.g. pressing the back button
+     */
+    private String formSessionId;
+
     public String[] getSelections() {
         return selections;
     }
@@ -134,5 +140,15 @@ public class SessionNavigationBean extends InstallRequestBean {
     @JsonSetter(value = "selected_values")
     public void setSelectedValues(String[] selectedValues) {
         this.selectedValues = selectedValues;
+    }
+
+    @JsonGetter(value = "form_session_id")
+    public String getFormSessionId() {
+        return formSessionId;
+    }
+
+    @JsonSetter(value = "form_session_id")
+    public void setFormSessionId(String formSessionId) {
+        this.formSessionId = formSessionId;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/CommandListResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/CommandListResponseBean.java
@@ -26,8 +26,7 @@ public class CommandListResponseBean extends MenuBean {
         this.commands = commands;
     }
 
-    public CommandListResponseBean(MenuScreen menuScreen, SessionWrapper session,
-            String menuSessionId) {
+    public CommandListResponseBean(MenuScreen menuScreen, SessionWrapper session) {
         processTitle(session);
         String[] badges = menuScreen.getBadges();
         MenuDisplayable[] options = menuScreen.getMenuDisplayables();

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -124,7 +124,7 @@ public class MenuSessionRunnerService {
     private static final Log log = LogFactory.getLog(MenuSessionRunnerService.class);
 
     public BaseResponseBean getNextMenu(MenuSession menuSession) throws Exception {
-        return getNextMenu(menuSession, null, 0, "", 0, null, 0, null);
+        return getNextMenu(menuSession, null, 0, "", 0, null, 0);
     }
 
     @Trace
@@ -134,8 +134,7 @@ public class MenuSessionRunnerService {
             String searchText,
             int sortIndex,
             QueryData queryData,
-            int casesPerPage,
-            String smartLinkTemplate) throws Exception {
+            int casesPerPage) throws Exception {
         Screen nextScreen = menuSession.getNextScreen(detailSelection != null);
 
         // No next menu screen? Start form entry!
@@ -166,7 +165,7 @@ public class MenuSessionRunnerService {
             if (nextScreen.shouldBeSkipped()) {
                 if (((EntityScreen)nextScreen).autoSelectEntities(menuSession.getSessionWrapper())) {
                     return getNextMenu(menuSession, detailSelection, offset, searchText, sortIndex, queryData,
-                            casesPerPage, smartLinkTemplate);
+                            casesPerPage);
                 }
             }
             addHereFuncHandler((EntityScreen)nextScreen, menuSession);
@@ -219,7 +218,7 @@ public class MenuSessionRunnerService {
     public BaseResponseBean advanceSessionWithSelections(MenuSession menuSession,
             String[] selections, QueryData queryData) throws Exception {
         return advanceSessionWithSelections(menuSession, selections, null, queryData,
-                0, null, 0, 0, null, null);
+                0, null, 0, 0, null);
     }
 
     /**
@@ -246,7 +245,6 @@ public class MenuSessionRunnerService {
             String searchText,
             int sortIndex,
             int casesPerPage,
-            String smartLinkTemplate,
             String[] selectedValues) throws Exception {
         NotificationMessage notificationMessage = null;
         try {
@@ -259,8 +257,7 @@ public class MenuSessionRunnerService {
                         searchText,
                         sortIndex,
                         queryData,
-                        casesPerPage,
-                        smartLinkTemplate
+                        casesPerPage
                 );
             }
             for (int i = 1; i <= selections.length; i++) {
@@ -321,8 +318,7 @@ public class MenuSessionRunnerService {
                 searchText,
                 sortIndex,
                 queryData,
-                casesPerPage,
-                smartLinkTemplate
+                casesPerPage
         );
         restoreFactory.cacheSessionSelections(menuSession.getSelections());
 

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -156,8 +156,7 @@ public class MenuSessionRunnerService {
         if (nextScreen instanceof MenuScreen) {
             menuResponseBean = new CommandListResponseBean(
                     (MenuScreen)nextScreen,
-                    menuSession.getSessionWrapper(),
-                    menuSession.getId()
+                    menuSession.getSessionWrapper()
             );
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "menu");
             Sentry.setTag(Constants.MODULE_TAG, "menu");

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -218,7 +218,7 @@ public class MenuSessionRunnerService {
     public BaseResponseBean advanceSessionWithSelections(MenuSession menuSession,
             String[] selections, QueryData queryData) throws Exception {
         return advanceSessionWithSelections(menuSession, selections, null, queryData,
-                0, null, 0, 0, null);
+                0, null, 0, 0, null, null);
     }
 
     /**
@@ -245,8 +245,10 @@ public class MenuSessionRunnerService {
             String searchText,
             int sortIndex,
             int casesPerPage,
-            String[] selectedValues) throws Exception {
+            String[] selectedValues,
+            String formSessionId) throws Exception {
         NotificationMessage notificationMessage = null;
+        boolean nonAppNav = formSessionId != null;
         try {
             // If we have no selections, we're are the root screen.
             if (selections == null) {
@@ -259,6 +261,13 @@ public class MenuSessionRunnerService {
                         queryData,
                         casesPerPage
                 );
+            }
+            if (nonAppNav) {
+                // User has navigated with a session ID. This means they have navigated 'back' or via
+                // another non-app mechanism. In this case remove the last selection so that they don't
+                // re-enter the form. This will have the effect of navigating to the screen prior to
+                // the form if possible.
+                selections = Arrays.copyOf(selections, selections.length - 1);
             }
             for (int i = 1; i <= selections.length; i++) {
                 String selection = selections[i - 1];
@@ -307,8 +316,11 @@ public class MenuSessionRunnerService {
                 }
             }
         } catch (CommCareSessionException ccse) {
-            notificationMessage = new NotificationMessage(ccse.getMessage(), true,
-                    NotificationMessage.Tag.menu);
+            // don't show a message in cases where the user is doing 'non-app' navigation
+            if (!nonAppNav) {
+                notificationMessage = new NotificationMessage(ccse.getMessage(), true,
+                        NotificationMessage.Tag.menu);
+            }
         }
 
         BaseResponseBean nextResponse = getNextMenu(

--- a/src/test/java/org/commcare/formplayer/junit/Installer.kt
+++ b/src/test/java/org/commcare/formplayer/junit/Installer.kt
@@ -94,11 +94,11 @@ class Installer(
             for (template in paths) {
                 val path = String.format(template, nameOrPath)
                 if (checkInstallReference(path)) {
-                    log.info(String.format("Found install reference at %s", path))
+                    log.info("Found install reference at $path")
                     return path
                 }
             }
-            throw RuntimeException(String.format("Unable to find install reference for %s", nameOrPath))
+            throw RuntimeException("Unable to find install reference for $nameOrPath")
         }
 
         /**

--- a/src/test/java/org/commcare/formplayer/junit/Installer.kt
+++ b/src/test/java/org/commcare/formplayer/junit/Installer.kt
@@ -3,6 +3,8 @@ package org.commcare.formplayer.junit
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import org.apache.commons.logging.LogFactory
+import org.assertj.core.api.Assertions
 import org.commcare.formplayer.auth.DjangoAuth
 import org.commcare.formplayer.beans.InstallRequestBean
 import org.commcare.formplayer.beans.menus.CommandListResponseBean
@@ -18,6 +20,7 @@ import org.commcare.modern.util.Pair
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
+import java.io.File
 import java.io.IOException
 import java.io.StringReader
 
@@ -67,6 +70,36 @@ class Installer(
 
     companion object {
         private val mapper = ObjectMapper()
+        private val log = LogFactory.getLog(Installer::class.java)
+
+        /**
+         * Turn a test name or relative path into an app install reference.
+         *
+         * Accepts:
+         * * an archive name in `src/test/resources/archives`
+         * * an exploded archive directly in `src/test/resources/archives`
+         * * any path relative to src/test/resources` that points to an exploded archive directory
+         * * any path relative to src/test/resources` that points to a CCZ or profile.ccpr file
+         */
+        @JvmStatic
+        fun getInstallReference(nameOrPath: String): String {
+            if (checkInstallReference(nameOrPath)) {
+                return nameOrPath
+            }
+            val paths = arrayOf(
+                "%s/profile.ccpr",
+                "archives/%s.ccz",
+                "archives/%s/profile.ccpr"
+            )
+            for (template in paths) {
+                val path = String.format(template, nameOrPath)
+                if (checkInstallReference(path)) {
+                    log.info(String.format("Found install reference at %s", path))
+                    return path
+                }
+            }
+            throw RuntimeException(String.format("Unable to find install reference for %s", nameOrPath))
+        }
 
         /**
          * Utility method to extract the 'installReference' field from test JSON files and map the
@@ -81,7 +114,7 @@ class Installer(
         @Throws(IOException::class)
         fun <T> getInstallReferenceAndBean(requestPath: String, clazz: Class<T>): Pair<String, T> {
             val root: JsonNode = mapper.readTree(
-                StringReader(FileUtils.getFile(this.javaClass, requestPath))
+                StringReader(FileUtils.getFile(this::class.java, requestPath))
             )
             val installReference = (root as ObjectNode).remove("installReference").asText()
             val beanContent: String = mapper.writeValueAsString(root)
@@ -104,6 +137,18 @@ class Installer(
             Mockito.mockStatic(SessionUtils::class.java, answer).use { _ ->
                 return supplier.get()
             }
+        }
+
+        private fun checkInstallReference(path: String): Boolean {
+            val resource = this::class.java.classLoader.getResource(path) ?: return false
+            val file = File(resource.file)
+            if (file.isDirectory) {
+                return false
+            }
+            Assertions.assertThat(arrayOf(".ccz", ".ccpr"))
+                .`as`("check file extension: %s", path)
+                .anyMatch { s: String? -> path.endsWith(s!!) }
+            return true
         }
     }
 }

--- a/src/test/java/org/commcare/formplayer/junit/StorageFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/StorageFactoryExtension.kt
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.junit
 
+import org.commcare.formplayer.application.SQLiteProperties
+import org.commcare.formplayer.sandbox.SqlSandboxUtils
 import org.commcare.formplayer.services.FormplayerStorageFactory
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -56,11 +58,12 @@ class StorageFactoryExtension(
         storageFactory = SpringExtension.getApplicationContext(context).getBean(FormplayerStorageFactory::class.java)
     }
 
-    override fun beforeEach(context: ExtensionContext?) {
+    override fun beforeEach(context: ExtensionContext) {
         storageFactory.configure(username, domain, appId, asUser, asCaseId)
     }
 
-    override fun afterEach(context: ExtensionContext?) {
+    override fun afterEach(context: ExtensionContext) {
         storageFactory.sqLiteDB.closeConnection()
+        SqlSandboxUtils.deleteDatabaseFolder(SQLiteProperties.getDataDir())
     }
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/EvaluateXpathRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/EvaluateXpathRequest.kt
@@ -17,7 +17,7 @@ class EvaluateXpathRequest(
     private val xpath: String,
     private val formSessionService: FormSessionService
 ) : MockRequest<EvaluateXPathRequestBean, EvaluateXPathResponseBean>(
-    mockMvc, Constants.URL_EVALUATE_XPATH, EvaluateXPathResponseBean::class
+    mockMvc, Constants.URL_EVALUATE_XPATH, EvaluateXPathResponseBean::class.java
 ) {
 
     fun request(): Response<EvaluateXPathResponseBean> {

--- a/src/test/java/org/commcare/formplayer/junit/request/MockRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/MockRequest.kt
@@ -9,15 +9,14 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import javax.servlet.http.Cookie
-import kotlin.reflect.KClass
 
 /**
  * Base class for mock requests
  */
-open class MockRequest<B, T : Any>(
+open class MockRequest<B, out T : Any>(
     private val mockMvc: MockMvc,
     private val requestPath: String,
-    private val kClass: KClass<T>
+    private val kClass: Class<T>
 ) {
 
     internal val mapper = ObjectMapper()

--- a/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/NewFormRequest.kt
@@ -17,7 +17,7 @@ class NewFormRequest(
     private val webClientMock: WebClient,
     private val formPath: String
     ) : MockRequest<NewSessionRequestBean, NewFormResponse>(
-    mockMvc, Constants.URL_NEW_SESSION, NewFormResponse::class
+    mockMvc, Constants.URL_NEW_SESSION, NewFormResponse::class.java
 ) {
 
     fun request(requestPath: String): Response<NewFormResponse> {

--- a/src/test/java/org/commcare/formplayer/junit/request/Response.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/Response.kt
@@ -5,21 +5,20 @@ import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.ResultActions
 import org.springframework.test.web.servlet.ResultHandler
 import org.springframework.test.web.servlet.ResultMatcher
-import kotlin.reflect.KClass
 
 /**
  * Wrapper class for MockMVC responses that gives access ot the response bean as well as the
  * ResultActions object.
  */
-class Response<T : Any>(
+class Response<out T: Any>(
     private val mapper: ObjectMapper,
     val response: ResultActions,
-    private val kClass: KClass<T>
+    private val kClass: Class<T>
 ) : ResultActions {
 
     fun bean(): T {
         return mapper.readValue(
-            response.andReturn().response.contentAsString, kClass.java
+            response.andReturn().response.contentAsString, kClass
         )
     }
 

--- a/src/test/java/org/commcare/formplayer/junit/request/Response.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/Response.kt
@@ -10,7 +10,7 @@ import org.springframework.test.web.servlet.ResultMatcher
  * Wrapper class for MockMVC responses that gives access ot the response bean as well as the
  * ResultActions object.
  */
-class Response<out T: Any>(
+class Response<out T : Any>(
     private val mapper: ObjectMapper,
     val response: ResultActions,
     private val kClass: Class<T>

--- a/src/test/java/org/commcare/formplayer/junit/request/SessionNavigationRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SessionNavigationRequest.kt
@@ -1,0 +1,65 @@
+package org.commcare.formplayer.junit.request
+
+import org.commcare.formplayer.beans.SessionNavigationBean
+import org.commcare.formplayer.beans.menus.BaseResponseBean
+import org.commcare.formplayer.junit.Installer.Companion.mockInstallReference
+import org.commcare.formplayer.util.Constants
+import org.springframework.test.web.servlet.MockMvc
+
+/**
+ * Request class for making navigation requests.
+ *
+ * This class is generically typed to allow it to return different
+ * response types depending on the navigation.
+ *
+ * Basic usage:
+ * <pre>
+ *     Response<CommandListResponseBean> response = new SessionNavigationRequest<>(
+ *         mockMvc, CommandListResponseBean.class).request(selectionsArray);
+ *     CommandListResponseBean responseBean = response.bean();
+ * </pre>
+ *
+ * Typically you will need to mock the app install reference as well. This can be done
+ * by passing the install reference:
+ * <pre>
+ *     installRef = Installer.getInstallReference("basic")
+ *     response = SessionNavigationRequest(
+ *         mockMvc, CommandListResponseBean.class, installRef
+ *     ).request(selectionsArray)
+ *     responseBean: CommandListResponseBean = response.bean()
+ * </pre>
+ */
+class SessionNavigationRequest<out T: BaseResponseBean>(
+    mockMvc: MockMvc,
+    kClass: Class<T>,
+    val installReference: String? = null
+) : MockRequest<SessionNavigationBean, T>(
+    mockMvc, Constants.URL_MENU_NAVIGATION, kClass
+) {
+
+    fun request(selections: Array<String>): Response<T> {
+        val bean = getNavigationBean(selections)
+        return requestWithBean(bean)
+    }
+
+    override fun requestWithBean(requestBean: SessionNavigationBean): Response<T> {
+        return if (installReference == null) {
+            super.requestWithBean(requestBean)
+        } else {
+            mockInstallReference(
+                { super.requestWithBean(requestBean) },
+                installReference
+            )
+        }
+    }
+
+    fun getNavigationBean(selections: Array<String>): SessionNavigationBean {
+        val sessionNavigationBean = SessionNavigationBean()
+        sessionNavigationBean.domain = "test-domain"
+        sessionNavigationBean.appId = "test-app-id"
+        sessionNavigationBean.username = "test-username"
+        sessionNavigationBean.selections = selections
+        return sessionNavigationBean
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/junit/request/SessionNavigationRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SessionNavigationRequest.kt
@@ -29,7 +29,7 @@ import org.springframework.test.web.servlet.MockMvc
  *     responseBean: CommandListResponseBean = response.bean()
  * </pre>
  */
-class SessionNavigationRequest<out T: BaseResponseBean>(
+class SessionNavigationRequest<out T : BaseResponseBean>(
     mockMvc: MockMvc,
     kClass: Class<T>,
     val installReference: String? = null
@@ -61,5 +61,4 @@ class SessionNavigationRequest<out T: BaseResponseBean>(
         sessionNavigationBean.selections = selections
         return sessionNavigationBean
     }
-
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -18,7 +18,7 @@ class SubmitFormRequest(mockMvc: MockMvc) : MockRequest<SubmitRequestBean, Submi
         bean.sessionId = sessionId
         bean.answers = answers
         bean.isPrevalidated = prevalidated
-        return requestWithBean(bean);
+        return requestWithBean(bean)
     }
 
     fun request(requestPath: String, sessionId: String): Response<SubmitResponseBean> {

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -13,7 +13,7 @@ class SubmitFormRequest(mockMvc: MockMvc) : MockRequest<SubmitRequestBean, Submi
     mockMvc, Constants.URL_SUBMIT_FORM, SubmitResponseBean::class.java
 ) {
 
-    fun request(sessionId: String, answers: Map<String, Object>, prevalidated: Boolean): Response<SubmitResponseBean> {
+    fun request(sessionId: String, answers: Map<String, Any>, prevalidated: Boolean): Response<SubmitResponseBean> {
         val bean = SubmitRequestBean()
         bean.sessionId = sessionId
         bean.answers = answers

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -13,6 +13,14 @@ class SubmitFormRequest(mockMvc: MockMvc) : MockRequest<SubmitRequestBean, Submi
     mockMvc, Constants.URL_SUBMIT_FORM, SubmitResponseBean::class.java
 ) {
 
+    fun request(sessionId: String, answers: Map<String, Object>, prevalidated: Boolean): Response<SubmitResponseBean> {
+        val bean = SubmitRequestBean()
+        bean.sessionId = sessionId
+        bean.answers = answers
+        bean.isPrevalidated = prevalidated
+        return requestWithBean(bean);
+    }
+
     fun request(requestPath: String, sessionId: String): Response<SubmitResponseBean> {
         val requestPayload = FileUtils.getFile(this.javaClass, requestPath)
         val bean = mapper.readValue(requestPayload, SubmitRequestBean::class.java)

--- a/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SubmitFormRequest.kt
@@ -10,7 +10,7 @@ import org.springframework.test.web.servlet.MockMvc
  * Request class for making a mock request submits a form.
  */
 class SubmitFormRequest(mockMvc: MockMvc) : MockRequest<SubmitRequestBean, SubmitResponseBean>(
-    mockMvc, Constants.URL_SUBMIT_FORM, SubmitResponseBean::class
+    mockMvc, Constants.URL_SUBMIT_FORM, SubmitResponseBean::class.java
 ) {
 
     fun request(requestPath: String, sessionId: String): Response<SubmitResponseBean> {

--- a/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/SyncDbRequest.kt
@@ -13,7 +13,7 @@ class SyncDbRequest(
     mockMvc: MockMvc,
     private val restoreFactory: RestoreFactory
     ) : MockRequest<SyncDbRequestBean, SyncDbResponseBean>(
-    mockMvc, Constants.URL_SYNC_DB, SyncDbResponseBean::class
+    mockMvc, Constants.URL_SYNC_DB, SyncDbResponseBean::class.java
 ) {
 
     fun request(): Response<SyncDbResponseBean> {

--- a/src/test/java/org/commcare/formplayer/tests/BackNavigationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/BackNavigationTests.java
@@ -1,0 +1,99 @@
+package org.commcare.formplayer.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.commcare.formplayer.application.FormSubmissionController;
+import org.commcare.formplayer.application.MenuController;
+import org.commcare.formplayer.beans.NewFormResponse;
+import org.commcare.formplayer.beans.SessionNavigationBean;
+import org.commcare.formplayer.beans.SubmitResponseBean;
+import org.commcare.formplayer.beans.menus.BaseResponseBean;
+import org.commcare.formplayer.beans.menus.CommandListResponseBean;
+import org.commcare.formplayer.beans.menus.EntityListResponse;
+import org.commcare.formplayer.configuration.CacheConfiguration;
+import org.commcare.formplayer.junit.FormSessionTest;
+import org.commcare.formplayer.junit.Installer;
+import org.commcare.formplayer.junit.RestoreFactoryExtension;
+import org.commcare.formplayer.junit.StorageFactoryExtension;
+import org.commcare.formplayer.junit.request.SessionNavigationRequest;
+import org.commcare.formplayer.junit.request.SubmitFormRequest;
+import org.commcare.formplayer.utils.TestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest
+@Import({MenuController.class, FormSubmissionController.class})
+@ContextConfiguration(classes={TestContext.class, CacheConfiguration.class})
+@FormSessionTest
+public class BackNavigationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RegisterExtension
+    static RestoreFactoryExtension restoreFactoryExt = new RestoreFactoryExtension.builder()
+            .withUser("back_nav").withDomain("back_nav")
+            .withRestorePath("restores/basic.xml")
+            .build();
+
+    @RegisterExtension
+    static StorageFactoryExtension storageExt = new StorageFactoryExtension.builder()
+            .withUser("back_nav").withDomain("back_nav").build();
+
+    @Test
+    public void testGoBackToFormListForModule() throws Exception {
+        // navigate to 'Case Tests' -> 'Create a Case' form
+        String[] selections = {"2", "0"};
+
+        String sessionId = navigate(selections, NewFormResponse.class, null).getSessionId();
+
+        SubmitResponseBean submitResponseBean = new SubmitFormRequest(mockMvc).request(
+                sessionId, ImmutableMap.of("0", "name", "1", "1"), true
+        ).bean();
+        assertEquals("success", submitResponseBean.getStatus());
+
+        // performing the same navigation again (but with the sessionId) should put us back at the
+        // form list screen for the 'Case Tests' (m2) module
+        CommandListResponseBean backResponse = navigate(selections, CommandListResponseBean.class, sessionId);
+        assertThat(backResponse.getCommands())
+                .hasSize(6)
+                .anyMatch(command -> command.getIndex() == 0 && command.getDisplayText().equals("Create a Case"));
+    }
+
+    @Test
+    public void testGoBackToCaseList() throws Exception {
+        // navigate to 'Case Tests' -> 'Update a Case' form with 'c3' case
+        String[] selections = {"2", "1", "124938b2-c228-4107-b7e6-31a905c3f4ff"};
+
+        String sessionId = navigate(selections, NewFormResponse.class, null).getSessionId();
+
+        SubmitResponseBean submitResponseBean = new SubmitFormRequest(mockMvc).request(
+                sessionId, ImmutableMap.of("4", 1 ), true
+        ).bean();
+        assertEquals("success", submitResponseBean.getStatus());
+
+        // performing the same navigation again (but with the sessionId) should put us back at the
+        // case list screen
+        EntityListResponse backResponse = navigate(selections, EntityListResponse.class, sessionId);
+        assertThat(backResponse.getTitle()).isEqualTo("Update a Case");
+    }
+
+    private <T extends BaseResponseBean> T navigate(String[] selections, Class<T> responseClass, String sessionId) throws Exception {
+        String installReference = Installer.getInstallReference("basic");
+        SessionNavigationRequest<T> request = new SessionNavigationRequest<>(mockMvc, responseClass, installReference);
+        SessionNavigationBean bean = request.getNavigationBean(selections);
+        if (sessionId != null) {
+            bean.setFormSessionId(sessionId);
+        }
+        return request.requestWithBean(bean).bean();
+    }
+
+}

--- a/src/test/java/org/commcare/formplayer/tests/BackNavigationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/BackNavigationTests.java
@@ -33,7 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest
 @Import({MenuController.class, FormSubmissionController.class})
-@ContextConfiguration(classes={TestContext.class, CacheConfiguration.class})
+@ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
 @FormSessionTest
 public class BackNavigationTests {
 
@@ -105,7 +105,7 @@ public class BackNavigationTests {
         String sessionId = formResponse.bean().getSessionId();
 
         SubmitResponseBean submitResponseBean = new SubmitFormRequest(mockMvc).request(
-                sessionId, ImmutableMap.of("0", "1" ), true
+                sessionId, ImmutableMap.of("0", "1"), true
         ).bean();
         assertThat(submitResponseBean.getStatus()).isEqualTo("success");
 
@@ -115,9 +115,11 @@ public class BackNavigationTests {
         assertThat(backResponse.getTitle()).isEqualTo("Minimize Duplicates");
     }
 
-    private <T extends BaseResponseBean> Response<T> navigate(String[] selections, Class<T> responseClass, String sessionId) {
+    private <T extends BaseResponseBean> Response<T> navigate(
+            String[] selections, Class<T> responseClass, String sessionId) {
         String installReference = Installer.getInstallReference("basic");
-        SessionNavigationRequest<T> request = new SessionNavigationRequest<>(mockMvc, responseClass, installReference);
+        SessionNavigationRequest<T> request = new SessionNavigationRequest<>(
+                mockMvc, responseClass, installReference);
         SessionNavigationBean bean = request.getNavigationBean(selections);
         if (sessionId != null) {
             bean.setFormSessionId(sessionId);

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -651,7 +651,6 @@ public class BaseTestClass {
         evaluateXPathRequestBean.setUsername(menuSession.getUsername());
         evaluateXPathRequestBean.setDomain(menuSession.getDomain());
         evaluateXPathRequestBean.setRestoreAs(menuSession.getAsUser());
-        evaluateXPathRequestBean.setMenuSessionId(menuSessionId);
         evaluateXPathRequestBean.setXpath(xpath);
         return generateMockQuery(
                 ControllerType.DEBUGGER,

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -705,7 +705,7 @@ public class BaseTestClass {
         if (locale != null && !"".equals(locale.trim())) {
             sessionNavigationBean.setLocale(locale);
         }
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_GET_DETAILS,
@@ -742,7 +742,7 @@ public class BaseTestClass {
         if (locale != null && !"".equals(locale.trim())) {
             sessionNavigationBean.setLocale(locale);
         }
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_MENU_NAVIGATION,
@@ -758,7 +758,7 @@ public class BaseTestClass {
         sessionNavigationBean.setUsername(testName + "username");
         sessionNavigationBean.setSelections(selections);
         sessionNavigationBean.setSortIndex(sortIndex);
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_MENU_NAVIGATION,
@@ -777,7 +777,7 @@ public class BaseTestClass {
         if (locale != null && !"".equals(locale.trim())) {
             sessionNavigationBean.setLocale(locale);
         }
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_MENU_NAVIGATION,
@@ -794,7 +794,7 @@ public class BaseTestClass {
         sessionNavigationBean.setUsername(testName + "username");
         sessionNavigationBean.setSelections(selections);
         sessionNavigationBean.setSelectedValues(selectedValues);
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_MENU_NAVIGATION,
@@ -814,7 +814,7 @@ public class BaseTestClass {
         sessionNavigationBean.setDomain(testName + "domain");
         sessionNavigationBean.setAppId(testName + "appid");
         sessionNavigationBean.setUsername(testName + "username");
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_GET_ENDPOINT,
@@ -849,7 +849,7 @@ public class BaseTestClass {
         sessionNavigationBean.setUsername(testName + "username");
         sessionNavigationBean.setQueryData(queryData);
         sessionNavigationBean.setSelectedValues(selectedValues);
-        return generateMockQueryWithInstallReference(getInstallReference(testName),
+        return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_MENU_NAVIGATION,
@@ -1003,49 +1003,6 @@ public class BaseTestClass {
                 serializableMenuSession.isPreview()).first;
         return SessionSerializer.deserialize(engine.getPlatform(),
                 serializableMenuSession.getCommcareSession());
-    }
-
-    /**
-     * Turn a test name or relative path into an app install reference.
-     *
-     * Accepts:
-     * * an archive name in `src/test/resources/archives`
-     * * an exploded archive directly in `src/test/resources/archives`
-     * * any path relative to src/test/resources` that points to an exploded archive directory
-     * * any path relative to src/test/resources` that points to a CCZ or profile.ccpr file
-     */
-    private String getInstallReference(String nameOrPath) {
-        if (checkInstallReference(nameOrPath)) {
-            return nameOrPath;
-        }
-        String[] paths = {
-                "%s/profile.ccpr",
-                "archives/%s.ccz",
-                "archives/%s/profile.ccpr"
-        };
-        for (String template : paths) {
-            String path = String.format(template, nameOrPath);
-            if (checkInstallReference(path)) {
-                log.info(String.format("Found install reference at %s", path));
-                return path;
-            }
-        }
-        throw new RuntimeException(String.format("Unable to find install reference for %s", nameOrPath));
-    }
-
-    private boolean checkInstallReference(String path) {
-        URL resource = this.getClass().getClassLoader().getResource(path);
-        if (resource == null) {
-            return false;
-        }
-        File file = new File(resource.getFile());
-        if (file.isDirectory()) {
-            return false;
-        }
-        Assertions.assertThat(new String[]{".ccz", ".ccpr"})
-                .as("check file extension: %s", path)
-                .anyMatch(path::endsWith);
-        return true;
     }
 
     // Ensure that 'selected_cases' instance is populated correctly


### PR DESCRIPTION
## Product Description
Jira: https://dimagi-dev.atlassian.net/browse/USH-2620

See HQ PR for full description: https://github.com/dimagi/commcare-hq/pull/32575

## Technical Summary
HQ cross request: https://github.com/dimagi/commcare-hq/pull/32575

Detect the presence of a 'form_session_id' during a navigation request and act appropriately. If the session ID is present it implies that the user has performed some non-app based navigation such as going back in the browser history.

When this is detected, attempt to navigate to the previous screen prior to form submission.

## Safety Assurance

### Safety story
The first few commits are cleanups, only the last commit is a functional change.

Assuming the HQ portion of this change is working correct and the form_session_id param is properly cleared after form submission, this should only impact manual navigation.

### Automated test coverage
TODO

### QA Plan
QA on staging

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
