### PR TITLE
sort params to keep cache key consistent

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
@@ -40,6 +40,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @CacheConfig(cacheNames = "case_search")
 @Component
@@ -209,7 +212,9 @@ public class CaseSearchHelper {
             builder.append("_").append(restoreFactory.getAsUsername());
         }
         builder.append("_").append(uri);
-        for (String key : queryParams.keySet()) {
+        List<String> keyList = queryParams.keySet().stream().collect(Collectors.toList());
+        Collections.sort(keyList);
+        for (String key : keyList) {
             builder.append("_").append(key);
             for (String value : queryParams.get(key)) {
                 builder.append("=").append(value);


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
As per discussion about better cache handling, this sorts the query params key set values that are used to create keys for case search caches. There is no ordering guarantee with `MultiMap` key sets. This will avoid possible issues with cache key inconsistency.
## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

This doesn't change the fundamental structure of the cache keys, just the ordering of the params. I believe any pre-existing cache key will be removed by a Formplayer deploy, meaning that there should be no issue where FP attempts to reference a cache key with the old ordering. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
