### PR TITLE
Fixes entity list initialization after eof navigation

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -492,7 +492,7 @@ public class MenuSessionRunnerService {
             }
 
             autoAdvanceSession(menuSession, "", new QueryData(),
-                    false, entityScreenContext
+                    true, entityScreenContext
             );
             BaseResponseBean response = getNextMenu(menuSession, null, entityScreenContext);
             response.setSelections(menuSession.getSelections());

--- a/src/test/resources/archives/caseclaim/suite.xml
+++ b/src/test/resources/archives/caseclaim/suite.xml
@@ -124,6 +124,43 @@
       </stack>
     </action>
   </detail>
+  <detail id="m2_case_short">
+    <title>
+      <text>
+        <locale id="m1.case_short.title"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m1.case_short.case_name_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+      <sort type="string" order="1" direction="ascending">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
+    </field>
+    <action auto_launch="$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0" redo_last="false">
+      <display>
+        <text>
+          <locale id="case_search.m1"/>
+        </text>
+      </display>
+      <stack>
+        <push>
+          <mark/>
+          <command value="'search_command.m1'"/>
+        </push>
+      </stack>
+    </action>
+  </detail>
   <detail id="m0_search_short">
     <title>
       <text>
@@ -260,6 +297,23 @@
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
   </entry>
+  <entry>
+    <form>http://openrosa.org/formdesigner/5CCB1614-68B3-44C0-A166-D63AA7C1D4FB</form>
+    <command id="m2-f0">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id" detail-select="m2_case_short" detail-confirm="m1_case_long"/>
+    </session>
+    <stack>
+      <create>
+        <command value="'m2'"/>
+      </create>
+    </stack>
+  </entry>
   <menu id="root">
     <text>
       <locale id="modules.m0"/>
@@ -272,6 +326,12 @@
     </text>
     <command id="m1-f0"/>
     <command id="m1-f1"/>
+  </menu>
+  <menu id="m2">
+    <text>
+      <locale id="modules.m1"/>
+    </text>
+    <command id="m2-f0"/>
   </menu>
   <remote-request>
     <post url="http://localhost:8000/a/test/phone/claim-case/" relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">


### PR DESCRIPTION
## Technical Summary

Since the entity list reponse is constructed using the entity screen class now, we need to initialise the entity screen fully after eof navigation to make sure that entities gets constructed properly when we are navigating to a case list after eof navigation. 

https://dimagi-dev.atlassian.net/browse/USH-3325

Regression of https://github.com/dimagi/formplayer/pull/1384

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Regression fix with test coverage, code path is limited to apps using eof navigation


### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [x] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
