### PR TITLE
No details if only a popup field is defined

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -102,7 +102,7 @@ public class EntityListResponse extends MenuBean {
             entities = new EntityBean[entityBeans.size()];
             entityBeans.toArray(entities);
             setNoItemsText(getNoItemsTextLocaleString(detail));
-            hasDetails = nextScreen.getLongDetail() != null;
+            hasDetails = hasDetails(nextScreen);
 
             processTitle(session);
             processCaseTiles(detail);
@@ -129,6 +129,15 @@ public class EntityListResponse extends MenuBean {
                 }
             }
         }
+    }
+
+    private boolean hasDetails(EntityScreen nextScreen) {
+        if (nextScreen.getLongDetail() == null) {
+            return false;
+        }
+        return !Arrays
+                .stream(nextScreen.getLongDetail().getFields())
+                .allMatch(field -> "address-popup".equals(field.getTemplateForm()));
     }
 
     private void processCaseTiles(Detail shortDetail) {


### PR DESCRIPTION
## Product Description

The details should not be shown if only an address popup field is defined

## Technical Summary

https://dimagi-dev.atlassian.net/browse/USH-4008

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
