### PR TITLE
add 'hasDetails' to EntityListResponse

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -61,6 +61,8 @@ public class EntityListResponse extends MenuBean {
     private boolean isMultiSelect = false;
     private int maxSelectValue = -1;
 
+    private boolean hasDetails = true;
+
     public EntityListResponse() {
     }
 
@@ -112,6 +114,7 @@ public class EntityListResponse extends MenuBean {
             entities = new EntityBean[entityBeans.size()];
             entityBeans.toArray(entities);
             setNoItemsText(getNoItemsTextLocaleString(detail));
+            hasDetails = nextScreen.getLongDetail() != null;
         }
 
         processTitle(session);
@@ -265,6 +268,10 @@ public class EntityListResponse extends MenuBean {
 
     public void setSortIndices(int[] sortIndices) {
         this.sortIndices = sortIndices;
+    }
+
+    public boolean isHasDetails() {
+        return hasDetails;
     }
 
     static class LogNotifier implements EntitySortNotificationInterface {


### PR DESCRIPTION
## Product Description
Add `hasDetails` attribute to entity list response to allow Web Apps to skip the details request when there is no 'long detail' configured.

Cross: https://github.com/dimagi/commcare-core/pull/1280

## Technical Summary
Adds `hasDetails` to the entity list response. 

## Safety Assurance

### Safety story
Simple addition of one field.

### QA Plan
Tested locally

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
