### PR TITLE
Fixes endpoint launch for auto form submission

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -60,8 +60,8 @@ public class MenuController extends AbstractBaseController {
     @UserRestore
     @AppInstall
     public EntityDetailListResponse getDetails(@RequestBody SessionNavigationBean sessionNavigationBean,
-                                               @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                               HttpServletRequest request) throws Exception {
+            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+            HttpServletRequest request) throws Exception {
         MenuSession menuSession = menuSessionFactory.getMenuSessionFromBean(sessionNavigationBean);
         boolean isFuzzySearch = storageFactory.getPropertyManager().isFuzzySearchEnabled();
         if (sessionNavigationBean.getIsPersistent()) {
@@ -79,9 +79,10 @@ public class MenuController extends AbstractBaseController {
                     null,
                     true
             );
-            notificationLogger.logNotification(baseResponseBean.getNotification(),request);
+            notificationLogger.logNotification(baseResponseBean.getNotification(), request);
             // See if we have a persistent case tile to expand
-            EntityDetailListResponse detail = runnerService.getInlineDetail(menuSession, storageFactory.getPropertyManager().isFuzzySearchEnabled());
+            EntityDetailListResponse detail = runnerService.getInlineDetail(menuSession,
+                    storageFactory.getPropertyManager().isFuzzySearchEnabled());
             if (detail == null) {
                 throw new RuntimeException("Could not get inline details");
             }
@@ -108,13 +109,14 @@ public class MenuController extends AbstractBaseController {
                 null,
                 true
         );
-        notificationLogger.logNotification(baseResponseBean.getNotification(),request);
+        notificationLogger.logNotification(baseResponseBean.getNotification(), request);
 
         Screen currentScreen = menuSession.getNextScreen(true, entityScreenContext);
 
         if (!(currentScreen instanceof EntityScreen)) {
             // See if we have a persistent case tile to expand
-            EntityDetailResponse detail = runnerService.getPersistentDetail(menuSession, storageFactory.getPropertyManager().isFuzzySearchEnabled());
+            EntityDetailResponse detail = runnerService.getPersistentDetail(menuSession,
+                    storageFactory.getPropertyManager().isFuzzySearchEnabled());
             if (detail == null) {
                 throw new RuntimeException("Tried to get details while not on a case list.");
             }
@@ -145,13 +147,14 @@ public class MenuController extends AbstractBaseController {
      * @param authToken             The Django session id auth token
      * @return A MenuBean or a NewFormResponse
      */
-    @RequestMapping(value = {Constants.URL_MENU_NAVIGATION, Constants.URL_INITIAL_MENU_NAVIGATION}, method = RequestMethod.POST)
+    @RequestMapping(value = {Constants.URL_MENU_NAVIGATION,
+            Constants.URL_INITIAL_MENU_NAVIGATION}, method = RequestMethod.POST)
     @UserLock
     @UserRestore
     @AppInstall
     public BaseResponseBean navigateSessionWithAuth(@RequestBody SessionNavigationBean sessionNavigationBean,
-                                                    @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                                    HttpServletRequest request) throws Exception {
+            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+            HttpServletRequest request) throws Exception {
         String[] selections = sessionNavigationBean.getSelections();
         MenuSession menuSession;
         menuSession = menuSessionFactory.getMenuSessionFromBean(sessionNavigationBean);
@@ -181,7 +184,8 @@ public class MenuController extends AbstractBaseController {
         }
     }
 
-    private SubmitResponseBean handleAutoFormSubmission(HttpServletRequest request, SessionNavigationBean sessionNavigationBean,
+    private SubmitResponseBean handleAutoFormSubmission(HttpServletRequest request,
+            SessionNavigationBean sessionNavigationBean,
             BaseResponseBean response) throws Exception {
         if (response instanceof NewFormResponse) {
             NewFormResponse formResponse = ((NewFormResponse)response);
@@ -194,7 +198,8 @@ public class MenuController extends AbstractBaseController {
         return null;
     }
 
-    private static <T extends LocationRelevantResponseBean> T setLocationNeeds(T responseBean, MenuSession menuSession) {
+    private static <T extends LocationRelevantResponseBean> T setLocationNeeds(T responseBean,
+            MenuSession menuSession) {
         responseBean.setShouldRequestLocation(menuSession.locationRequestNeeded());
         responseBean.setShouldWatchLocation(menuSession.hereFunctionEvaluated());
         return responseBean;
@@ -205,8 +210,8 @@ public class MenuController extends AbstractBaseController {
     @UserRestore
     @AppInstall
     public BaseResponseBean navigateToEndpoint(@RequestBody SessionNavigationBean sessionNavigationBean,
-                                                    @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                                                    HttpServletRequest request) throws Exception {
+            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+            HttpServletRequest request) throws Exception {
         // Apps using aggressive syncs are likely to hit a sync whenever using endpoint-based navigation,
         // since they use it to jump between different sandboxes. Turn it off.
         restoreFactory.setPermitAggressiveSyncs(false);

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -7,6 +7,7 @@ import org.commcare.formplayer.annotations.UserLock;
 import org.commcare.formplayer.annotations.UserRestore;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.SessionNavigationBean;
+import org.commcare.formplayer.beans.SubmitResponseBean;
 import org.commcare.formplayer.beans.menus.BaseResponseBean;
 import org.commcare.formplayer.beans.menus.EntityDetailListResponse;
 import org.commcare.formplayer.beans.menus.EntityDetailResponse;
@@ -169,6 +170,19 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getFormSessionId(),
                 true
         );
+
+        SubmitResponseBean formSubmissionResponse = handleAutoFormSubmission(request, sessionNavigationBean,
+                response);
+        if (formSubmissionResponse != null) {
+            return formSubmissionResponse;
+        } else {
+            notificationLogger.logNotification(response.getNotification(), request);
+            return setLocationNeeds(response, menuSession);
+        }
+    }
+
+    private SubmitResponseBean handleAutoFormSubmission(HttpServletRequest request, SessionNavigationBean sessionNavigationBean,
+            BaseResponseBean response) throws Exception {
         if (response instanceof NewFormResponse) {
             NewFormResponse formResponse = ((NewFormResponse)response);
             if (formResponse.getShouldAutoSubmit()) {
@@ -177,8 +191,7 @@ public class MenuController extends AbstractBaseController {
                         true, new HashMap<>());
             }
         }
-        notificationLogger.logNotification(response.getNotification(), request);
-        return setLocationNeeds(response, menuSession);
+        return null;
     }
 
     private static <T extends LocationRelevantResponseBean> T setLocationNeeds(T responseBean, MenuSession menuSession) {

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -215,7 +215,13 @@ public class MenuController extends AbstractBaseController {
         BaseResponseBean response = runnerService.advanceSessionWithEndpoint(menuSession,
                 sessionNavigationBean.getEndpointId(),
                 sessionNavigationBean.getEndpointArgs());
-        notificationLogger.logNotification(response.getNotification(), request);
-        return setLocationNeeds(response, menuSession);
+        SubmitResponseBean formSubmissionResponse = handleAutoFormSubmission(request, sessionNavigationBean,
+                response);
+        if (formSubmissionResponse != null) {
+            return formSubmissionResponse;
+        } else {
+            notificationLogger.logNotification(response.getNotification(), request);
+            return setLocationNeeds(response, menuSession);
+        }
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/AutoFormSubmissionTest.kt
+++ b/src/test/java/org/commcare/formplayer/tests/AutoFormSubmissionTest.kt
@@ -1,6 +1,9 @@
 package org.commcare.formplayer.tests
 
+import org.commcare.formplayer.beans.NewFormResponse
 import org.commcare.formplayer.beans.SubmitResponseBean
+import org.commcare.formplayer.util.Constants
+import org.commcare.formplayer.utils.WithHqUser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
@@ -14,10 +17,23 @@ class AutoFormSubmissionTest : BaseTestClass() {
     }
 
     @Test
-    fun testAutoSelection() {
+    fun testAutoFormSubmission() {
         // We directly go to the form without selecting the case
         val selections = arrayOf("2", "0")
         val response = sessionNavigate(selections, APP, SubmitResponseBean::class.java)
+        assertNotNull(response)
+        assertEquals("success", response.status)
+    }
+
+    @Test
+    @WithHqUser(enabledToggles = [Constants.TOGGLE_SESSION_ENDPOINTS])
+    fun testAutoSubmitFormEndpoint() {
+        val response = sessionNavigateWithEndpoint(
+            APP,
+            "auto_submit_form",
+            HashMap(),
+            SubmitResponseBean::class.java
+        )
         assertNotNull(response)
         assertEquals("success", response.status)
     }

--- a/src/test/resources/archives/multi_select_case_list/suite.xml
+++ b/src/test/resources/archives/multi_select_case_list/suite.xml
@@ -199,4 +199,12 @@
       </push>
     </stack>
   </endpoint>
+  <endpoint id="auto_submit_form">
+    <stack>
+      <push>
+        <command value="'menu-auto-submit'"/>
+        <command value="'m0-auto-submit-form'"/>
+      </push>
+    </stack>
+  </endpoint>
 </suite>


### PR DESCRIPTION
## Technical Summary
Adds auto form submission handling to get_endpoint so that the form gets submitted in the same request as get_endpoint

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Only affects endpoint launches which has good test coverage 

### Automated test coverage

[Covered in endpoint tests](https://github.com/dimagi/formplayer/blob/master/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java)

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

Review commit by commit as there are some indentation changes in a commit
