### PR TITLE
Avoid adding a null value to the request headers

### DIFF
--- a/src/main/java/org/commcare/formplayer/util/RequestUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/RequestUtils.java
@@ -131,10 +131,10 @@ public class RequestUtils {
             return null;
         }
         String ipAddress = request.getHeader("X-FORWARDED-FOR");
-        if (ipAddress == null) {
-            request.getRemoteAddr();
+        if (ipAddress != null) {
+            return ipAddress;
         }
-        return ipAddress;
+        return request.getRemoteAddr();
     }
 
     // If a multipart request returns the part having content type as 'application/json',

--- a/src/main/java/org/commcare/formplayer/web/client/WebClient.java
+++ b/src/main/java/org/commcare/formplayer/web/client/WebClient.java
@@ -64,7 +64,10 @@ public class WebClient {
         if (isMultipart) {
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         }
-        headers.add("X-CommCareHQ-Origin-IP", RequestUtils.getIpAddress());
+        String ipAddress = RequestUtils.getIpAddress();
+        if (ipAddress != null) {
+            headers.add("X-CommCareHQ-Origin-IP", ipAddress);
+        }
         return postRaw(uri, headers, body, String.class).getBody();
     }
 


### PR DESCRIPTION
## Technical Summary
https://dimagi.sentry.io/issues/4080192544/?query=is%3Aunresolved+Parameter+specified+as+non-null+is+null&referrer=issue-stream&statsPeriod=14d&stream_index=0

This was missed on code review on https://github.com/dimagi/formplayer/pull/1391

## Safety Assurance

### Safety story
Small fixes for a bug along with a safety check to ensure it can't happen.

### QA Plan
None


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
