### PR TITLE
Added new clear upload translation to web apps

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -133,8 +133,8 @@ public class NewFormResponseFactory {
                 serializedSession.getInstanceXml()
         );
 
-        String[] translationKey = {"repeat.dialog.add.new"};
-        for (String key : translationKey) {
+        String[] translationKeys = {"repeat.dialog.add.new", "upload.clear.title"};
+        for (String key : translationKeys) {
             String translation = Localization.getWithDefault(key, null);
             if (translation != null) {
                 response.addToTranslation(key, translation);


### PR DESCRIPTION
## Product Description
Part of https://dimagi-dev.atlassian.net/browse/USH-3867

Add new translation string to the set of translations set down to Web Apps.

Necessary for https://github.com/dimagi/commcare-hq/pull/33790

## Safety Assurance

### Safety story
This is pretty trivial.

### Automated test coverage
unlikely

### QA Plan
not requesting QA

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
