### PR TITLE
Fixes loading Search Input Instance from storage

### DIFF
--- a/src/main/java/org/commcare/formplayer/objects/SerializableDataInstance.java
+++ b/src/main/java/org/commcare/formplayer/objects/SerializableDataInstance.java
@@ -91,7 +91,7 @@ public class SerializableDataInstance {
      * @param key The storage key without the namespace
      * @return
      */
-    public ExternalDataInstance toInstance(String instanceId, String key) {
+    public ExternalDataInstance toInstance(String instanceId, String key, String refId) {
         TreeElement root = getInstanceXml();
         if (!instanceId.equals(getInstanceId())) {
             root = TreeUtilities.renameInstance(root, instanceId);
@@ -104,7 +104,7 @@ public class SerializableDataInstance {
             newReference = reference;
         } else {
             String refScheme = VirtualInstances.getReferenceScheme(reference);
-            newReference = VirtualInstances.getInstanceReference(refScheme, instanceId);
+            newReference = VirtualInstances.getInstanceReference(refScheme, refId);
         }
         ExternalDataInstanceSource instanceSource = ExternalDataInstanceSource.buildVirtual(
                         instanceId, root, newReference, isUseCaseTemplate(), key);

--- a/src/main/java/org/commcare/formplayer/services/FormplayerRemoteInstanceFetcher.java
+++ b/src/main/java/org/commcare/formplayer/services/FormplayerRemoteInstanceFetcher.java
@@ -27,7 +27,7 @@ public class FormplayerRemoteInstanceFetcher implements RemoteInstanceFetcher {
     }
 
     @Override
-    public AbstractTreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source)
+    public AbstractTreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source, String refId)
             throws RemoteInstanceException {
         if (source.getSourceUri() != null) {
             try {
@@ -40,7 +40,8 @@ public class FormplayerRemoteInstanceFetcher implements RemoteInstanceFetcher {
                         + instanceId + ". Please try opening the form again.", e);
             }
         } else if (source.getStorageReferenceId() != null) {
-            ExternalDataInstance instance = mVirtualDataInstanceStorage.read(source.getStorageReferenceId(), instanceId);
+            ExternalDataInstance instance = mVirtualDataInstanceStorage.read(source.getStorageReferenceId(),
+                    instanceId, refId);
             return instance.getRoot();
         }
         throw new RemoteInstanceException("Could not retrieve data for instance " + instanceId

--- a/src/main/java/org/commcare/formplayer/services/VirtualDataInstanceService.java
+++ b/src/main/java/org/commcare/formplayer/services/VirtualDataInstanceService.java
@@ -47,7 +47,7 @@ public class VirtualDataInstanceService implements VirtualDataInstanceStorage {
     }
 
     @Override
-    public ExternalDataInstance read(String key, String instanceId) {
+    public ExternalDataInstance read(String key, String instanceId, String refId) {
         String namespaceKey = namespaceKey(key);
         Cache cache = cacheManager.getCache(VIRTUAL_DATA_INSTANCES_CACHE);
         SerializableDataInstance savedInstance = cache.get(namespaceKey, SerializableDataInstance.class);
@@ -58,7 +58,7 @@ public class VirtualDataInstanceService implements VirtualDataInstanceStorage {
             }
         }
         if (validateInstance(savedInstance, key)) {
-            return savedInstance.toInstance(instanceId, key);
+            return savedInstance.toInstance(instanceId, key, refId);
         }
         throw new InstanceNotFoundException(key, getNamespace());
     }

--- a/src/test/java/org/commcare/formplayer/services/VirtualDataInstanceServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/VirtualDataInstanceServiceTest.java
@@ -106,7 +106,8 @@ public class VirtualDataInstanceServiceTest {
         assertEquals(externalDataInstance.getRoot(), getCachedRecord(recordId).get().getInstanceXml());
 
         // get Record hits the cache (repo is mocked)
-        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
+        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases",
+                "selected_cases");
         assertEquals(externalDataInstance.getRoot(), fetchedRecord.getRoot());
     }
 
@@ -124,7 +125,8 @@ public class VirtualDataInstanceServiceTest {
         assertEquals(externalDataInstance.getRoot(), getCachedRecord(recordId).get().getInstanceXml());
 
         // get Record hits the cache (repo is mocked)
-        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
+        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases",
+                "selected_cases");
         assertEquals(externalDataInstance.getRoot(), fetchedRecord.getRoot());
     }
 
@@ -175,7 +177,8 @@ public class VirtualDataInstanceServiceTest {
         assertEquals(key, recordId);
 
         // get Record hits the cache (repo is mocked)
-        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
+        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases",
+                "selected_cases");
         assertNotNull(fetchedRecord);
 
         // call the runnable to change the session detail in some way that should prevent reading the

--- a/src/test/java/org/commcare/formplayer/services/VirtualDataInstanceServiceTest.java
+++ b/src/test/java/org/commcare/formplayer/services/VirtualDataInstanceServiceTest.java
@@ -106,7 +106,7 @@ public class VirtualDataInstanceServiceTest {
         assertEquals(externalDataInstance.getRoot(), getCachedRecord(recordId).get().getInstanceXml());
 
         // get Record hits the cache (repo is mocked)
-        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases");
+        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
         assertEquals(externalDataInstance.getRoot(), fetchedRecord.getRoot());
     }
 
@@ -124,7 +124,7 @@ public class VirtualDataInstanceServiceTest {
         assertEquals(externalDataInstance.getRoot(), getCachedRecord(recordId).get().getInstanceXml());
 
         // get Record hits the cache (repo is mocked)
-        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases");
+        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
         assertEquals(externalDataInstance.getRoot(), fetchedRecord.getRoot());
     }
 
@@ -175,7 +175,7 @@ public class VirtualDataInstanceServiceTest {
         assertEquals(key, recordId);
 
         // get Record hits the cache (repo is mocked)
-        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases");
+        ExternalDataInstance fetchedRecord = virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
         assertNotNull(fetchedRecord);
 
         // call the runnable to change the session detail in some way that should prevent reading the
@@ -183,7 +183,7 @@ public class VirtualDataInstanceServiceTest {
         adjustSessionDetail.run();
 
         assertThrows(InstanceNotFoundException.class, () -> {
-            virtualDataInstanceService.read(recordId, "selected_cases");
+            virtualDataInstanceService.read(recordId, "selected_cases", "selected_cases");
         });
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -296,12 +296,13 @@ public class BaseTestClass {
         when(virtualDataInstanceService.write(any(String.class), any(ExternalDataInstance.class)))
                 .thenAnswer(getVirtualInstanceMockWrite());
 
-        when(virtualDataInstanceService.read(any(String.class), any(String.class))).thenAnswer(invocation -> {
+        when(virtualDataInstanceService.read(any(String.class), any(String.class), any(String.class))).thenAnswer(invocation -> {
             String key = (String)invocation.getArguments()[0];
             String instanceId = (String)invocation.getArguments()[1];
+            String refId = (String)invocation.getArguments()[2];
             if (serializableDataInstanceMap.containsKey(key)) {
                 SerializableDataInstance savedInstance = serializableDataInstanceMap.get(key);
-                return savedInstance.toInstance(instanceId, key);
+                return savedInstance.toInstance(instanceId, key, refId);
             }
             throw new InstanceNotFoundException(key, "test-namespace");
         });

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -296,16 +296,17 @@ public class BaseTestClass {
         when(virtualDataInstanceService.write(any(String.class), any(ExternalDataInstance.class)))
                 .thenAnswer(getVirtualInstanceMockWrite());
 
-        when(virtualDataInstanceService.read(any(String.class), any(String.class), any(String.class))).thenAnswer(invocation -> {
-            String key = (String)invocation.getArguments()[0];
-            String instanceId = (String)invocation.getArguments()[1];
-            String refId = (String)invocation.getArguments()[2];
-            if (serializableDataInstanceMap.containsKey(key)) {
-                SerializableDataInstance savedInstance = serializableDataInstanceMap.get(key);
-                return savedInstance.toInstance(instanceId, key, refId);
-            }
-            throw new InstanceNotFoundException(key, "test-namespace");
-        });
+        when(virtualDataInstanceService.read(any(String.class), any(String.class), any(String.class))).thenAnswer(
+                invocation -> {
+                    String key = (String)invocation.getArguments()[0];
+                    String instanceId = (String)invocation.getArguments()[1];
+                    String refId = (String)invocation.getArguments()[2];
+                    if (serializableDataInstanceMap.containsKey(key)) {
+                        SerializableDataInstance savedInstance = serializableDataInstanceMap.get(key);
+                        return savedInstance.toInstance(instanceId, key, refId);
+                    }
+                    throw new InstanceNotFoundException(key, "test-namespace");
+                });
 
         when(virtualDataInstanceService.contains(any(String.class))).thenAnswer(invocation -> {
             String key = (String)invocation.getArguments()[0];
@@ -376,11 +377,11 @@ public class BaseTestClass {
 
     private void setupSubmitServiceMock() {
         Mockito.doReturn(
-                "<OpenRosaResponse>" +
-                        "<message nature='status'>" +
-                        "OK" +
-                        "</message>" +
-                        "</OpenRosaResponse>")
+                        "<OpenRosaResponse>" +
+                                "<message nature='status'>" +
+                                "OK" +
+                                "</message>" +
+                                "</OpenRosaResponse>")
                 .when(submitServiceMock).submitForm(anyString(), anyString());
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/FormEntryWithQueryTests.java
@@ -231,6 +231,16 @@ public class FormEntryWithQueryTests extends BaseTestClass {
         QuestionBean nameNewInstanceRef = formResponse.getTree()[1];
         assertEquals("bob", nameLegacyInstanceRef.getAnswer());
         assertEquals("bob", nameNewInstanceRef.getAnswer());
+
+        // redo the same query to test for instance loading correctly from storage
+        NewFormResponse newFormResponse = sessionNavigateWithQuery(selections,
+                "caseclaimquery",
+                queryData,
+                NewFormResponse.class);
+        nameLegacyInstanceRef = newFormResponse.getTree()[0];
+        nameNewInstanceRef = newFormResponse.getTree()[1];
+        assertEquals("bob", nameLegacyInstanceRef.getAnswer());
+        assertEquals("bob", nameNewInstanceRef.getAnswer());
     }
 
     @Override


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/QA-4784

## Technical Summary

The [core fix here](https://github.com/dimagi/formplayer/commit/c49da5d13da21a7c4bd496180003047a69be6f4a) is to use reference id (same as datum id) instead of instance id to construct instance reference when loading the instance from storage. This issue was introduced by https://github.com/dimagi/formplayer/pull/1315/files for new instance reference scheme. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
PR adds a [test](https://github.com/dimagi/formplayer/commit/cf261d803cd7001472503378a457e19e20a51534) to check for search input instance loading correctly from storage by re-running same request twice. 

### QA Plan
https://dimagi-dev.atlassian.net/browse/QA-4784


### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [x] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/commcare-core/pull/1221