### PR TITLE
Adds metadata in request response 

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/ResponseMetaData.java
+++ b/src/main/java/org/commcare/formplayer/beans/ResponseMetaData.java
@@ -1,0 +1,27 @@
+package org.commcare.formplayer.beans;
+
+/**
+ * Useful meta data to include in request response
+ */
+public class ResponseMetaData {
+
+    private boolean attemptRestore;
+    private boolean appInstall;
+
+    public ResponseMetaData() {
+        // default constructor for jackson
+    }
+
+    public ResponseMetaData(boolean attemptRestore, boolean appInstall) {
+        this.attemptRestore = attemptRestore;
+        this.appInstall = appInstall;
+    }
+
+    public boolean isAttemptRestore() {
+        return attemptRestore;
+    }
+
+    public boolean isAppInstall() {
+        return appInstall;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.beans.menus;
 
 import org.commcare.formplayer.beans.NotificationMessage;
+import org.commcare.formplayer.beans.ResponseMetaData;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.util.screen.ScreenUtils;
 
@@ -26,6 +27,8 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
     private HashMap<String, String> translations;
     private String smartLinkRedirect;
     private boolean dynamicSearch;
+
+    private ResponseMetaData metaData;
 
     public BaseResponseBean() {
     }
@@ -128,6 +131,14 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     public void setTranslations(HashMap<String, String> translations) {
         this.translations = translations;
+    }
+
+    public ResponseMetaData getMetaData() {
+        return metaData;
+    }
+
+    public void setMetaData(ResponseMetaData metaData) {
+        this.metaData = metaData;
     }
 
     public void addToTranslation(String key, String value) {

--- a/src/main/java/org/commcare/formplayer/services/InstallService.java
+++ b/src/main/java/org/commcare/formplayer/services/InstallService.java
@@ -44,6 +44,9 @@ public class InstallService {
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private ResponseMetaDataTracker responseMetaDataTracker;
+
     private final Log log = LogFactory.getLog(InstallService.class);
 
     CategoryTimingHelper.RecordingTimer installTimer;
@@ -91,6 +94,7 @@ public class InstallService {
             engine.initEnvironment();
             installTimer.end();
             installTimer.record();
+            responseMetaDataTracker.setNewInstall(true);
             return new Pair<>(engine, newInstall);
         } catch (UnresolvedResourceException e) {
             throw new UnresolvedResourceRuntimeException(e);

--- a/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
+++ b/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
@@ -1,0 +1,30 @@
+package org.commcare.formplayer.services;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class ResponseMetaDataTracker {
+
+    private boolean attemptRestore = false;
+
+    private boolean newInstall = false;
+
+    public boolean isAttemptRestore() {
+        return attemptRestore;
+    }
+
+    public void setAttemptRestore(boolean attemptRestore) {
+        this.attemptRestore = attemptRestore;
+    }
+
+    public boolean isNewInstall() {
+        return newInstall;
+    }
+
+    public void setNewInstall(boolean newInstall) {
+        this.newInstall = newInstall;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -116,6 +116,9 @@ public class RestoreFactory {
     protected StatsDClient datadogStatsDClient;
 
     @Autowired
+    private ResponseMetaDataTracker responseMetaDataTracker;
+
+    @Autowired
     private CategoryTimingHelper categoryTimingHelper;
 
     @Autowired
@@ -535,6 +538,7 @@ public class RestoreFactory {
         downloadRestoreTimer = categoryTimingHelper.newTimer(Constants.TimingCategories.DOWNLOAD_RESTORE, domain);
         downloadRestoreTimer.start();
         try {
+            responseMetaDataTracker.setAttemptRestore(true);
             response = webClient.getRaw(restoreUrl, org.springframework.core.io.Resource.class);
             status = response.getStatusCode().toString();
         } catch (HttpClientErrorException e) {

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -76,6 +76,7 @@ import org.commcare.formplayer.services.MenuSessionFactory;
 import org.commcare.formplayer.services.MenuSessionRunnerService;
 import org.commcare.formplayer.services.MenuSessionService;
 import org.commcare.formplayer.services.NewFormResponseFactory;
+import org.commcare.formplayer.services.ResponseMetaDataTracker;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.services.SubmitService;
 import org.commcare.formplayer.services.VirtualDataInstanceService;
@@ -167,6 +168,9 @@ public class BaseTestClass {
 
     @Autowired
     private MenuSessionService menuSessionService;
+
+    @Autowired
+    private ResponseMetaDataTracker responseMetaDataTracker;
 
     @Autowired
     protected WebClient webClientMock;

--- a/src/test/java/org/commcare/formplayer/utils/TestContext.java
+++ b/src/test/java/org/commcare/formplayer/utils/TestContext.java
@@ -23,6 +23,7 @@ import org.commcare.formplayer.services.MenuSessionFactory;
 import org.commcare.formplayer.services.MenuSessionRunnerService;
 import org.commcare.formplayer.services.MenuSessionService;
 import org.commcare.formplayer.services.NewFormResponseFactory;
+import org.commcare.formplayer.services.ResponseMetaDataTracker;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.services.SubmitService;
 import org.commcare.formplayer.services.VirtualDataInstanceService;
@@ -134,6 +135,11 @@ public class TestContext {
     @Bean
     public RestoreFactory restoreFactory() {
         return Mockito.spy(RestoreFactory.class);
+    }
+
+    @Bean
+    public ResponseMetaDataTracker responseMetaDataTracker() {
+        return Mockito.spy(ResponseMetaDataTracker.class);
     }
 
     @Bean


### PR DESCRIPTION
## Technical Summary

Adds metadata in request response  to indicate if the request went through a restore or app install

<img width="932" alt="Screenshot 2024-01-08 at 12 31 55 PM" src="https://github.com/dimagi/formplayer/assets/4679137/d674c176-9189-4c00-a2c7-24fd6061dba0">


This is to help in adding visibility to requests that takes more than normal time once in a while. 

## Safety Assurance

### Safety story

Locally tested

### QA Plan
No



### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
