### PR TITLE
Handle auto launch better in EOF navigation

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -96,7 +96,7 @@ public class MenuSessionFactory {
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen)screen;
-                entityScreen.init(menuSession.getSessionWrapper());
+                entityScreen.initReferences(menuSession.getSessionWrapper());
                 SessionDatum neededDatum = entityScreen.getSession().getNeededDatum();
                 for (StackFrameStep step : steps) {
                     if (step.getId().equals(neededDatum.getDataId())) {
@@ -107,6 +107,14 @@ public class MenuSessionFactory {
                         break;
                     }
                 }
+
+                // Only init subscreen if we are not going to auto-launch a different screen
+                String nextInput = currentStep == null ? "" : currentStep;
+                entityScreen.evaluateAutoLaunch(nextInput);
+                if (entityScreen.getAutoLaunchAction() == null) {
+                    entityScreen.initListSubScreen();
+                }
+
                 if (currentStep != null && currentStep != NEXT_SCREEN && entityScreen.shouldBeSkipped()) {
                     menuSession.handleInput(currentStep, needsFullInit, true, false, entityScreenContext);
                     screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);

--- a/src/test/resources/archives/caseclaim/suite.xml
+++ b/src/test/resources/archives/caseclaim/suite.xml
@@ -147,6 +147,22 @@
         </text>
       </sort>
     </field>
+    <field>
+      <header>
+        <text>
+          <locale id="m1.case_short.title"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="$calculated_property">
+            <variable name="calculated_property">
+              <xpath function="count(instance('results')/results/cases) > 0"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
     <action auto_launch="$next_input = '' or count(instance('casedb')/casedb/case[@case_id=$next_input]) = 0" redo_last="false">
       <display>
         <text>


### PR DESCRIPTION
## Technical Summary

[Issue](https://dimagi-dev.atlassian.net/browse/USH-3325?focusedCommentId=271078)

https://github.com/dimagi/formplayer/pull/1384 resulted in an unintended consequence where after eof navigation we were always initialising the normal entity screen (not case search) even when the screen is going to auto-launch to entity screen. This resulted into an issue where if `instance('results')` is used for one of the detail fields for entity screen, it caused a `XPathMissingInstanceException` due to instance('results') not being available for the normal entity screen. 

This PR makes a change to only initialise entityListSubscreen and in turn the detail fields for the entity if we are not going to auto-launch to another screen.

## Safety Assurance

Relying on existing tests around EOF Navigations along with adding a test change to cover the regression. The impact of this change should be limited to case search workflows with auto-launch.  

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Not planning, but I can be convinced otherwise given it's a sensitive area.  I think we have good core navigation tests in FP to flag any regressions. But it might cause a rare edge case which is not covered in our tests. 

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [x] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/commcare-core/pull/1300
