### PR TITLE
set default log levels

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -77,3 +77,8 @@ spring.datasource.password=${POSTGRESQL_PASSWROD:commcarehq}
 # --------------- set multipart file upload and request size limit
 spring.servlet.multipart.max-file-size=4MB
 spring.servlet.multipart.max-request-size=5MB
+
+logging.level.root=WARN
+logging.level.org.springframework.web=INFO
+logging.level.org.hibernate=ERROR
+logging.level.io.micrometer=ERROR


### PR DESCRIPTION
## Technical Summary
This is mostly for convenience in dev to reduce the amount of verbose logs.

## Safety Assurance

### Safety story
Change to default application properties which to configure logging should not have any impact in production.

### QA Plan
None


### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
