### PR TITLE
Show the most recent commit diff to the respective staging file

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -55,7 +55,7 @@ function rebuildstaging() {
         git --git-dir "$REPO_ROOT/.git" pull origin main
     fi
 
-    git --git-dir "$REPO_ROOT/.git" show
+    git --git-dir "$REPO_ROOT/.git" show -n 1 -- formplayer-staging.yml
     echo "rebuilding staging branch..."
     git-build-branch "$REPO_ROOT/formplayer-staging.yml" "$@"
 }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Once I added formplayer-staging.yml to staging-branches, the git show logic had the potential to show a diff in the formplayer-staging.yml when rebuilding the commcare-hq staging branch (or vice versa), which is confusing.

This ensures we grab the most recent commit to the `formplayer-staging.yml` file in staging-branches, and show that diff to the user.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
