### PR TITLE
remove query key fallback

### DIFF
--- a/src/main/java/org/commcare/formplayer/objects/QueryData.java
+++ b/src/main/java/org/commcare/formplayer/objects/QueryData.java
@@ -24,12 +24,12 @@ public class QueryData extends Hashtable<String, Object> {
     public static final String KEY_FORCE_MANUAL_SEARCH = "force_manual_search";
     private static final String KEY_INPUTS = "inputs";
 
-    public Boolean getExecute(String key, String fallbackKey) {
-        return getPropertyWithFallback(key, fallbackKey, KEY_EXECUTE);
+    public Boolean getExecute(String key) {
+        return getPropertyWithFallback(key, KEY_EXECUTE);
     }
 
-    public boolean isForceManualSearch(String key, String fallbackKey) {
-        return getPropertyWithFallback(key, fallbackKey, KEY_FORCE_MANUAL_SEARCH);
+    public boolean isForceManualSearch(String key) {
+        return getPropertyWithFallback(key, KEY_FORCE_MANUAL_SEARCH);
     }
 
     public void setExecute(String key, Boolean value) {
@@ -40,11 +40,8 @@ public class QueryData extends Hashtable<String, Object> {
         setProperty(key, value, KEY_FORCE_MANUAL_SEARCH);
     }
 
-    public Hashtable<String, String> getInputs(String key, String fallbackKey) {
+    public Hashtable<String, String> getInputs(String key) {
         Map<String, Object> value = (Map<String, Object>) this.get(key);
-        if (value == null) {
-            value = (Map<String, Object>) this.get(fallbackKey);
-        }
         if (value != null) {
             Map<String, String> valueInputs = (Map<String, String>) value.get(this.KEY_INPUTS);
             if (valueInputs != null) {
@@ -87,11 +84,8 @@ public class QueryData extends Hashtable<String, Object> {
 
     // temporary method for backward compatibility, will be replaced with original getProperty method
     // without fallback in the subsequent deploy
-    private Boolean getPropertyWithFallback(String key, String fallbackKey, String property) {
+    private Boolean getPropertyWithFallback(String key, String property) {
         Map<String, Object> value = (Map<String, Object>) this.get(key);
-        if(value == null){
-            value = (Map<String, Object>) this.get(fallbackKey);
-        }
         if (value != null) {
             return value.containsKey(property) && (Boolean) value.get(property);
         }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -182,8 +182,7 @@ public class MenuSessionRunnerService {
             Sentry.setTag(Constants.MODULE_NAME_TAG, caseListName);
         } else if (nextScreen instanceof FormplayerQueryScreen) {
             String queryKey = ((FormplayerQueryScreen)nextScreen).getQueryKey();
-            String fallbackQueryKey = menuSession.getSessionWrapper().getCommand();
-            answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey, fallbackQueryKey);
+            answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey);
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_search");
             Sentry.setTag(Constants.MODULE_TAG, "case_search");
@@ -415,12 +414,10 @@ public class MenuSessionRunnerService {
             boolean replay, boolean skipCache)
             throws CommCareSessionException {
         String queryKey = queryScreen.getQueryKey();
-        String fallbackQueryKey = menuSession.getSessionWrapper().getCommand();
-        boolean forceManualSearch = queryData != null && queryData.isForceManualSearch(queryKey, fallbackQueryKey);
-
+        boolean forceManualSearch = queryData != null && queryData.isForceManualSearch(queryKey);
         boolean autoSearch = replay || (queryScreen.doDefaultSearch() && !forceManualSearch);
-        answerQueryPrompts(queryScreen, queryData, queryKey, fallbackQueryKey);
-        if ((queryData != null && queryData.getExecute(queryKey, fallbackQueryKey)) || autoSearch) {
+        answerQueryPrompts(queryScreen, queryData, queryKey);
+        if ((queryData != null && queryData.getExecute(queryKey)) || autoSearch) {
             return doQuery(
                     queryScreen,
                     queryScreen.doDefaultSearch() && !forceManualSearch,
@@ -435,9 +432,8 @@ public class MenuSessionRunnerService {
     }
 
     // Sets the query fields and refreshes any itemset choices based on them
-    private void answerQueryPrompts(FormplayerQueryScreen screen, QueryData queryData, String queryKey,
-            String fallbackQueryKey) {
-        Hashtable<String, String> queryDictionary = queryData == null ? null : queryData.getInputs(queryKey, fallbackQueryKey);
+    private void answerQueryPrompts(FormplayerQueryScreen screen, QueryData queryData, String queryKey) {
+        Hashtable<String, String> queryDictionary = queryData == null ? null : queryData.getInputs(queryKey);
         if (queryDictionary != null) {
             screen.answerPrompts(queryDictionary);
         }

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -93,7 +93,7 @@ public class CaseClaimTests extends BaseTestClass {
         configureQueryMock();
         // Run query with an app with dynamic_search true and verify
         QueryData queryData = new QueryData();
-        queryData.setForceManualSearch("search_command.m1", true);
+        queryData.setForceManualSearch("search_command.m1_results", true);
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assertTrue(queryResponseBean.getDynamicSearch());
 


### PR DESCRIPTION
## Technical Summary

Removes fallback that was added in https://github.com/dimagi/formplayer/pull/1495/files to maintain backward compatibility with older API versions. 

## Safety Assurance

### Safety story

This fallback was added to support compatibility between live sessions before and after deploy and removing this should not result in any functional changes. 

### Automated test coverage
Tests with new query key was added as part of [original PR ](https://github.com/dimagi/formplayer/pull/1495/)

### QA Plan
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
