### PR TITLE
Remove obsolete backward compatibility flag for case search dropdowns

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8'
 
     //Unmanaged Dependencies
-    implementation group: 'com.datadoghq', name: 'dd-trace-api', version: '1.19.2'
+    implementation group: 'com.datadoghq', name: 'dd-trace-api', version: '1.19.3'
     implementation group: 'com.datadoghq', name: 'java-dogstatsd-client', version: '4.2.0'
     implementation group: 'io.sentry', name: 'sentry-spring-boot-starter', version: "${sentryVersion}"
     implementation group: 'io.sentry', name: 'sentry-logback', version: "${sentryVersion}"

--- a/src/main/java/org/commcare/formplayer/objects/QueryData.java
+++ b/src/main/java/org/commcare/formplayer/objects/QueryData.java
@@ -23,11 +23,6 @@ public class QueryData extends Hashtable<String, Object> {
     public static final String KEY_FORCE_MANUAL_SEARCH = "force_manual_search";
     private static final String KEY_INPUTS = "inputs";
 
-    // whether the select prompt selection is passed as itemset keys
-    // only here to maintain backward compatibility and can be removed
-    // once web apps fully transition using keys to convey select prompt selection.
-    private static final String KEY_SELECT_VALUES_BY_KEY = "select_values_by_key";
-
     public Boolean getExecute(String key) {
         return getProperty(key, KEY_EXECUTE);
     }
@@ -91,11 +86,4 @@ public class QueryData extends Hashtable<String, Object> {
         ((Map<String, Object>) this.get(key)).put(property, value);
     }
 
-    public boolean isSelectValuesByKeys(String key) {
-        return getProperty(key, KEY_SELECT_VALUES_BY_KEY);
-    }
-
-    public void setSelectValuesByKeys(String key, Boolean value) {
-        setProperty(key, value, KEY_SELECT_VALUES_BY_KEY);
-    }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -435,7 +435,7 @@ public class MenuSessionRunnerService {
     private void answerQueryPrompts(FormplayerQueryScreen screen, QueryData queryData, String queryKey) {
         Hashtable<String, String> queryDictionary = queryData == null ? null : queryData.getInputs(queryKey);
         if (queryDictionary != null) {
-            screen.answerPrompts(queryDictionary, queryData.isSelectValuesByKeys(queryKey));
+            screen.answerPrompts(queryDictionary);
         }
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -131,8 +131,8 @@ public class CaseClaimTests extends BaseTestClass {
 
         // select empty with a valid choice
         inputs.put("name", "#,#chris");
-        inputs.put("state", "0");
-        inputs.put("district", "#,#1");
+        inputs.put("state", "ka");
+        inputs.put("district", "#,#hampi");
         queryData.setExecute("search_command.m1", false);
         queryResponseBean = runQuery(queryData);
         assert queryResponseBean.getDisplays()[0].getValue().contentEquals("#,#chris");
@@ -218,13 +218,13 @@ public class CaseClaimTests extends BaseTestClass {
         assert queryResponseBean.getDisplays()[0].getValue().contentEquals("Burt");
 
         // multi-select test
-        inputs.put("state", "0");
-        inputs.put("district", "0#,#1"); // select 2 districts
+        inputs.put("state", "ka");
+        inputs.put("district", "bang#,#hampi"); // select 2 districts
         queryResponseBean = runQuery(queryData);
         assert queryResponseBean.getDisplays()[2].getValue().contentEquals("bang#,#hampi");
 
         // Select an invalid choice in multi-select and verify it's removed from formplayer response
-        inputs.put("district", "0#,#2#,#1");
+        inputs.put("district", "bang#,#WhyAmIHere#,#hampi");
         queryResponseBean = runQuery(queryData);
         assert queryResponseBean.getDisplays()[2].getValue().contentEquals("bang#,#hampi");
 
@@ -337,7 +337,7 @@ public class CaseClaimTests extends BaseTestClass {
     @Test
     public void testDependentItemsets_DependentChoicesChangeWithSelection() throws Exception {
         Hashtable<String, String> inputs = new Hashtable<>();
-        inputs.put("state", "1");
+        inputs.put("state", "rj");
         QueryData queryData = setUpQueryDataWithInput(inputs, true, false);
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assert queryResponseBean.getDisplays()[1].getValue().contentEquals("rj");
@@ -346,7 +346,7 @@ public class CaseClaimTests extends BaseTestClass {
         assertArrayEquals(queryResponseBean.getDisplays()[2].getItemsetChoices(),
                 new String[]{"Baran", "Kota"});
 
-        inputs.put("state", "0");
+        inputs.put("state", "ka");
         queryResponseBean = runQuery(queryData);
         assert queryResponseBean.getDisplays()[1].getValue().contentEquals("ka");
         assertArrayEquals(queryResponseBean.getDisplays()[1].getItemsetChoices(),
@@ -399,16 +399,16 @@ public class CaseClaimTests extends BaseTestClass {
     @Test
     public void testDependentItemsets_SelectionPeristsInResponse() throws Exception {
         Hashtable<String, String> inputs = new Hashtable<>();
-        inputs.put("state", "0");
-        inputs.put("district", "0");
+        inputs.put("state", "ka");
+        inputs.put("district", "bang");
         QueryData queryData = setUpQueryDataWithInput(inputs, true, false);
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assertEquals("ka", queryResponseBean.getDisplays()[1].getValue());
         assertEquals("bang", queryResponseBean.getDisplays()[2].getValue());
 
         // Change selection
-        inputs.put("state", "1");
-        inputs.put("district", "1");
+        inputs.put("state", "rj");
+        inputs.put("district", "kota");
         queryResponseBean = runQuery(queryData);
         assertEquals("rj", queryResponseBean.getDisplays()[1].getValue());
         assertEquals("kota", queryResponseBean.getDisplays()[2].getValue());
@@ -418,7 +418,7 @@ public class CaseClaimTests extends BaseTestClass {
     public void testDependentItemsets_WithKeysInResponse() throws Exception {
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("state", "rj");
-        QueryData queryData = setUpQueryDataWithInput(inputs, true, false, true);
+        QueryData queryData = setUpQueryDataWithInput(inputs, true, false);
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assertEquals(queryResponseBean.getDisplays()[1].getValue(), "rj");
         assertArrayEquals(queryResponseBean.getDisplays()[1].getItemsetChoices(),
@@ -452,7 +452,7 @@ public class CaseClaimTests extends BaseTestClass {
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("state", "ka");
         inputs.put("district", "baran");
-        QueryData queryData = setUpQueryDataWithInput(inputs, true, false, true);
+        QueryData queryData = setUpQueryDataWithInput(inputs, true, false);
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assertEquals(queryResponseBean.getDisplays()[1].getValue(),"ka");
         assertNull(queryResponseBean.getDisplays()[2].getValue());
@@ -538,11 +538,6 @@ public class CaseClaimTests extends BaseTestClass {
 
     private QueryData setUpQueryDataWithInput(Hashtable<String, String> inputs, boolean forceManual,
             boolean execute) {
-        return setUpQueryDataWithInput(inputs, forceManual, execute, false);
-    }
-
-    private QueryData setUpQueryDataWithInput(Hashtable<String, String> inputs, boolean forceManual,
-            boolean execute, boolean selectValuesByKeys) {
         QueryData queryData = new QueryData();
         queryData.setInputs("search_command.m1", inputs);
         if (forceManual) {
@@ -551,7 +546,6 @@ public class CaseClaimTests extends BaseTestClass {
         if (execute) {
             queryData.setExecute("search_command.m1", true);
         }
-        queryData.setSelectValuesByKeys("search_command.m1", selectValuesByKeys);
         return queryData;
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -114,6 +114,10 @@ public class CaseClaimTests extends BaseTestClass {
 
         // Empty params should be carried over to url as well
         queryData.setExecute("search_command.m1", true);
+        inputs.put("age", "22");
+        inputs.put("state", "ka");
+        inputs.put("name", "Burt");
+        inputs.put("dob", "");
         sessionNavigateWithQuery(new String[]{"1", "action 1"},
                 "caseclaim",
                 queryData,
@@ -122,11 +126,10 @@ public class CaseClaimTests extends BaseTestClass {
                 requestDataCaptor.capture());
         assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(0));
         Multimap<String, String> requestData = requestDataCaptor.getAllValues().get(0);
-        assertEquals(4, requestData.keySet().size());
+        assertEquals(6, requestData.keySet().size());
         assertArrayEquals(new String[]{"case1", "case2", "case3"},
                 requestData.get("case_type").toArray());
-        assertArrayEquals(new String[]{""}, requestData.get("name").toArray());
-        assertArrayEquals(new String[]{""}, requestData.get("state").toArray());
+        assertArrayEquals(new String[]{""}, requestData.get("dob").toArray());
         assertArrayEquals(new String[]{"False"}, requestData.get("include_closed").toArray());
 
         // select empty with a valid choice
@@ -148,7 +151,7 @@ public class CaseClaimTests extends BaseTestClass {
                 requestDataCaptor.capture());
         assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(2));
         requestData = requestDataCaptor.getAllValues().get(2);
-        assertEquals(5, requestData.keySet().size());
+        assertEquals(7, requestData.keySet().size());
         assertArrayEquals(new String[]{"case1", "case2", "case3"},
                 requestData.get("case_type").toArray());
         assertArrayEquals(new String[]{"", "chris"}, requestData.get("name").toArray());
@@ -229,6 +232,7 @@ public class CaseClaimTests extends BaseTestClass {
         assert queryResponseBean.getDisplays()[2].getValue().contentEquals("bang#,#hampi");
 
         // Execute Search to get results
+        inputs.put("age", "22"); // satisfy required condition to execute search
         queryData.setExecute("search_command.m1", true);
         responseBean = sessionNavigateWithQuery(new String[]{"1", "action 1"},
                 "caseclaim",
@@ -271,10 +275,11 @@ public class CaseClaimTests extends BaseTestClass {
         // Therefore there are only 2 http calls here instead of 3
         assertEquals("http://localhost:8000/a/test/phone/search/", urlCaptor.getAllValues().get(1));
         requestData = requestDataCaptor.getAllValues().get(1);
-        assertEquals(5, requestData.keySet().size());
+        assertEquals(6, requestData.keySet().size());
         assertArrayEquals(new String[]{"case1", "case2", "case3"},
                 requestData.get("case_type").toArray());
         assertArrayEquals(new String[]{"Burt"}, requestData.get("name").toArray());
+        assertArrayEquals(new String[]{"22"}, requestData.get("age").toArray());
         assertArrayEquals(new String[]{"bang", "hampi"}, requestData.get("district").toArray());
         assertArrayEquals(new String[]{"ka"}, requestData.get("state").toArray());
         assertArrayEquals(new String[]{"False"}, requestData.get("include_closed").toArray());
@@ -459,13 +464,13 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     @Test
-    public void testQueryPromptValidation_NullInputCausesNoError() throws Exception {
-        runRequestAndValidateAgeError(null, null, true, false);
+    public void testQueryPromptValidation_NullInputCausesRequiredError() throws Exception {
+        runRequestAndValidateAgeError(null, "One of age or DOB is required", true, false);
     }
 
     @Test
-    public void testQueryPromptValidation_EmptyInputCausesNoError() throws Exception {
-        runRequestAndValidateAgeError("", null, true, false);
+    public void testQueryPromptValidation_EmptyInputCausesRequiredError() throws Exception {
+        runRequestAndValidateAgeError("", "One of age or DOB is required", true, false);
     }
 
     @Test
@@ -479,13 +484,13 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     @Test
-    public void testQueryPromptValidationWithExecute_NullInputCausesNoError() throws Exception {
-        runRequestAndValidateAgeError(null, null, true, true);
+    public void testQueryPromptValidationWithExecute_NullInputCausesRequiredError() throws Exception {
+        runRequestAndValidateAgeError(null, "One of age or DOB is required", true, true);
     }
 
     @Test
-    public void testQueryPromptValidationWithExecute_EmptyInputCausesNoError() throws Exception {
-        runRequestAndValidateAgeError("", null, true, true);
+    public void testQueryPromptValidationWithExecute_EmptyInputCausesRequiredError() throws Exception {
+        runRequestAndValidateAgeError("", "One of age or DOB is required", true, true);
     }
 
     @Test
@@ -558,6 +563,8 @@ public class CaseClaimTests extends BaseTestClass {
 
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("name", "Burt");
+        inputs.put("age", "33");
+        inputs.put("state", "ka");
         QueryData queryData = setUpQueryDataWithInput(inputs, true, true);
         CommandListResponseBean response = sessionNavigateWithQuery(
                 new String[]{"1", "action 1", "3512eb7c-7a58-4a95-beda-205eb0d7f163"},


### PR DESCRIPTION
## Technical Summary

remove backward compatibility flag introduced as part of the [spec](https://docs.google.com/document/d/1Xtly4YfrdaB1w1Ozwlwy9LQ4JIrVRmhvg-44-Rl-z6A/edit) as all response to FP should have it set to `true` now. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Removes a obsolete flag
tested on staging. 

### Automated test coverage
Updated tests in the PR to test for new behaviour

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/commcare-core/pull/1325
