### PR TITLE
Clickable Icons: Clear cache search cache for get_details request based on a request flag

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -94,6 +94,10 @@ public class MenuController extends AbstractBaseController {
         String detailSelection = selections[selections.length - 1];
         System.arraycopy(selections, 0, commitSelections, 0, selections.length - 1);
 
+        if (sessionNavigationBean.getIsRefreshCaseSearch()) {
+            runnerService.clearCaseSearchCache();
+        }
+
         EntityScreenContext entityScreenContext = new EntityScreenContext(sessionNavigationBean.getOffset(),
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -27,6 +27,8 @@ public class SessionNavigationBean extends InstallRequestBean {
     private String[] selectedValues;
     private boolean isShortDetail;
 
+    private boolean isRefreshCaseSearch;
+
     /**
      * Form session ID used to prevent attempts to navigate into a form session
      * e.g. pressing the back button
@@ -117,6 +119,13 @@ public class SessionNavigationBean extends InstallRequestBean {
 
     public boolean getIsShortDetail() {
         return isShortDetail;
+    }
+    public boolean getIsRefreshCaseSearch() {
+        return isRefreshCaseSearch;
+    }
+
+    public void setIsRefreshCaseSearch(boolean refreshCaseSearch) {
+        isRefreshCaseSearch = refreshCaseSearch;
     }
 
     public void setIsShortDetail(boolean shortDetail) {

--- a/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
@@ -217,4 +217,8 @@ public class CaseSearchHelper {
         }
         return builder.toString();
     }
+
+    public void clearCache() {
+        cacheManager.getCache("case_search").clear();
+    }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -780,4 +780,8 @@ public class MenuSessionRunnerService {
     public CaseSearchHelper getCaseSearchHelper() {
         return caseSearchHelper;
     }
+
+    public void clearCaseSearchCache() {
+        caseSearchHelper.clearCache();
+    }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -695,15 +695,15 @@ public class BaseTestClass {
     }
 
     <T> T getDetails(String[] selections, String testName, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, null, clazz, false, false);
+        return getDetails(selections, testName, null, null, clazz, false, false, false);
     }
 
     <T> T getDetails(String[] selections, String testName, QueryData queryData, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, queryData, clazz, false, false);
+        return getDetails(selections, testName, null, queryData, clazz, false, false, false);
     }
 
     <T> T getDetails(String[] selections, String testName, String locale, QueryData queryData, Class<T> clazz,
-            boolean inline, boolean isShortDetail) throws Exception {
+            boolean inline, boolean isShortDetail, boolean isRefreshCaseSearch) throws Exception {
         SessionNavigationBean sessionNavigationBean = new SessionNavigationBean();
         sessionNavigationBean.setDomain(testName + "domain");
         sessionNavigationBean.setAppId(testName + "appid");
@@ -712,6 +712,7 @@ public class BaseTestClass {
         sessionNavigationBean.setIsPersistent(inline);
         sessionNavigationBean.setQueryData(queryData);
         sessionNavigationBean.setIsShortDetail(isShortDetail);
+        sessionNavigationBean.setIsRefreshCaseSearch(isRefreshCaseSearch);
         if (locale != null && !"".equals(locale.trim())) {
             sessionNavigationBean.setLocale(locale);
         }
@@ -724,7 +725,7 @@ public class BaseTestClass {
     }
 
     <T> T getDetailsInline(String[] selections, String testName, Class<T> clazz) throws Exception {
-        return getDetails(selections, testName, null, null, clazz, true, false);
+        return getDetails(selections, testName, null, null, clazz, true, false, false);
     }
 
     <T> T sessionNavigate(String requestPath, Class<T> clazz) throws Exception {


### PR DESCRIPTION
## Product Description
https://dimagi-dev.atlassian.net/browse/QA-5771

Fixes issue where get_details request doesn't give latest data after performing a case change using clickable icon due to cache search cache not refreshing.

## Technical Summary

Adds a flag called `is_refresh_case_search` to request beans and clear cache search cache if it's set to `true`

## Safety Assurance

### Safety story
Should only affect clickable icons feature when we set the `isRefreshCaseSearch` to true for `get_details`

### Automated test coverage
PR adds a test to verify new bheaviour

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
