### PR TITLE
Datadog Metric Slicing

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -20,6 +20,7 @@ import org.commcare.formplayer.services.MenuSessionFactory;
 import org.commcare.formplayer.services.ResponseMetaDataTracker;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.util.Constants;
+import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
 import org.commcare.util.screen.EntityScreen;
 import org.commcare.util.screen.EntityScreenContext;
@@ -60,6 +61,9 @@ public class MenuController extends AbstractBaseController {
 
     @Autowired
     private ResponseMetaDataTracker responseMetaDataTracker;
+
+    @Autowired
+    private FormplayerDatadog datadog;
 
     private final Log log = LogFactory.getLog(MenuController.class);
 
@@ -170,6 +174,12 @@ public class MenuController extends AbstractBaseController {
         String[] selections = sessionNavigationBean.getSelections();
         MenuSession menuSession;
         menuSession = menuSessionFactory.getMenuSessionFromBean(sessionNavigationBean);
+        String[] requestInitiatedByTags = sessionNavigationBean.getRequestInitiatedByTags();
+        if (requestInitiatedByTags != null) {
+            for (String requestInitiatedByTag : requestInitiatedByTags) {
+                datadog.addRequestScopedTag(Constants.MODULE_INITIATED_BY_TAG, requestInitiatedByTag);
+            }
+        }
         EntityScreenContext entityScreenContext = new EntityScreenContext(sessionNavigationBean.getOffset(),
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -20,7 +20,6 @@ import org.commcare.formplayer.services.MenuSessionFactory;
 import org.commcare.formplayer.services.ResponseMetaDataTracker;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.util.Constants;
-import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
 import org.commcare.util.screen.EntityScreen;
 import org.commcare.util.screen.EntityScreenContext;
@@ -61,9 +60,6 @@ public class MenuController extends AbstractBaseController {
 
     @Autowired
     private ResponseMetaDataTracker responseMetaDataTracker;
-
-    @Autowired
-    private FormplayerDatadog datadog;
 
     private final Log log = LogFactory.getLog(MenuController.class);
 

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -174,12 +174,6 @@ public class MenuController extends AbstractBaseController {
         String[] selections = sessionNavigationBean.getSelections();
         MenuSession menuSession;
         menuSession = menuSessionFactory.getMenuSessionFromBean(sessionNavigationBean);
-        String[] requestInitiatedByTags = sessionNavigationBean.getRequestInitiatedByTags();
-        if (requestInitiatedByTags != null) {
-            for (String requestInitiatedByTag : requestInitiatedByTags) {
-                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG_PREFIX + requestInitiatedByTag, Constants.TAG_VALUE_TRUE);
-            }
-        }
         EntityScreenContext entityScreenContext = new EntityScreenContext(sessionNavigationBean.getOffset(),
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -177,7 +177,7 @@ public class MenuController extends AbstractBaseController {
         String[] requestInitiatedByTags = sessionNavigationBean.getRequestInitiatedByTags();
         if (requestInitiatedByTags != null) {
             for (String requestInitiatedByTag : requestInitiatedByTags) {
-                datadog.addRequestScopedTag(Constants.MODULE_INITIATED_BY_TAG, requestInitiatedByTag);
+                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG, requestInitiatedByTag);
             }
         }
         EntityScreenContext entityScreenContext = new EntityScreenContext(sessionNavigationBean.getOffset(),

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -177,7 +177,7 @@ public class MenuController extends AbstractBaseController {
         String[] requestInitiatedByTags = sessionNavigationBean.getRequestInitiatedByTags();
         if (requestInitiatedByTags != null) {
             for (String requestInitiatedByTag : requestInitiatedByTags) {
-                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG, requestInitiatedByTag);
+                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG_PREFIX + requestInitiatedByTag, Constants.TAG_VALUE_TRUE);
             }
         }
         EntityScreenContext entityScreenContext = new EntityScreenContext(sessionNavigationBean.getOffset(),

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -6,7 +6,9 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
+import org.commcare.formplayer.beans.InstallRequestBean;
 import org.commcare.formplayer.util.*;
+import org.commcare.util.screen.ScreenUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 
@@ -63,6 +65,10 @@ public class MetricsAspect {
         datadogArgs.add(new FormplayerDatadog.Tag(Constants.REQUEST_TAG, requestPath));
         datadogArgs.add(new FormplayerDatadog.Tag(Constants.DURATION_TAG, timer.getDurationBucket()));
 
+        if (args != null && args.length > 0 && args[0] instanceof InstallRequestBean) {
+            String appDisplayTitle = ScreenUtils.getAppTitle();
+            datadogArgs.add(new FormplayerDatadog.Tag(Constants.APP_NAME_TAG, appDisplayTitle));
+        }
         datadog.recordExecutionTime(Constants.DATADOG_TIMINGS, timer.durationInMs(), datadogArgs);
 
         FormplayerSentry.newBreadcrumb()

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -58,11 +58,10 @@ public class MetricsAspect {
 
         if (args != null && args.length > 0 && args[0] instanceof SessionNavigationBean) {
             SessionNavigationBean bean = (SessionNavigationBean) args[0];
-            String[] requestInitiatedByTags = bean.getRequestInitiatedByTags();
-            if (requestInitiatedByTags != null) {
-                for (String requestInitiatedByTag : requestInitiatedByTags) {
-                    datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG_PREFIX + requestInitiatedByTag, Constants.TAG_VALUE_TRUE);
-                }
+            String requestInitiatedByTag = bean.getRequestInitiatedByTag();
+            if (requestInitiatedByTag != null) {
+                System.out.println("requestedInitiateydby is " + requestInitiatedByTag);
+                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG, requestInitiatedByTag);
             }
         }
 

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -60,7 +60,6 @@ public class MetricsAspect {
             SessionNavigationBean bean = (SessionNavigationBean) args[0];
             String requestInitiatedByTag = bean.getRequestInitiatedByTag();
             if (requestInitiatedByTag != null) {
-                System.out.println("requestedInitiateydby is " + requestInitiatedByTag);
                 datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG, requestInitiatedByTag);
             }
         }

--- a/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/MetricsAspect.java
@@ -7,6 +7,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.beans.InstallRequestBean;
+import org.commcare.formplayer.beans.SessionNavigationBean;
 import org.commcare.formplayer.util.*;
 import org.commcare.util.screen.ScreenUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,6 +54,16 @@ public class MetricsAspect {
         if (args != null && args.length > 0 && args[0] instanceof AuthenticatedRequestBean) {
             AuthenticatedRequestBean bean = (AuthenticatedRequestBean) args[0];
             domain = bean.getDomain();
+        }
+
+        if (args != null && args.length > 0 && args[0] instanceof SessionNavigationBean) {
+            SessionNavigationBean bean = (SessionNavigationBean) args[0];
+            String[] requestInitiatedByTags = bean.getRequestInitiatedByTags();
+            if (requestInitiatedByTags != null) {
+                for (String requestInitiatedByTag : requestInitiatedByTags) {
+                    datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG_PREFIX + requestInitiatedByTag, Constants.TAG_VALUE_TRUE);
+                }
+            }
         }
 
         SimpleTimer timer = new SimpleTimer();

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -26,6 +26,7 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int casesPerPage;
     private String[] selectedValues;
     private boolean isShortDetail;
+    private String[] requestInitiatedByTags;
 
     private boolean isRefreshCaseSearch;
     /**
@@ -76,6 +77,14 @@ public class SessionNavigationBean extends InstallRequestBean {
     @JsonSetter(value = "endpoint_args")
     public void setEndpointArgs(HashMap<String, String> endpointArgs) {
         this.endpointArgs = endpointArgs;
+    }
+
+    public String[] getRequestInitiatedByTags() {
+        return requestInitiatedByTags;
+    }
+
+    public void setRequestInitiatedByTags(String[] requestInitiatedByTags) {
+        this.requestInitiatedByTags = requestInitiatedByTags;
     }
 
     @JsonGetter(value = "search_text")

--- a/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/SessionNavigationBean.java
@@ -26,7 +26,7 @@ public class SessionNavigationBean extends InstallRequestBean {
     private int casesPerPage;
     private String[] selectedValues;
     private boolean isShortDetail;
-    private String[] requestInitiatedByTags;
+    private String requestInitiatedByTag;
 
     private boolean isRefreshCaseSearch;
     /**
@@ -79,12 +79,12 @@ public class SessionNavigationBean extends InstallRequestBean {
         this.endpointArgs = endpointArgs;
     }
 
-    public String[] getRequestInitiatedByTags() {
-        return requestInitiatedByTags;
+    public String getRequestInitiatedByTag() {
+        return requestInitiatedByTag;
     }
 
-    public void setRequestInitiatedByTags(String[] requestInitiatedByTags) {
-        this.requestInitiatedByTags = requestInitiatedByTags;
+    public void requestInitiatedByTag(String requestInitiatedByTag) {
+        this.requestInitiatedByTag = requestInitiatedByTag;
     }
 
     @JsonGetter(value = "search_text")

--- a/src/main/java/org/commcare/formplayer/objects/QueryData.java
+++ b/src/main/java/org/commcare/formplayer/objects/QueryData.java
@@ -23,7 +23,6 @@ public class QueryData extends Hashtable<String, Object> {
     private static final String KEY_EXECUTE = "execute";
     public static final String KEY_FORCE_MANUAL_SEARCH = "force_manual_search";
     private static final String KEY_INPUTS = "inputs";
-    private static final String INITIATED_BY = "initiatedBy";
 
     public Boolean getExecute(String key) {
         return getPropertyWithFallback(key, KEY_EXECUTE);
@@ -39,20 +38,6 @@ public class QueryData extends Hashtable<String, Object> {
 
     public void setForceManualSearch(String key, Boolean value) {
         setProperty(key, value, KEY_FORCE_MANUAL_SEARCH);
-    }
-
-    public String getInitiatedBy(String key) {
-        Map<String, Object> value = (Map<String, Object>) this.get(key);
-        if (value != null) {
-            String initiatedBy = (String) value.get(INITIATED_BY);
-                return initiatedBy;
-        }
-        return null;
-    }
-
-    public void setInitiatedBy(String key, String value) {
-        this.initKey(key);
-        ((Map<String, Object>) this.get(key)).put(INITIATED_BY, value);
     }
 
     public Hashtable<String, String> getInputs(String key) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -186,10 +186,6 @@ public class MenuSessionRunnerService {
             String queryKey = ((FormplayerQueryScreen)nextScreen).getQueryKey();
             answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey);
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
-            String queryInitiatedBy = queryData == null ? null : queryData.getInitiatedBy(queryKey);
-            if (queryInitiatedBy != null) {
-                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG, queryInitiatedBy);
-            }
             String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_search");

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -188,7 +188,7 @@ public class MenuSessionRunnerService {
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
             String queryInitiatedBy = queryData == null ? null : queryData.getInitiatedBy(queryKey);
             if (queryInitiatedBy != null) {
-                datadog.addRequestScopedTag(Constants.MODULE_INITIATED_BY_TAG, queryInitiatedBy);
+                datadog.addRequestScopedTag(Constants.REQUEST_INITIATED_BY_TAG, queryInitiatedBy);
             }
             String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -162,6 +162,8 @@ public class MenuSessionRunnerService {
                     (MenuScreen)nextScreen,
                     menuSession.getSessionWrapper()
             );
+            String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
+            datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "menu");
             Sentry.setTag(Constants.MODULE_TAG, "menu");
         } else if (nextScreen instanceof EntityScreen) {

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -126,7 +126,7 @@ public class Constants {
     public static final String DOMAIN_TAG = "domain";
     public static final String FORM_NAME_TAG = "form_name";
     public static final String MODULE_TAG = "module";
-    public static final String MODULE_INITIATED_BY_TAG = "module_initiated_by";
+    public static final String REQUEST_INITIATED_BY_TAG = "request_initiated_by";
     public static final String MODULE_NAME_TAG = "module_name";
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -122,6 +122,7 @@ public class Constants {
     public static final String DATADOG_RESTORE_COUNT = "restore.count";
 
     // Datadog/Sentry tags
+    public static final String APP_NAME_TAG = "app_name";
     public static final String DOMAIN_TAG = "domain";
     public static final String FORM_NAME_TAG = "form_name";
     public static final String MODULE_TAG = "module";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -130,9 +130,7 @@ public class Constants {
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";
     public static final String DURATION_TAG = "duration";
-    public static final String REQUEST_INITIATED_BY_TAG_PREFIX = "request_initiated_by_";
-
-    public static final String TAG_VALUE_TRUE = "true";
+    public static final String REQUEST_INITIATED_BY_TAG = "request_initiated_by";
 
     //.Sentry tags
     public static final String URI = "uri";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -126,11 +126,13 @@ public class Constants {
     public static final String DOMAIN_TAG = "domain";
     public static final String FORM_NAME_TAG = "form_name";
     public static final String MODULE_TAG = "module";
-    public static final String REQUEST_INITIATED_BY_TAG = "request_initiated_by";
     public static final String MODULE_NAME_TAG = "module_name";
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";
     public static final String DURATION_TAG = "duration";
+    public static final String REQUEST_INITIATED_BY_TAG_PREFIX = "request_initiated_by_";
+
+    public static final String TAG_VALUE_TRUE = "true";
 
     //.Sentry tags
     public static final String URI = "uri";

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -508,13 +508,6 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     @Test
-    public void testQueryInitiatedBy() throws Exception {
-        QueryData queryData = new QueryData();
-        queryData.setInitiatedBy("search_command.m1_results", "field_change");
-        assertEquals(queryData.getInitiatedBy("search_command.m1_results"), "field_change");
-    }
-
-    @Test
     public void testDependentItemsets_DependentChoicesChangeWithSelection() throws Exception {
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("state", "rj");


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
For the metric `formplayer.metrics.timings`
-  Datadog tag `module_initiated_by` is renamed to `request_initiated_by`.
- `app_name` tag is added
- `module_name` tag is included when `navigate_menu` enters a menu

TODO: Add screenshot

![Screen Shot 2024-03-18 at 4 46 21 PM](https://github.com/dimagi/formplayer/assets/88759246/25c7b5d6-e550-42f8-9f98-b43fe85c313e)

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket ](https://dimagi.atlassian.net/browse/USH-4182)
[Related HQ Changes](https://github.com/dimagi/commcare-hq/pull/34247)

This PR consists of two changes:
1. The `module_initiated_by` tag was introduced previously in this [PR](https://github.com/dimagi/formplayer/pull/1533). This tag will be renamed to a more general `request_initiated_by`. This name better reflects that the tag reflects the user action that resulted in the request. 
2. The `request_initiated_by` value is moved from `QueryData` to `SessionNavigationBean` as the values are no longer specific to  just `Query`

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
tested on staging
The blast zone would include endpoints where HQ includes a `requestInitiatedByTag` value. However, the logic added only involves adding a datadog tag which is already extensively used.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
tests already exists for `navigate_menu` and `navigate_menu_start` endpoints.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
[QA Ticket](https://dimagi.atlassian.net/browse/QA-6188?focusedCommentId=316724&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-316724)


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
