### PR TITLE
use instance_id_ variables For Multi Select Endpoints

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -754,7 +754,7 @@ public class MenuSessionRunnerService {
                 if (instanceSrc.contentEquals(JR_SELECTED_ENTITIES_REFERENCE)) {
                     String[] selectedEntites = argumentValue.split(",");
                     String uuid = storeInSelectedEntitiesInstance(argument, selectedEntites);
-                    argumentValues.put(argument.getId(), uuid);
+                    argumentValues.put("instance_id_" + argument.getId(), uuid);
                 } else {
                     throw new RuntimeException(
                             "Invalid instance-src defined for argument " + argument.getId() + " for endpoint "

--- a/src/test/resources/archives/case_claim_with_multi_select/suite.xml
+++ b/src/test/resources/archives/case_claim_with_multi_select/suite.xml
@@ -288,7 +288,7 @@
     <stack>
       <push>
         <command value="'m1-auto-launch'"/>
-        <instance-datum id="selected_cases" value="$selected_cases"/>
+        <instance-datum id="selected_cases" value="$instance_id_selected_cases"/>
       </push>
     </stack>
   </endpoint>
@@ -296,12 +296,12 @@
     <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
     <stack>
       <push>
-        <instance-datum id="selected_cases" value="$selected_cases"/>
+        <instance-datum id="selected_cases" value="$instance_id_selected_cases"/>
         <command value="'claim_command.case_list.selected_cases'"/>
       </push>
       <push>
         <command value="'m1-auto-launch'"/>
-        <instance-datum id="selected_cases" value="$selected_cases"/>
+        <instance-datum id="selected_cases" value="$instance_id_selected_cases"/>
       </push>
     </stack>
   </endpoint>


### PR DESCRIPTION
## Technical Summary
This is a modification on top of the [multi-select session endpoints support](https://docs.google.com/document/d/1nw-MbFvlMR5FQCpmQlHdmmJYQ-3e5BnMwx-epjumP9g/edit#heading=h.u0xbvhmgljhi). Instead of substituting the instance arguments directly, use a prefix `instance_id_argname` to signify that we want to substitue the argument with corresponding instance guid. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [ ] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [ ] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross-request: https://github.com/dimagi/commcare-core/pull/1327
