### PR TITLE
Fix Incorrect Entity Context Attached to Entity Screen

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -97,7 +97,7 @@ public class MenuController extends AbstractBaseController {
         );
         logNotification(baseResponseBean.getNotification(),request);
 
-        Screen currentScreen = menuSession.getNextScreen(true);
+        Screen currentScreen = menuSession.getNextScreen(true, entityScreenContext);
 
         if (!(currentScreen instanceof EntityScreen)) {
             // See if we have a persistent case tile to expand

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -15,6 +15,7 @@ import org.commcare.suite.model.SessionDatum;
 import org.commcare.suite.model.StackFrameStep;
 import org.commcare.util.screen.CommCareSessionException;
 import org.commcare.util.screen.EntityScreen;
+import org.commcare.util.screen.EntityScreenContext;
 import org.commcare.util.screen.MenuScreen;
 import org.commcare.util.screen.QueryScreen;
 import org.commcare.util.screen.Screen;
@@ -71,14 +72,15 @@ public class MenuSessionFactory {
     public void rebuildSessionFromFrame(MenuSession menuSession, CaseSearchHelper caseSearchHelper) throws CommCareSessionException, RemoteInstanceFetcher.RemoteInstanceException {
         Vector<StackFrameStep> steps = menuSession.getSessionWrapper().getFrame().getSteps();
         menuSession.resetSession();
-        Screen screen = menuSession.getNextScreen(false);
+        EntityScreenContext entityScreenContext = new EntityScreenContext();
+        Screen screen = menuSession.getNextScreen(false, entityScreenContext);
         int processedStepsCount = 0;
         boolean needsFullInit = false;
         while (screen != null) {
             String currentStep = null;
             if (screen instanceof MenuScreen) {
                 if (menuSession.autoAdvanceMenu(screen, storageFactory.getPropertyManager().isAutoAdvanceMenu())) {
-                    screen = menuSession.getNextScreen(needsFullInit);
+                    screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
                     continue;
                 }
 
@@ -106,8 +108,8 @@ public class MenuSessionFactory {
                     }
                 }
                 if (currentStep != null && currentStep != NEXT_SCREEN && entityScreen.shouldBeSkipped()) {
-                    menuSession.handleInput(currentStep, needsFullInit, true, false, null);
-                    screen = menuSession.getNextScreen(needsFullInit);
+                    menuSession.handleInput(currentStep, needsFullInit, true, false, entityScreenContext);
+                    screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
                     continue;
                 }
             } else if (screen instanceof QueryScreen) {
@@ -133,7 +135,7 @@ public class MenuSessionFactory {
                                 false
                             );
                             queryScreen.updateSession(searchDataInstance);
-                            screen = menuSession.getNextScreen(needsFullInit);
+                            screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
                             currentStep = NEXT_SCREEN;
                             break;
                         } catch (InvalidStructureException | IOException | XmlPullParserException | UnfullfilledRequirementsException e) {
@@ -146,9 +148,9 @@ public class MenuSessionFactory {
             if (currentStep == null) {
                 break;
             } else if (currentStep != NEXT_SCREEN) {
-                menuSession.handleInput(currentStep, needsFullInit, true, false, null);
+                menuSession.handleInput(currentStep, needsFullInit, true, false, entityScreenContext);
                 menuSession.addSelection(currentStep);
-                screen = menuSession.getNextScreen(needsFullInit);
+                screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
             }
         }
     }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -722,7 +722,8 @@ public class BaseTestClass {
     <T> T sessionNavigate(String requestPath, Class<T> clazz) throws Exception {
         Pair<String, SessionNavigationBean> refAndBean = Installer.getInstallReferenceAndBean(requestPath,
                 SessionNavigationBean.class);
-        return generateMockQueryWithInstallReference(refAndBean.first,
+        String installReference = Installer.getInstallReference(refAndBean.first);
+        return generateMockQueryWithInstallReference(installReference,
                 ControllerType.MENU,
                 RequestType.POST,
                 Constants.URL_MENU_NAVIGATION,

--- a/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CasePaginationTests.java
@@ -108,6 +108,22 @@ public class CasePaginationTests extends BaseTestClass {
         assert entityListResponse.getPageCount() == 0;
     }
 
+
+    /**
+     * This test uses an alternative path for session navigation in code to
+     * get to the entity screen. Mainly added to cover a regression when an
+     * auto-computed datum is present before the nodeset datum for a entry
+     */
+    @Test
+    public void testFuzzySearchInAlternativeApp() throws Exception {
+        EntityListResponse entityListResponse =
+                sessionNavigate("requests/navigators/search_navigator_2.json",
+                        EntityListResponse.class);
+        assert entityListResponse.getEntities().length == 1;
+        assert entityListResponse.getCurrentPage() == 0;
+        assert entityListResponse.getPageCount() == 0;
+    }
+
     @Test
     public void testNormalSearch() throws Exception {
         SQLiteDB db = storageFactoryMock.getSQLiteDB();

--- a/src/test/resources/archives/multi_select_case_list/suite.xml
+++ b/src/test/resources/archives/multi_select_case_list/suite.xml
@@ -102,6 +102,8 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
+<!--      Add a computed datum before nodeset datum to alter session navigation pathway for increased test coverage-->
+      <datum id="case_id_new_case_0" function="uuid()"/>
       <instance-datum id="selected_cases" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long" max-select-value="10"/>
     </session>
     <stack>

--- a/src/test/resources/requests/navigators/search_navigator_2.json
+++ b/src/test/resources/requests/navigators/search_navigator_2.json
@@ -1,0 +1,9 @@
+{
+  "username": "loaduser",
+  "password": "loadpass",
+  "domain": "loaddomain",
+  "app_id": "loadappid",
+  "selections": [0, 1],
+  "search_text": "batman",
+  "installReference": "archives/multi_select_case_list"
+}

--- a/src/test/resources/restores/ccqa.xml
+++ b/src/test/resources/restores/ccqa.xml
@@ -5964,6 +5964,42 @@ This XML file does not appear to have any style information associated with it. 
             <referrals>[]</referrals>
         </update>
     </case>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="5e421eb8bf414e03b4871195b869d894" date_modified="2016-07-18T19:55:11.240000Z" user_id="7afceb0259b2866be17b3632392f8a4b">
+        <create>
+            <case_type>case</case_type>
+            <case_name>123</case_name>
+            <owner_id>fb65b50c05aa5676ba68b5d5b8d581d2</owner_id>
+        </create>
+        <update>
+            <date_opened>2016-07-18</date_opened>
+            <sample_choice_question/>
+            <sample_number_question/>
+        </update>
+    </case>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="3512eb7c-7a58-4a95-beda-205eb0d7f163" date_modified="2017-04-21T14:38:49.323000Z" user_id="7afceb0259b2866be17b3632392f8a4b">
+        <create>
+            <case_type>case</case_type>
+            <case_name>Rudolph</case_name>
+            <owner_id>fb65b50c05aa5676ba68b5d5b8d581d2</owner_id>
+        </create>
+        <update>
+            <date_opened>2017-04-21</date_opened>
+            <sample_choice_question>choice1</sample_choice_question>
+            <sample_number_question>123</sample_number_question>
+        </update>
+    </case>
+    <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="94f8d030-c6f9-49e0-bc3f-5e0cdbf10c18" date_modified="2016-07-12T22:45:34.770000Z" user_id="7afceb0259b2866be17b3632392f8a4b">
+        <create>
+            <case_type>case</case_type>
+            <case_name>Batman Begins</case_name>
+            <owner_id>fb65b50c05aa5676ba68b5d5b8d581d2</owner_id>
+        </create>
+        <update>
+            <date_opened>2016-07-12</date_opened>
+            <sample_choice_question>choice2</sample_choice_question>
+            <sample_number_question>123</sample_number_question>
+        </update>
+    </case>
     <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="f8cba529-7e56-4f4e-9434-3b1e9f7d6377" date_modified="2016-04-21T14:55:13.474000Z" user_id="40a873063e6bf9a60d28ba7826b5efd6">
         <create>
             <case_type>coverage_basic</case_type>


### PR DESCRIPTION
## Technical Summary

https://dimagi-dev.atlassian.net/browse/SUPPORT-16768

There were some places in code that were passing the incorrect EntityContext to entity screen. This code pathway was triggered when there in auto computed datum present first before the nodeset datum. I have made the changes to pass in right entityContext to the session navigation code and also removed some methods which were re-initialising Entity context in order to lessen probability of us making a similar mistake again. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Mostly ensuring safety through tests and local testing

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

PR adds a regression test to verify the behaviour

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Not planned

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [x] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
