### PR TITLE
Add IP address to post requests to HQ

### DIFF
--- a/src/main/java/org/commcare/formplayer/util/RequestUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/RequestUtils.java
@@ -121,6 +121,22 @@ public class RequestUtils {
         return attribute != null && (Boolean)attribute;
     }
 
+    /**
+     * Gets the IP address by using "X-FORWARDED-FOR" request header falling back to request.getRemoteAddr()
+     * @return IP address from the request
+     */
+    public static String getIpAddress() {
+        HttpServletRequest request = getCurrentRequest();
+        if (request == null) {
+            return null;
+        }
+        String ipAddress = request.getHeader("X-FORWARDED-FOR");
+        if (ipAddress == null) {
+            request.getRemoteAddr();
+        }
+        return ipAddress;
+    }
+
     // If a multipart request returns the part having content type as 'application/json',
     // otherwise the whole request content
     private static String getJsonBody(HttpServletRequest request) throws IOException, ServletException {

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -64,7 +64,7 @@ public class WebClient {
         if (isMultipart) {
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         }
-        headers.add("X-FORWARDED-FOR", RequestUtils.getIpAddress());
+        headers.add("X-CommCareHQ-Origin-IP", RequestUtils.getIpAddress());
         return postRaw(uri, headers, body, String.class).getBody();
     }
 

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -64,6 +64,7 @@ public class WebClient {
         if (isMultipart) {
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         }
+        headers.add("X-FORWARDED-FOR", RequestUtils.getIpAddress());
         return postRaw(uri, headers, body, String.class).getBody();
     }
 


### PR DESCRIPTION
## Product Description

https://dimagi-dev.atlassian.net/browse/USH-3093

## Technical Summary

Probably all the complexity here is in to get the IP address from the request. I am using the header "X-FORWARDED-FOR" to get the IP with a fall back to the `request.getRemoteAddr()` . I am assuming that `"X-FORWARDED-FOR"  will always be there when requests are forwarded from Nginx but we probably need to cross-check that assumption on HQ. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Testing form submission locally and on staging should be a good enough safety check. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA
### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [x] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
