### PR TITLE
Clear case search db when clearing user data

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -13,16 +13,20 @@ import org.commcare.formplayer.beans.NotificationMessage;
 import org.commcare.formplayer.beans.ServerUpBean;
 import org.commcare.formplayer.beans.SyncDbRequestBean;
 import org.commcare.formplayer.beans.SyncDbResponseBean;
+import org.commcare.formplayer.services.CaseSearchHelper;
 import org.commcare.formplayer.services.CategoryTimingHelper;
 import org.commcare.formplayer.services.FormSessionService;
 import org.commcare.formplayer.services.FormplayerLockRegistry;
 import org.commcare.formplayer.services.RestoreFactory;
+import org.commcare.formplayer.sqlitedb.CaseSearchDB;
 import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.NotificationLogger;
+import org.javarosa.core.model.instance.ExternalDataInstanceSource;
 import org.javarosa.xform.parse.XFormParseException;
 import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.schema.JSONReporter;
+import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xpath.XPathException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -102,7 +106,12 @@ public class UtilController {
     @UserLock
     public NotificationMessage clearUserData(
             @RequestBody AuthenticatedRequestBean requestBean,
-            HttpServletRequest request) {
+            HttpServletRequest request) throws InvalidStructureException {
+
+        // Test clearing case db
+        CaseSearchDB caseSearchDB = new CaseSearchDB(requestBean.getDomain(), requestBean.getUsername(),
+                requestBean.getRestoreAs());
+        caseSearchDB.deleteDatabaseFile();
 
         String message = "Successfully cleared the user data for  " + requestBean.getUsername();
         new UserDB(

--- a/src/main/java/org/commcare/formplayer/application/UtilController.java
+++ b/src/main/java/org/commcare/formplayer/application/UtilController.java
@@ -108,11 +108,6 @@ public class UtilController {
             @RequestBody AuthenticatedRequestBean requestBean,
             HttpServletRequest request) throws InvalidStructureException {
 
-        // Test clearing case db
-        CaseSearchDB caseSearchDB = new CaseSearchDB(requestBean.getDomain(), requestBean.getUsername(),
-                requestBean.getRestoreAs());
-        caseSearchDB.deleteDatabaseFile();
-
         String message = "Successfully cleared the user data for  " + requestBean.getUsername();
         new UserDB(
                 requestBean.getDomain(),
@@ -121,6 +116,9 @@ public class UtilController {
         ).deleteDatabaseFolder();
         NotificationMessage notificationMessage = new NotificationMessage(message, false, NotificationMessage.Tag.clear_data);
         notificationLogger.logNotification(notificationMessage, request);
+        CaseSearchDB caseSearchDB = new CaseSearchDB(requestBean.getDomain(), requestBean.getUsername(),
+                requestBean.getRestoreAs());
+        caseSearchDB.deleteDatabaseFile();
         return notificationMessage;
     }
 


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Written by @Robert-Costello 
P2 ticket: https://dimagi.atlassian.net/browse/USH-4181


## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Adds to what is cleared when syncing user data as a workaround for stale data in case search. (now if stale data is shown they can clear user data to see the updated results)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
This has been tested on staging by support, tech, and delivery members

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA has been requested

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
