### PR TITLE
Adds DD tag for Case Search Input

### DIFF
--- a/src/main/java/org/commcare/formplayer/objects/QueryData.java
+++ b/src/main/java/org/commcare/formplayer/objects/QueryData.java
@@ -52,6 +52,11 @@ public class QueryData extends Hashtable<String, Object> {
         return null;
     }
 
+    public void setInitiatedBy(String key, String value) {
+        this.initKey(key);
+        ((Map<String, Object>) this.get(key)).put(INITIATED_BY, value);
+    }
+
     public Hashtable<String, String> getInputs(String key) {
         Map<String, Object> value = (Map<String, Object>) this.get(key);
         if (value != null) {

--- a/src/main/java/org/commcare/formplayer/objects/QueryData.java
+++ b/src/main/java/org/commcare/formplayer/objects/QueryData.java
@@ -23,6 +23,7 @@ public class QueryData extends Hashtable<String, Object> {
     private static final String KEY_EXECUTE = "execute";
     public static final String KEY_FORCE_MANUAL_SEARCH = "force_manual_search";
     private static final String KEY_INPUTS = "inputs";
+    private static final String INITIATED_BY = "initiatedBy";
 
     public Boolean getExecute(String key) {
         return getPropertyWithFallback(key, KEY_EXECUTE);
@@ -38,6 +39,17 @@ public class QueryData extends Hashtable<String, Object> {
 
     public void setForceManualSearch(String key, Boolean value) {
         setProperty(key, value, KEY_FORCE_MANUAL_SEARCH);
+    }
+
+    public String getInitiatedBy(String key) {
+        Map<String, Object> value = (Map<String, Object>) this.get(key);
+        if (value != null) {
+            String initiatedBy = (String) value.get(INITIATED_BY);
+            if (initiatedBy != null) {
+                return initiatedBy;
+            }
+        }
+        return null;
     }
 
     public Hashtable<String, String> getInputs(String key) {

--- a/src/main/java/org/commcare/formplayer/objects/QueryData.java
+++ b/src/main/java/org/commcare/formplayer/objects/QueryData.java
@@ -45,9 +45,7 @@ public class QueryData extends Hashtable<String, Object> {
         Map<String, Object> value = (Map<String, Object>) this.get(key);
         if (value != null) {
             String initiatedBy = (String) value.get(INITIATED_BY);
-            if (initiatedBy != null) {
                 return initiatedBy;
-            }
         }
         return null;
     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -188,6 +188,8 @@ public class MenuSessionRunnerService {
             if (queryInitiatedBy != null) {
                 datadog.addRequestScopedTag(Constants.MODULE_INITIATED_BY_TAG, queryInitiatedBy);
             }
+            String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
+            datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_search");
             Sentry.setTag(Constants.MODULE_TAG, "case_search");
         } else {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -184,7 +184,7 @@ public class MenuSessionRunnerService {
             String queryKey = ((FormplayerQueryScreen)nextScreen).getQueryKey();
             answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey);
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
-            String queryInitiatedBy = queryData.getInitiatedBy(queryKey);
+            String queryInitiatedBy = queryData == null ? null : queryData.getInitiatedBy(queryKey);
             if (queryInitiatedBy != null) {
                 datadog.addRequestScopedTag(Constants.MODULE_INITIATED_BY_TAG, queryInitiatedBy);
             }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -184,6 +184,10 @@ public class MenuSessionRunnerService {
             String queryKey = ((FormplayerQueryScreen)nextScreen).getQueryKey();
             answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey);
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
+            String queryInitiatedBy = queryData.getInitiatedBy(queryKey);
+            if (queryInitiatedBy != null) {
+                datadog.addRequestScopedTag(Constants.MODULE_INITIATED_BY_TAG, queryInitiatedBy);
+            }
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_search");
             Sentry.setTag(Constants.MODULE_TAG, "case_search");
         } else {

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -125,6 +125,7 @@ public class Constants {
     public static final String DOMAIN_TAG = "domain";
     public static final String FORM_NAME_TAG = "form_name";
     public static final String MODULE_TAG = "module";
+    public static final String MODULE_INITIATED_BY_TAG = "module_initiated_by";
     public static final String MODULE_NAME_TAG = "module_name";
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -491,6 +491,13 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     @Test
+    public void testQueryInitiatedBy() throws Exception {
+        QueryData queryData = new QueryData();
+        queryData.setInitiatedBy("search_command.m1_results", "field_change");
+        assertEquals(queryData.getInitiatedBy("search_command.m1_results"), "field_change");
+    }
+
+    @Test
     public void testDependentItemsets_DependentChoicesChangeWithSelection() throws Exception {
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("state", "rj");


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Adds a `module_initiated_by` tag to Datadog. This value is passed by HQ to signify what initiated the query. Specifically in this case, we are interested in queries triggered via user search input for case search. These will be tagged as `field_change`.

![Screen Shot 2024-01-22 at 9 24 54 AM](https://github.com/dimagi/formplayer/assets/88759246/72cbcdd7-11ec-46e8-9e25-b6007358f4ee)

This additionally includes `module_name` tags for requests tagged as `case_search` module 

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Commcare HQ ](https://github.com/dimagi/commcare-hq/pull/34006)
[Jira Ticket](https://dimagi-dev.atlassian.net/browse/USH-4051)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Locally tested and tested on staging

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
