### PR TITLE
Jt/visually segmented case search groups

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
@@ -192,7 +192,7 @@ public class DisplayElement {
         return requiredMsg;
     }
 
-    @JsonGetter(value = "group_key")
+    @JsonGetter(value = "groupKey")
     @Nullable
     public String getGroupKey() {
         return groupKey;

--- a/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
@@ -51,6 +51,9 @@ public class DisplayElement {
     @Nullable
     private String requiredMsg;
 
+    @Nullable
+    private String groupKey;
+
     public DisplayElement() {
     }
 
@@ -68,8 +71,8 @@ public class DisplayElement {
     public DisplayElement(DisplayUnit displayUnit, EvaluationContext ec, String id,
             @Nullable String input,
             @Nullable String receive, @Nullable String hidden, @Nullable String value,
-            @Nullable String[] itemsetChoicesKeys, @Nullable String[] itemsetChoicesLabels, boolean allowBlankValue, boolean required,
-            String requiredMsg, String error) {
+            @Nullable String[] itemsetChoicesKeys, @Nullable String[] itemsetChoicesLabels, boolean allowBlankValue,
+            boolean required, String requiredMsg, String error, @Nullable String groupKey) {
         this.id = id;
         this.text = displayUnit.getText().evaluate(ec);
         if (displayUnit.getImageURI() != null) {
@@ -91,6 +94,7 @@ public class DisplayElement {
         this.allowBlankValue = allowBlankValue;
         this.required = required;
         this.requiredMsg = requiredMsg;
+        this.groupKey = groupKey;
         this.error = error;
     }
 
@@ -186,5 +190,11 @@ public class DisplayElement {
     @Nullable
     public String getRequiredMsg() {
         return requiredMsg;
+    }
+
+    @JsonGetter(value = "group_key")
+    @Nullable
+    public String getGroupKey() {
+        return groupKey;
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/DisplayElement.java
@@ -192,7 +192,6 @@ public class DisplayElement {
         return requiredMsg;
     }
 
-    @JsonGetter(value = "groupKey")
     @Nullable
     public String getGroupKey() {
         return groupKey;

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -25,7 +25,7 @@ public class QueryResponseBean extends MenuBean {
     private DisplayElement[] displays;
     private final String type = "query";
     private String description;
-    private OrderedHashtable<String, String> groupHeader;
+    private OrderedHashtable<String, String> groupHeaders;
 
     QueryResponseBean() {
     }
@@ -46,8 +46,8 @@ public class QueryResponseBean extends MenuBean {
         this.displays = displays;
     }
 
-    public OrderedHashtable<String, String> getGroupHeader(){
-        return groupHeader;
+    public OrderedHashtable<String, String> getGroupHeaders(){
+        return groupHeaders;
     }
 
     public QueryResponseBean(QueryScreen queryScreen) {
@@ -93,12 +93,12 @@ public class QueryResponseBean extends MenuBean {
         }
 
         OrderedHashtable<String, QueryGroup> queryGroupMap = queryScreen.getGroupHeaders();
-        groupHeader = new OrderedHashtable<>();
+        groupHeaders = new OrderedHashtable<>();
         for (Map.Entry<String, QueryGroup> entry : queryGroupMap.entrySet()) {
             String key = entry.getKey();
             QueryGroup queryGroupItem = entry.getValue();
             String text = queryGroupItem.getDisplay().getText().evaluate(ec);
-            groupHeader.put(key, text);
+            groupHeaders.put(key, text);
         }
 
         setTitle(queryScreen.getScreenTitle());

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -4,6 +4,7 @@ import org.commcare.modern.session.SessionWrapper;
 import org.commcare.modern.util.Pair;
 import org.commcare.session.RemoteQuerySessionManager;
 import org.commcare.suite.model.QueryPrompt;
+import org.commcare.suite.model.QueryGroup;
 import org.commcare.util.screen.QueryScreen;
 import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.utils.ItemSetUtils;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 /**
  * Created by willpride on 4/13/16.
@@ -23,6 +25,7 @@ public class QueryResponseBean extends MenuBean {
     private DisplayElement[] displays;
     private final String type = "query";
     private String description;
+    private OrderedHashtable<String, String> groupHeader;
 
     QueryResponseBean() {
     }
@@ -41,6 +44,10 @@ public class QueryResponseBean extends MenuBean {
 
     private void setDisplays(DisplayElement[] displays) {
         this.displays = displays;
+    }
+
+    public OrderedHashtable<String, String> getGroupHeader(){
+        return groupHeader;
     }
 
     public QueryResponseBean(QueryScreen queryScreen) {
@@ -84,6 +91,16 @@ public class QueryResponseBean extends MenuBean {
                     );
             count++;
         }
+
+        OrderedHashtable<String, QueryGroup> queryGroupMap = queryScreen.getGroupHeaders();
+        groupHeader = new OrderedHashtable<>();
+        for (Map.Entry<String, QueryGroup> entry : queryGroupMap.entrySet()) {
+            String key = entry.getKey();
+            QueryGroup queryGroupItem = entry.getValue();
+            String text = queryGroupItem.getDisplay().getText().evaluate(ec);
+            groupHeader.put(key, text);
+        }
+
         setTitle(queryScreen.getScreenTitle());
         setDescription(queryScreen.getDescriptionText());
         setQueryKey(queryScreen.getQueryKey());

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -79,7 +79,8 @@ public class QueryResponseBean extends MenuBean {
                     queryPromptItem.isAllowBlankValue(),
                     isRequired,
                     requiredMessage,
-                    errors.get(key)
+                    errors.get(key),
+                    queryPromptItem.getGroupKey()
                     );
             count++;
         }

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -92,7 +92,7 @@ public class QueryResponseBean extends MenuBean {
             count++;
         }
 
-        OrderedHashtable<String, QueryGroup> queryGroupMap = queryScreen.getGroupHeaders();
+        Hashtable<String, QueryGroup> queryGroupMap = queryScreen.getGroupHeaders();
         groupHeaders = new OrderedHashtable<>();
         for (Map.Entry<String, QueryGroup> entry : queryGroupMap.entrySet()) {
             String key = entry.getKey();

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -25,7 +25,7 @@ public class QueryResponseBean extends MenuBean {
     private DisplayElement[] displays;
     private final String type = "query";
     private String description;
-    private OrderedHashtable<String, String> groupHeaders;
+    private Hashtable<String, String> groupHeaders;
 
     QueryResponseBean() {
     }
@@ -46,8 +46,12 @@ public class QueryResponseBean extends MenuBean {
         this.displays = displays;
     }
 
-    public OrderedHashtable<String, String> getGroupHeaders(){
+    public Hashtable<String, String> getGroupHeaders(){
         return groupHeaders;
+    }
+
+    public void setGroupHeaders(Hashtable<String, String> groupHeaders){
+        this.groupHeaders = groupHeaders;
     }
 
     public QueryResponseBean(QueryScreen queryScreen) {
@@ -92,15 +96,7 @@ public class QueryResponseBean extends MenuBean {
             count++;
         }
 
-        Hashtable<String, QueryGroup> queryGroupMap = queryScreen.getGroupHeaders();
-        groupHeaders = new OrderedHashtable<>();
-        for (Map.Entry<String, QueryGroup> entry : queryGroupMap.entrySet()) {
-            String key = entry.getKey();
-            QueryGroup queryGroupItem = entry.getValue();
-            String text = queryGroupItem.getDisplay().getText().evaluate(ec);
-            groupHeaders.put(key, text);
-        }
-
+        setGroupHeaders(queryScreen.evalGroupHeaders());
         setTitle(queryScreen.getScreenTitle());
         setDescription(queryScreen.getDescriptionText());
         setQueryKey(queryScreen.getQueryKey());

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -438,6 +438,27 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     @Test
+    public void testQueryPromptGrouped() throws Exception {
+        QueryData queryData = new QueryData();
+
+        QueryResponseBean queryResponseBean = sessionNavigateWithQuery(
+                new String[]{"1", "action 1"},
+                "caseclaim",
+                queryData,
+                QueryResponseBean.class);
+
+        String groupKey1 = "group_header_0";
+        String groupKey2 = "group_header_3";
+        String expectedHeader1 = "Group1 Header";
+        String expectedHeader2 = "Group2 Header";
+
+        assertEquals(queryResponseBean.getGroupHeaders().get(groupKey1), expectedHeader1);
+        assertEquals(queryResponseBean.getGroupHeaders().get(groupKey2), expectedHeader2);
+        assertEquals(queryResponseBean.getDisplays()[0].getGroupKey(), groupKey1);
+        assertEquals(queryResponseBean.getDisplays()[4].getGroupKey(), groupKey2);
+    }
+
+    @Test
     public void testDependentItemsets_DependentChoicesChangeWithSelection() throws Exception {
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("state", "rj");

--- a/src/test/resources/archives/caseclaim/default/app_strings.txt
+++ b/src/test/resources/archives/caseclaim/default/app_strings.txt
@@ -42,3 +42,5 @@ search_property.m1.age.validation=age should be greater than 18
 search_property.m1.age.required=One of age or DOB is required
 search_property.m1.dob=Date of Birth
 search_property.m1.dob.required=One of age or DOB is required
+search_property.m0.group_header_0=Group1 Header
+search_property.m0.group_header_3=Group2 Header

--- a/src/test/resources/archives/caseclaim/suite.xml
+++ b/src/test/resources/archives/caseclaim/suite.xml
@@ -371,14 +371,28 @@
         <data ref="'case2'" key="case_type"/>
         <data ref="'case3'" key="case_type"/>
         <data ref="'False'" key="include_closed"/>
-        <prompt key="name" default="instance('commcaresession')/session/context/deviceid" required="true()">
+        <group key="group_header_0">
+          <display>
+            <text>
+              <locale id="search_property.m0.group_header_0"/>
+            </text>
+          </display>
+        </group>
+        <group key="group_header_3">
+          <display>
+            <text>
+              <locale id="search_property.m0.group_header_3"/>
+            </text>
+          </display>
+        </group>
+        <prompt key="name" default="instance('commcaresession')/session/context/deviceid" required="true()" group_key="group_header_0">
           <display>
             <text>
               <locale id="search_property.m1.name"/>
             </text>
           </display>
         </prompt>
-        <prompt key="state" input="select1" default="&quot;ka&quot;" allow_blank_value="true" required="true()">
+        <prompt key="state" input="select1" default="&quot;ka&quot;" allow_blank_value="true" required="true()" group_key="group_header_0">
           <display>
             <text>
               <locale id="search_property.m1.state"/>
@@ -395,7 +409,7 @@
             <sort ref="id"/>
           </itemset>
         </prompt>
-        <prompt key="district" input="select">
+        <prompt key="district" input="select" group_key="group_header_3">
           <display>
             <text>
               <locale id="search_property.m1.district"/>
@@ -407,7 +421,7 @@
             <sort ref="id"/>
           </itemset>
         </prompt>
-        <prompt key="age">
+        <prompt key="age" group_key="group_header_3">
           <validation test="count(.) = 1 and int(instance('my-search-input')/input/field[@name='age'])>18">
             <text>
               <locale id="search_property.m1.age.validation"/>
@@ -424,7 +438,7 @@
             </text>
           </display>
         </prompt>
-        <prompt key="dob">
+        <prompt key="dob" group_key="group_header_3">
           <display>
             <text>
               <locale id="search_property.m1.dob"/>


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This change affects `queryResponse`. It adds `groupKey` to `display` elements and `groupHeaders` dictionary to `queryResponse`. The `groupKey` of each display element corresponds to a key in `groupHeaders`.
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Tech Spec](https://docs.google.com/document/d/1syEA-HC5g1FOjZ6m8DlfBspzKn9hKvq0zbMNbIWzQVE/edit#heading=h.d7s2sycdfk92)
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/USH-3826)
[Research Doc](https://docs.google.com/document/d/1ZkN0_ta8jEjQ5IYHLIduBN6ZFcVEjfSIQrN3AQgBVgw/edit#heading=h.x97repjoa0f2)

Commcare-core PR: https://github.com/dimagi/commcare-core/pull/1389
HQ PR: https://github.com/dimagi/commcare-hq/pull/33828
## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
locally tested.
This does not alter existing response values but only adds new key:values.  

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Will add tests

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Will [QA](https://dimagi-dev.atlassian.net/browse/QA-5881)

### Special deploy instructions
Needs to be merged with/after https://github.com/dimagi/commcare-core/pull/1389

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
