### PR TITLE
Inline Case Search Endpoint Support

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -30,6 +30,7 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.Vector;
 
 import datadog.trace.api.Trace;
@@ -133,7 +134,7 @@ public class MenuSessionFactory {
                             throw new CommCareSessionException("Query URL format error: " + e.getMessage(), e);
                         }
                         ImmutableMultimap.Builder<String, String> dataBuilder = ImmutableMultimap.builder();
-                        step.getExtras().forEach((key, value) -> dataBuilder.put(key, value.toString()));
+                        step.getExtras().forEach((key, value) -> dataBuilder.putAll(key, ((Collection)value)));
                         try {
                             ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(
                                 queryScreen.getQueryDatum().getDataId(),

--- a/src/test/resources/archives/case_claim_with_multi_select/suite.xml
+++ b/src/test/resources/archives/case_claim_with_multi_select/suite.xml
@@ -259,6 +259,33 @@
       <instance-datum id="selected_cases" autoselect="true" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id" detail-select="m1_case_short_autolaunch_autoselect" detail-confirm="m1_case_long"/>
     </session>
   </entry>
+  <entry>
+    <form>http://openrosa.org/formdesigner/5CCB1614-68B3-44C0-A166-D63AA7C1D4FB</form>
+    <post url="http://localhost:8000/a/shubham/phone/claim-case/" relevant="$case_id != ''">
+      <data key="case_id" ref="." nodeset="instance('selected_cases')/results/value" exclude="count(instance('casedb')/casedb/case[@case_id=current()/.]) = 1"/>
+    </post>
+    <command id="m2-f0">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="results:inline" src="jr://instance/remote/results:inline"/>
+    <instance id="selected_cases" src="jr://instance/selected-entities/selected_cases"/>
+    <session>
+      <query url="http://localhost:8000/a/shubham/phone/search/87189ba3c8bb401490d63e7157f566c1/" storage-instance="results:inline" template="case" default_search="true">
+        <data key="case_type" ref="'case'"/>
+        <prompt key="name">
+          <display>
+            <text>
+              <locale id="search_property.m1.name"/>
+            </text>
+          </display>
+        </prompt>
+      </query>
+      <instance-datum id="selected_cases" nodeset="instance('results:inline')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+    </session>
+  </entry>
   <menu id="m1">
     <text>
       <locale id="modules.m1"/>
@@ -283,6 +310,47 @@
     </text>
     <command id="m0-f0"/>
   </menu>
+  <menu id="m2-inline-search">
+    <text>
+      <locale id="modules.m1"/>
+    </text>
+    <command id="m2-f0"/>
+  </menu>
+  <endpoint id="inline_case_search_list_without_selection">
+    <stack>
+      <push>
+        <command value="'m2-inline-search'"/>
+      </push>
+    </stack>
+  </endpoint>
+  <endpoint id="inline_case_search_list">
+    <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
+    <stack>
+      <push>
+        <command value="'m2-inline-search'"/>
+        <query id="results:inline" value="http://localhost:8000/a/shubham/phone/case_fixture/d54c955d883b4dd99f57571649271af1/">
+          <data key="case_type" ref="'case'"/>
+          <data key="case_id" nodeset="instance('selected_cases')/results/value" ref="."/>
+        </query>
+        <instance-datum id="selected_cases" value="$selected_cases"/>
+      </push>
+    </stack>
+  </endpoint>
+  <endpoint id="inline_case_search_form">
+    <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
+    <stack>
+      <push>
+        <command value="'m2-inline-search'"/>
+        <query id="results:inline" value="http://localhost:8000/a/shubham/phone/case_fixture/d54c955d883b4dd99f57571649271af1/">
+          <data key="case_type" ref="'case'"/>
+          <data key="case_id" nodeset="instance('selected_cases')/results/value" ref="."/>
+        </query>
+        <instance-datum id="selected_cases" value="$selected_cases"/>
+        <command value="'m2-f0'"/>
+      </push>
+    </stack>
+  </endpoint>
+
   <endpoint id="case_list">
     <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
     <stack>


### PR DESCRIPTION
## Technical Summary

Adds support for smartlinking inline case search modules as per the [spec here](https://docs.google.com/document/d/1owt1WE91-8jF7yUnzlbk5jB0YC8Uqeg3I3yTQy5vuVo/edit#heading=h.d9dq3mdn6f9n)

[HQ PR](https://github.com/dimagi/commcare-hq/pull/33461) and [Core PR](https://github.com/dimagi/commcare-core/pull/1328)

The [main technical change](https://github.com/dimagi/formplayer/pull/1454/commits/d38c9a1c204a698d2773ea4b8895109b06ba7a8d) in the PR is to make the `selected_cases` instance available to the endpoint stack right after argument processing. This is so that we can use the `instance('selected_cases`)` expressions in the endpoint stack itself. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

- Should only affect session endpoint workflows which has wide enough test coverage for different workflows
- Locally tested

### Automated test coverage

https://github.com/dimagi/formplayer/pull/1454/commits/d0cd2816fb3f30c2324eec918e2fa4feb7444696

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None


### Special deploy instructions


- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
