### PR TITLE
Do not skip cache for page changes

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -377,7 +377,8 @@ public class MenuSessionRunnerService {
                 }
             } else if (nextScreen instanceof FormplayerQueryScreen) {
                 boolean replay = !nextInput.equals(NO_SELECTION);
-                boolean skipCache = !(replay || entityScreenContext.getDetailSelection() != null);
+                boolean skipCache = !(replay || entityScreenContext.getDetailSelection() != null
+                        || entityScreenContext.getOffSet() != 0);
                 sessionAdvanced = handleQueryScreen(
                         (FormplayerQueryScreen)nextScreen, menuSession, queryData,
                         replay, skipCache

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -854,12 +854,24 @@ public class BaseTestClass {
             QueryData queryData,
             String[] selectedValues,
             Class<T> clazz) throws Exception {
+        return sessionNavigateWithQuery(selections, testName, queryData, selectedValues, 0, 10, clazz);
+    }
+
+    <T> T sessionNavigateWithQuery(String[] selections,
+            String testName,
+            QueryData queryData,
+            String[] selectedValues,
+            int offset,
+            int casesPerPage,
+            Class<T> clazz) throws Exception {
         SessionNavigationBean sessionNavigationBean = new SessionNavigationBean();
         sessionNavigationBean.setSelections(selections);
         sessionNavigationBean.setDomain(testName + "domain");
         sessionNavigationBean.setAppId(testName + "appid");
         sessionNavigationBean.setUsername(testName + "username");
         sessionNavigationBean.setQueryData(queryData);
+        sessionNavigationBean.setOffset(offset);
+        sessionNavigationBean.setCasesPerPage(casesPerPage);
         sessionNavigationBean.setSelectedValues(selectedValues);
         return generateMockQueryWithInstallReference(Installer.getInstallReference(testName),
                 ControllerType.MENU,

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -396,6 +396,38 @@ public class CaseClaimTests extends BaseTestClass {
         }
     }
 
+
+    @Test
+    public void testCacheSkipWithPageChanges() throws Exception {
+        // open case search list for the first time to ppopulate the cache
+        try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery(
+                "query_responses/case_claim_response.xml")) {
+            sessionNavigateWithQuery(new String[]{"1", "action 1"},
+                    "caseclaim",
+                    null,
+                    null,
+                    0,
+                    2,
+                    EntityListResponse.class);
+        }
+
+        Mockito.reset(webClientMock);
+
+        // Making the same request with non zero offset should use the cache and hence should pass without
+        // mocking the case search request
+        try {
+            sessionNavigateWithQuery(new String[]{"1", "action 1"},
+                    "caseclaim",
+                    null,
+                    null,
+                    1,
+                    2,
+                    EntityListResponse.class);
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
     @Test
     public void testQueryPromptRequired() throws Exception {
         QueryData queryData = new QueryData();


### PR DESCRIPTION
## Technical Summary

Prompted by [the issue here](https://docs.google.com/document/d/1y-G9PH3c3FFupRawIYTeaX_cehc-hGHQomu1BwnB3gY/edit#heading=h.7vsnlyupdpde)

When shifting from page 1 to page 2 of a case list backed by case search, we currently redo case search request because of `skipCache` set to true. (This is a side effect of [the fix](https://github.com/dimagi/formplayer/pull/1172) that was implemented for https://dimagi-dev.atlassian.net/browse/USH-2171.)  This PR makes a change so that if we are not requesting the first page of the entity list, we keep `skipCache` set to `false` and not redo the case search. 

Caveating that a better solution here can be for Web Apps to send a flag in the request say 'pageChange` based on which FP can know that it was only a page change from user end and it should not skip the case search cache.  

## Safety Assurance

- Should only affect entity list pagination 
- Workflow should be unaffected as the only impact the change have is whether we do the case search request again or not.

### Automated test coverage
None around the specific change but the workflow is covered by a number of tests. Possibly a test here can be to verify whether we used cache or not when doing a request for `offset!=0` ?

### QA Plan
NA


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
