### PR TITLE
Backward compatibility fix for query extras

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -134,7 +134,15 @@ public class MenuSessionFactory {
                             throw new CommCareSessionException("Query URL format error: " + e.getMessage(), e);
                         }
                         ImmutableMultimap.Builder<String, String> dataBuilder = ImmutableMultimap.builder();
-                        step.getExtras().forEach((key, value) -> dataBuilder.putAll(key, ((Collection)value)));
+                        step.getExtras().forEach((key, value) -> {
+                            if (value instanceof Collection) {
+                                dataBuilder.putAll(key, ((Collection)value));
+                            } else {
+                                // only to maintain backward compatibility with old serialised app db state,
+                                // can be removed in subsequent deploys
+                                dataBuilder.putAll(key, value.toString());
+                            }
+                        });
                         try {
                             ExternalDataInstance searchDataInstance = caseSearchHelper.getRemoteDataInstance(
                                 queryScreen.getQueryDatum().getDataId(),


### PR DESCRIPTION
## Technical Summary

[Sentry](https://dimagi.sentry.io/issues/4477380077/?project=142105&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)

[Jira](https://dimagi-dev.atlassian.net/browse/SUPPORT-17607)

Corresponding FP fix for https://github.com/dimagi/commcare-core/pull/1334

## Safety Assurance

Retains old code for stack query extras processing which should already have been working.

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

Good test coverage to check for the core worflow around stack query datums. 

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [x] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
