### PR TITLE
set multipart file size limit

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,4 +70,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://${POSTGRESQL_HOST:postgres}:${POSTGRESQL_PORT:5432}/${POSTGRESQL_DATABASE:formplayer}?prepareThreshold=0
 spring.datasource.username=${POSTGRESQL_USERNAME:commcarehq}
 spring.datasource.password=${POSTGRESQL_PASSWROD:commcarehq}
-# ---------------
+
+# --------------- set multipart file upload and request size limit
+spring.servlet.multipart.max-file-size=3MB
+spring.servlet.multipart.max-request-size=4MB


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
This set the size limit for multipart file uploads and a slightly higher limit for multipart request to correspond with limit set [here](https://github.com/dimagi/formplayer/blob/saveMediaAttachment/src/main/java/org/commcare/formplayer/services/MediaValidator.kt#L13.).
As discussed [here](https://dimagi-dev.atlassian.net/browse/QA-4794#:~:text=The%20issue%20I,his%20sign%20off.) only files of 1MB or smaller are able to be uploaded currently.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
part of https://dimagi-dev.atlassian.net/browse/QA-4739 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
