### PR TITLE
Add how to create run config to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,16 @@ In order to set breakpoints, step through code, and link the runtime with source
 3. Navigate to the cloned `formplayer` repository and select `build.gradle` at the root
 4. De-select "Use auto-import" and "Create directories for empty content roots automatically" and *select* "Use gradle wrapper"
 5. Click "OK"
+6. Create a run configuration:
+   1. Open the run configurations (by clicking on the drop down menu next to the play button in the top).
+   2. Click the + in the upper left corner and then "JAR Application"
+   3. Pick any name (e.g. "Formplayer")
+   4. Set to jar path to <path to repo>/formplayer/build/libs/formplayer.jar
+   5. Hit the + in the "before launch" section and add project: formplayer, task: assemble
+   6. save
 
-After following these steps IntelliJ may need further configuration to work smoothly with Gradle. You might also want to install the [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok) for your IDE to resolve Lombok references. 
+After following these steps IntelliJ may need further configuration to work smoothly with Gradle. You might also want to install 
+the [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok) for your IDE to resolve Lombok references.
 
 Note: You can also use Android Studio as your IDE and follow the same steps as above.
 


### PR DESCRIPTION
* By default Intellij uses the "Application" template to create run configs which does not work.
* Add instructions to the readme on how to create a working "JAR Application" run configuration.

## Technical Summary
Just updating the readme

## Safety Assurance

### Safety story
Only documentation changes. No tests required

### Automated test coverage
Only documentation changes. No tests required

### QA Plan
Only documentation changes. No tests required

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
