### PR TITLE
Added translation population to answer requests

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -236,6 +236,8 @@ public class FormController extends AbstractBaseController {
 
         updateSession(formEntrySession);
 
+        responseBean.populateTranslations();
+
         categoryTimingHelper.timed(
                 Constants.TimingCategories.COMPILE_RESPONSE,
                 () -> {

--- a/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
@@ -6,6 +6,8 @@ import org.commcare.util.screen.ScreenUtils;
 
 import java.util.HashMap;
 
+import org.javarosa.core.services.locale.Localization;
+
 /**
  * Base class for responses being sent to the front end. Params are: title - self explanatory
  * notification - A message String and error boolean to be displayed by frontend sholdAutoSubmit - A
@@ -128,10 +130,17 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
         this.translations = translations;
     }
 
-    public void addToTranslation(String key, String value) {
+    public void populateTranslations() {
         if (this.translations == null) {
             this.translations = new HashMap<String, String>();
         }
-        this.translations.put(key, value);
+
+        String[] translationKeys = {"repeat.dialog.add.new", "upload.clear.title"};
+        for (String key : translationKeys) {
+            String translation = Localization.getWithDefault(key, null);
+            if (translation != null) {
+                this.translations.put(key, translation);
+            }
+        }
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -12,7 +12,6 @@ import org.commcare.formplayer.web.client.WebClient;
 import org.commcare.session.CommCareSession;
 import org.javarosa.core.model.FormDef;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
-import org.javarosa.core.services.locale.Localization;
 import org.javarosa.xform.util.XFormUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -133,13 +132,7 @@ public class NewFormResponseFactory {
                 serializedSession.getInstanceXml()
         );
 
-        String[] translationKeys = {"repeat.dialog.add.new", "upload.clear.title"};
-        for (String key : translationKeys) {
-            String translation = Localization.getWithDefault(key, null);
-            if (translation != null) {
-                response.addToTranslation(key, translation);
-            }
-        }
+        response.populateTranslations();
 
         return response;
     }


### PR DESCRIPTION
## Product Description
Followup for https://dimagi-dev.atlassian.net/browse/USH-3867

## Technical Summary

Translations were available only in the new form response. This meant they **weren't** available to questions shown after the form initially loaded, when a display condition switched from false to true, because that data comes from an `answer` response. This PR moves translations from `NewFormResponse` to `BaseResponseBean` so they're available on `answer` responses.

## Safety Assurance

### Safety story
Bug fix with a fairly small blast radius. Tested locally.

### Automated test coverage
I don't think so

### QA Plan
not requesting QA

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
