### PR TITLE
Supports getting short detail in `get_details` endpoint

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -129,7 +129,8 @@ public class MenuController extends AbstractBaseController {
                 new EntityDetailListResponse(entityScreen,
                         menuSession.getEvalContextWithHereFuncHandler(),
                         reference,
-                        storageFactory.getPropertyManager().isFuzzySearchEnabled()),
+                        storageFactory.getPropertyManager().isFuzzySearchEnabled(),
+                        sessionNavigationBean.getIsShortDetail()),
                 menuSession
         );
     }

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -25,6 +25,7 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int sortIndex;
     private int casesPerPage;
     private String[] selectedValues;
+    private boolean isShortDetail;
 
     /**
      * Form session ID used to prevent attempts to navigate into a form session
@@ -112,6 +113,14 @@ public class SessionNavigationBean extends InstallRequestBean {
 
     public void setIsPersistent(boolean persistent) {
         isPersistent = persistent;
+    }
+
+    public boolean getIsShortDetail() {
+        return isShortDetail;
+    }
+
+    public void setIsShortDetail(boolean shortDetail) {
+        isShortDetail = shortDetail;
     }
 
     public int getSortIndex() {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailListResponse.java
@@ -28,8 +28,8 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     }
 
     public EntityDetailListResponse(EntityScreen screen, EvaluationContext ec,
-            TreeReference treeReference, boolean isFuzzySearchEnabled) {
-        entityDetailList = processDetails(screen, ec, treeReference, isFuzzySearchEnabled);
+            TreeReference treeReference, boolean isFuzzySearchEnabled, boolean isShortDetail) {
+        entityDetailList = processDetails(screen, ec, treeReference, isFuzzySearchEnabled, isShortDetail);
     }
 
     public EntityDetailListResponse(Detail[] detailList, EvaluationContext ec,
@@ -38,8 +38,14 @@ public class EntityDetailListResponse extends LocationRelevantResponseBean {
     }
 
     private EntityDetailResponse[] processDetails(EntityScreen screen, EvaluationContext ec,
-            TreeReference ref, boolean isFuzzySearchEnabled) {
-        return processDetails(screen.getLongDetailList(ref), ec, ref, isFuzzySearchEnabled);
+            TreeReference ref, boolean isFuzzySearchEnabled, boolean isShortDetail) {
+        Detail[] detailList;
+        if (isShortDetail) {
+            detailList = new Detail[]{screen.getShortDetail()};
+        } else {
+            detailList = screen.getLongDetailList(ref);
+        }
+        return processDetails(detailList, ec, ref, isFuzzySearchEnabled);
     }
 
     private EntityDetailResponse[] processDetails(Detail[] detailList,

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -695,15 +695,15 @@ public class BaseTestClass {
     }
 
     <T> T getDetails(String[] selections, String testName, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, null, clazz, false);
+        return getDetails(selections, testName, null, null, clazz, false, false);
     }
 
     <T> T getDetails(String[] selections, String testName, QueryData queryData, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, queryData, clazz, false);
+        return getDetails(selections, testName, null, queryData, clazz, false, false);
     }
 
     <T> T getDetails(String[] selections, String testName, String locale, QueryData queryData, Class<T> clazz,
-            boolean inline) throws Exception {
+            boolean inline, boolean isShortDetail) throws Exception {
         SessionNavigationBean sessionNavigationBean = new SessionNavigationBean();
         sessionNavigationBean.setDomain(testName + "domain");
         sessionNavigationBean.setAppId(testName + "appid");
@@ -711,6 +711,7 @@ public class BaseTestClass {
         sessionNavigationBean.setSelections(selections);
         sessionNavigationBean.setIsPersistent(inline);
         sessionNavigationBean.setQueryData(queryData);
+        sessionNavigationBean.setIsShortDetail(isShortDetail);
         if (locale != null && !"".equals(locale.trim())) {
             sessionNavigationBean.setLocale(locale);
         }
@@ -723,7 +724,7 @@ public class BaseTestClass {
     }
 
     <T> T getDetailsInline(String[] selections, String testName, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, null, clazz, true);
+        return getDetails(selections, testName, null, null, clazz, true, false);
     }
 
     <T> T sessionNavigate(String requestPath, Class<T> clazz) throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -296,6 +296,23 @@ public class CaseClaimTests extends BaseTestClass {
         Object[] detailFields = entityDetailResponseItem.getDetails();
         assertEquals(detailFields.length, 1);
         assertEquals(detailFields[0], "Burt Maclin");
+
+        // test short detail request
+        responseBean = getDetails(detailSelections,
+                "caseclaim",
+                null,
+                queryData,
+                EntityDetailListResponse.class,
+                false,
+                true);
+        entityDetailResponse = responseBean.getEntityDetailList();
+        assertEquals(entityDetailResponse.length, 1);
+        entityDetailResponseItem = entityDetailResponse[0];
+        detailFields = entityDetailResponseItem.getDetails();
+        assertEquals(detailFields.length, 3);
+        assertEquals(detailFields[0], "Burt Maclin");
+        assertEquals(detailFields[1], "Burt Maclin");
+        assertEquals(detailFields[2], "Kurt Maclin");
     }
 
     @Test


### PR DESCRIPTION
[Jira](https://dimagi-dev.atlassian.net/browse/USH-3776)

## Technical Summary

Adds support for getting short detail for a case in `get_details` endpoint by setting a flag `is_short_detail` to `true`

Required to refresh a single case DB row after performing a [clickable action](https://docs.google.com/document/d/1coxsFVCYgaQdxE3rgYikRSgEgistrfIUJuoW5KMiM5w/edit#heading=h.yq5vabwe65r7)

## Safety Assurance

### Safety story

Changes are isolated to `is_short_detail` being `true`

### Automated test coverage

PR adds a test for new behaviour with tests for old behaviour already present

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
