### PR TITLE
Alt text for icons

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityBean.java
@@ -10,6 +10,7 @@ public class EntityBean {
     private Object[] data;
 
     private String groupKey;
+    private String[] altText;
 
     public EntityBean() {
     }
@@ -40,6 +41,14 @@ public class EntityBean {
 
     public void setGroupKey(String groupKey) {
         this.groupKey = groupKey;
+    }
+
+    public String[] getAltText() {
+        return altText;
+    }
+
+    public void setAltText(String[] altText) {
+        this.altText = altText;
     }
 
     @Override

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityDetailResponse.java
@@ -33,6 +33,7 @@ public class EntityDetailResponse {
     private EntityBean[] entities;
     protected Style[] styles;
     protected String[] headers;
+    protected String[] altText;
     protected String title;
     protected boolean isUseNodeset;
 
@@ -53,6 +54,7 @@ public class EntityDetailResponse {
         this.headers = entityScreen.getHeaders();
         this.styles = entityScreen.getStyles();
         this.tiles = processCaseTiles(entityScreen.getDetail());
+        this.altText = entityScreen.getAltText();
     }
 
     private static Object[] processDetails(Object[] data) {
@@ -171,6 +173,14 @@ public class EntityDetailResponse {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String[] getAltText() {
+        return altText;
+    }
+
+    public void setAltText(String[] altText) {
+        this.altText = altText;
     }
 
     public boolean isUsesCaseTiles() {

--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -245,6 +245,7 @@ public class EntityListResponse extends MenuBean {
         }
         entityBean.setData(data);
         entityBean.setGroupKey(entity.getGroupKey());
+        entityBean.setAltText(entity.getAltText());
         return entityBean;
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/CaseListLazyLoadingTests.kt
+++ b/src/test/java/org/commcare/formplayer/tests/CaseListLazyLoadingTests.kt
@@ -55,6 +55,7 @@ class CaseListLazyLoadingTests {
         assertEquals(singleEntity.data[0], "Batman Begins")
         assertEquals(singleEntity.data[1], "Batman Begins")
         assertEquals(singleEntity.groupKey, "Batman Begins")
+        assertEquals(singleEntity.altText.toList(), arrayOfNulls<String>(singleEntity.data.size).toList())
 
         response = navigate(selections, EntityListResponse::class.java, 1, 3)
         entitites = response.entities
@@ -64,6 +65,7 @@ class CaseListLazyLoadingTests {
         assertEquals(singleEntity.data[0], "Rudolph")
         assertEquals(singleEntity.data[1], "Rudolph")
         assertEquals(singleEntity.groupKey, "Rudolph")
+        assertEquals(singleEntity.altText.toList(), arrayOfNulls<String>(singleEntity.data.size).toList())
     }
 
     private fun <T : BaseResponseBean> navigate(

--- a/src/test/java/org/commcare/formplayer/tests/CaseListLazyLoadingTests.kt
+++ b/src/test/java/org/commcare/formplayer/tests/CaseListLazyLoadingTests.kt
@@ -8,6 +8,7 @@ import org.commcare.formplayer.junit.*
 import org.commcare.formplayer.junit.Installer.Companion.getInstallReference
 import org.commcare.formplayer.junit.request.SessionNavigationRequest
 import org.commcare.formplayer.utils.TestContext
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -55,7 +56,7 @@ class CaseListLazyLoadingTests {
         assertEquals(singleEntity.data[0], "Batman Begins")
         assertEquals(singleEntity.data[1], "Batman Begins")
         assertEquals(singleEntity.groupKey, "Batman Begins")
-        assertEquals(singleEntity.altText.toList(), arrayOfNulls<String>(singleEntity.data.size).toList())
+        assertArrayEquals(singleEntity.altText, arrayOfNulls<String>(singleEntity.data.size))
 
         response = navigate(selections, EntityListResponse::class.java, 1, 3)
         entitites = response.entities
@@ -65,7 +66,7 @@ class CaseListLazyLoadingTests {
         assertEquals(singleEntity.data[0], "Rudolph")
         assertEquals(singleEntity.data[1], "Rudolph")
         assertEquals(singleEntity.groupKey, "Rudolph")
-        assertEquals(singleEntity.altText.toList(), arrayOfNulls<String>(singleEntity.data.size).toList())
+        assertArrayEquals(singleEntity.altText, arrayOfNulls<String>(singleEntity.data.size))
     }
 
     private fun <T : BaseResponseBean> navigate(


### PR DESCRIPTION
## Product Description
Adds icon altText to EntityListResponse and EntityDetailResponse to be used by case list icons/clickable icons.

## Technical Summary
[USH-3933](https://dimagi.atlassian.net/browse/USH-3933)
https://github.com/dimagi/commcare-hq/pull/34044
https://github.com/dimagi/commcare-core/pull/1399

`altText` is a list of strings which correspond by index to the entity's `data` or `details` property, e.g.:
```
"entities": [
  {
    "altText": [null, null, "gold star"],
    "data": ["Name", "DOB", "jr://file/favorite_star.png"],
    ...
  }
]
```
or
```
"details": [
  {
    "altText": [null, null, "gold star"],
    "details": ["Name", "DOB", "jr://file/favorite_star.png"],
    ...
  }
]
```

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
Codecov says these are covered by existing tests, but happy to add if needed.

### QA Plan
QA with the other linked PRs.

### Special deploy instructions
This should be deployed before or alongside https://github.com/dimagi/commcare-hq/pull/34044.

### Rollback instructions
If this PR is reverted, https://github.com/dimagi/commcare-hq/pull/34044 should also be reverted to avoid invalid suite files in apps.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[USH-3933]: https://dimagi.atlassian.net/browse/USH-3933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ