### PR TITLE
Adds datadog tags to traces for restore and app installs

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
+++ b/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
@@ -1,11 +1,15 @@
 package org.commcare.formplayer.services;
 
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
+
+import datadog.trace.api.interceptor.MutableSpan;
 
 @Component
 @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
@@ -23,6 +27,11 @@ public class ResponseMetaDataTracker {
     }
 
     public void setAttemptRestore(boolean attemptRestore) {
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null && (span instanceof MutableSpan)) {
+            MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+            localRootSpan.setTag("attempt_restore", attemptRestore);
+        }
         datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.TimingCategories.COMPLETE_RESTORE);
         this.attemptRestore = attemptRestore;
     }
@@ -32,6 +41,11 @@ public class ResponseMetaDataTracker {
     }
 
     public void setNewInstall(boolean newInstall) {
+        final Span span = GlobalTracer.get().activeSpan();
+        if (span != null && (span instanceof MutableSpan)) {
+            MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+            localRootSpan.setTag("new_install", newInstall);
+        }
         datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.TimingCategories.APP_INSTALL);
         this.newInstall = newInstall;
     }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
No visual change.


## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Adds a span tags `attempt_restore` and `new_install` to Datadog. These processes can lead to slow response times so the tags are added so those requests can be filtered and analyzed independently.

![Screen Shot 2024-02-26 at 1 22 40 PM](https://github.com/dimagi/formplayer/assets/88759246/7208dcba-d065-4269-8b75-1a1a036fefa4)

Related https://github.com/dimagi/formplayer/pull/1526 which added this metadata to the response  and [PR](https://github.com/dimagi/formplayer/pull/1538) which adds these tags to metrics.
[USH-4069](https://dimagi.atlassian.net/browse/USH-4069)
## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Tested on staging. No change to product behavior.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[USH-4069]: https://dimagi.atlassian.net/browse/USH-4069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ