### PR TITLE
Datadog Improve Metric Fidelity for Autoselect

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -170,6 +170,7 @@ public class MenuSessionRunnerService {
             nextScreen.init(menuSession.getSessionWrapper());
             if (nextScreen.shouldBeSkipped()) {
                 if (((EntityScreen)nextScreen).autoSelectEntities(menuSession.getSessionWrapper())) {
+                    datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.AUTOSELECT);
                     return getNextMenu(menuSession, queryData, entityScreenContext);
                 }
             }
@@ -376,6 +377,9 @@ public class MenuSessionRunnerService {
                     if (nextScreen.shouldBeSkipped()) {
                         sessionAdvanced = ((EntityScreen)nextScreen).autoSelectEntities(
                                 menuSession.getSessionWrapper());
+                        if (sessionAdvanced) {
+                            datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.AUTOSELECT);
+                        }
                     }
                 }
                 if (previousScreen != null && previousScreen instanceof QueryScreen) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -475,8 +475,10 @@ public class MenuSessionRunnerService {
         if (shouldSync) {
             String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
             Map<String, String> extraTags = new HashMap<>();
-            extraTags.put(Constants.MODULE_NAME_TAG, moduleName);
+            Map<String, String> requestScopedTagNameAndValueMap = datadog.getRequestScopedTagNameAndValue();
 
+            requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_TAG, extraTags::put);
+            extraTags.put(Constants.MODULE_NAME_TAG, moduleName);
             restoreFactory.performTimedSync(false, true, false, extraTags);
             menuSession.getSessionWrapper().clearVolatiles();
         }
@@ -672,8 +674,10 @@ public class MenuSessionRunnerService {
             Sentry.setTag(Constants.FORM_NAME_TAG, formName);
 
             formEntryTimer.end();
-
             Map<String, String> extraTags = new HashMap<>();
+            Map<String, String> requestScopedTagNameAndValueMap = datadog.getRequestScopedTagNameAndValue();
+
+            requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_TAG, extraTags::put);
             extraTags.put(Constants.DOMAIN_TAG, restoreFactory.getDomain());
             extraTags.put(Constants.FORM_NAME_TAG, formName);
             categoryTimingHelper.recordCategoryTiming(

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -657,8 +657,6 @@ public class MenuSessionRunnerService {
         if (menuSession.getSessionWrapper().getForm() != null) {
             SimpleTimer formEntryTimer = new SimpleTimer();
             formEntryTimer.start();
-            Map<String, String> extraTags = new HashMap<>();
-            extraTags.put(Constants.DOMAIN_TAG, restoreFactory.getDomain());
             NewFormResponse formResponseBean = generateFormEntrySession(menuSession);
             formResponseBean.setAppId(menuSession.getAppId());
             formResponseBean.setAppVersion(
@@ -674,6 +672,10 @@ public class MenuSessionRunnerService {
             Sentry.setTag(Constants.FORM_NAME_TAG, formName);
 
             formEntryTimer.end();
+
+            Map<String, String> extraTags = new HashMap<>();
+            extraTags.put(Constants.DOMAIN_TAG, restoreFactory.getDomain());
+            extraTags.put(Constants.FORM_NAME_TAG, formName);
             categoryTimingHelper.recordCategoryTiming(
                 formEntryTimer,
                 Constants.TimingCategories.FORM_ENTRY,

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -175,7 +175,7 @@ public class MenuSessionRunnerService {
             nextScreen.init(menuSession.getSessionWrapper());
             if (nextScreen.shouldBeSkipped()) {
                 if (((EntityScreen)nextScreen).autoSelectEntities(menuSession.getSessionWrapper())) {
-                    datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.AUTOSELECT);
+                    datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.AUTOSELECT);
                     return getNextMenu(menuSession, queryData, entityScreenContext);
                 }
             }
@@ -383,7 +383,7 @@ public class MenuSessionRunnerService {
                         sessionAdvanced = ((EntityScreen)nextScreen).autoSelectEntities(
                                 menuSession.getSessionWrapper());
                         if (sessionAdvanced) {
-                            datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.AUTOSELECT);
+                            datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.AUTOSELECT);
                         }
                     }
                 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -469,8 +469,10 @@ public class MenuSessionRunnerService {
         }
         if (shouldSync) {
             String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
-            datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
-            restoreFactory.performTimedSync(false, true, false);
+            Map<String, String> extraTags = new HashMap<>();
+            extraTags.put(Constants.MODULE_NAME_TAG, moduleName);
+
+            restoreFactory.performTimedSync(false, true, false, extraTags);
             menuSession.getSessionWrapper().clearVolatiles();
         }
     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -468,6 +468,8 @@ public class MenuSessionRunnerService {
             throw new SyncRestoreException("Unknown error performing case claim", e);
         }
         if (shouldSync) {
+            String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
+            datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             restoreFactory.performTimedSync(false, true, false);
             menuSession.getSessionWrapper().clearVolatiles();
         }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -175,7 +175,7 @@ public class MenuSessionRunnerService {
             nextScreen.init(menuSession.getSessionWrapper());
             if (nextScreen.shouldBeSkipped()) {
                 if (((EntityScreen)nextScreen).autoSelectEntities(menuSession.getSessionWrapper())) {
-                    datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.AUTOSELECT);
+                    datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_AUTOSELECT_TAG, Constants.TAG_VALUE_TRUE);
                     return getNextMenu(menuSession, queryData, entityScreenContext);
                 }
             }
@@ -383,7 +383,7 @@ public class MenuSessionRunnerService {
                         sessionAdvanced = ((EntityScreen)nextScreen).autoSelectEntities(
                                 menuSession.getSessionWrapper());
                         if (sessionAdvanced) {
-                            datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.AUTOSELECT);
+                            datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_AUTOSELECT_TAG, Constants.TAG_VALUE_TRUE);
                         }
                     }
                 }
@@ -477,7 +477,7 @@ public class MenuSessionRunnerService {
             Map<String, String> extraTags = new HashMap<>();
             Map<String, String> requestScopedTagNameAndValueMap = datadog.getRequestScopedTagNameAndValue();
 
-            requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_TAG, extraTags::put);
+            requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_AUTOSELECT_TAG, extraTags::put);
             extraTags.put(Constants.MODULE_NAME_TAG, moduleName);
             restoreFactory.performTimedSync(false, true, false, extraTags);
             menuSession.getSessionWrapper().clearVolatiles();
@@ -677,7 +677,7 @@ public class MenuSessionRunnerService {
             Map<String, String> extraTags = new HashMap<>();
             Map<String, String> requestScopedTagNameAndValueMap = datadog.getRequestScopedTagNameAndValue();
 
-            requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_TAG, extraTags::put);
+            requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_AUTOSELECT_TAG, extraTags::put);
             extraTags.put(Constants.DOMAIN_TAG, restoreFactory.getDomain());
             extraTags.put(Constants.FORM_NAME_TAG, formName);
             categoryTimingHelper.recordCategoryTiming(

--- a/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
+++ b/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
@@ -23,7 +23,7 @@ public class ResponseMetaDataTracker {
     }
 
     public void setAttemptRestore(boolean attemptRestore) {
-        datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.TimingCategories.COMPLETE_RESTORE);
+        datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.TimingCategories.COMPLETE_RESTORE);
         this.attemptRestore = attemptRestore;
     }
 
@@ -32,7 +32,7 @@ public class ResponseMetaDataTracker {
     }
 
     public void setNewInstall(boolean newInstall) {
-        datadog.addRequestScopedTag(Constants.CATEGORY_TAG, Constants.TimingCategories.APP_INSTALL);
+        datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.TimingCategories.APP_INSTALL);
         this.newInstall = newInstall;
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
+++ b/src/main/java/org/commcare/formplayer/services/ResponseMetaDataTracker.java
@@ -23,7 +23,7 @@ public class ResponseMetaDataTracker {
     }
 
     public void setAttemptRestore(boolean attemptRestore) {
-        datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.TimingCategories.COMPLETE_RESTORE);
+        datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_COMPLETE_RESTORE, Constants.TAG_VALUE_TRUE);
         this.attemptRestore = attemptRestore;
     }
 
@@ -32,7 +32,7 @@ public class ResponseMetaDataTracker {
     }
 
     public void setNewInstall(boolean newInstall) {
-        datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_TAG, Constants.TimingCategories.APP_INSTALL);
+        datadog.addRequestScopedTag(Constants.REQUEST_INCLUDES_APP_INSTALL, Constants.TAG_VALUE_TRUE);
         this.newInstall = newInstall;
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -198,12 +198,15 @@ public class RestoreFactory {
     public UserSqlSandbox performTimedSync() throws SyncRestoreException {
         return performTimedSync(true, false, false);
     }
-
     public UserSqlSandbox performTimedSync(boolean shouldPurge, boolean skipFixtures, boolean isResponseTo412)
             throws SyncRestoreException {
+        return performTimedSync(shouldPurge, skipFixtures, isResponseTo412, new HashMap<>());
+    }
+
+    public UserSqlSandbox performTimedSync(boolean shouldPurge, boolean skipFixtures, boolean isResponseTo412, Map<String, String> extraTags)
+            throws SyncRestoreException {
         // create extras to send to category timing helper
-        Map<String, String> extras = new HashMap<>();
-        extras.put(Constants.DOMAIN_TAG, domain);
+        extraTags.put(Constants.DOMAIN_TAG, domain);
 
         SimpleTimer completeRestoreTimer = new SimpleTimer();
         completeRestoreTimer.start();
@@ -230,7 +233,7 @@ public class RestoreFactory {
                         purgeTimer,
                         Constants.TimingCategories.PURGE_CASES,
                         null,
-                        extras
+                        extraTags
                 );
             } catch (InvalidCaseGraphException e) {
                 FormplayerSentry.captureException(e, SentryLevel.WARNING);
@@ -248,7 +251,7 @@ public class RestoreFactory {
                 completeRestoreTimer,
                 Constants.TimingCategories.COMPLETE_RESTORE,
                 null,
-                extras
+                extraTags
         );
         return sandbox;
     }

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -155,6 +155,7 @@ public class Constants {
         public static final String VALIDATE_SUBMISSION = "validate_submission";
         public static final String VALIDATE_ANSWERS = "validate_answers";
         public static final String END_OF_FORM_NAV = "end_of_form_navigation";
+        public static final String FORM_ENTRY = "form_entry";
 
         public static final String GET_SESSION = "get_session";
         public static final String INITIALIZE_SESSION = "initialize_session";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -131,11 +131,13 @@ public class Constants {
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";
     public static final String DURATION_TAG = "duration";
-    public static final String REQUEST_INCLUDES_TAG = "request_includes";
 
 
-    // Datadog tags value
-    public static final String AUTOSELECT = "autoselect";
+    // Datadog tags assigned true/false values
+    public static final String REQUEST_INCLUDES_AUTOSELECT_TAG = "request_includes_autoselect";
+    public static final String REQUEST_INCLUDES_COMPLETE_RESTORE = "request_includes_complete_restore";
+    public static final String REQUEST_INCLUDES_APP_INSTALL = "request_includes_app_install";
+    public static final String TAG_VALUE_TRUE = "true";
 
     //.Sentry tags
     public static final String URI = "uri";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -132,6 +132,9 @@ public class Constants {
     public static final String CATEGORY_TAG = "category";
     public static final String DURATION_TAG = "duration";
 
+    // Datadog tags value
+    public static final String AUTOSELECT = "autoselect";
+
     //.Sentry tags
     public static final String URI = "uri";
     public static final String AS_USER = "as_user";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -131,6 +131,8 @@ public class Constants {
     public static final String REQUEST_TAG = "request";
     public static final String CATEGORY_TAG = "category";
     public static final String DURATION_TAG = "duration";
+    public static final String REQUEST_INCLUDES_TAG = "request_includes";
+
 
     // Datadog tags value
     public static final String AUTOSELECT = "autoselect";

--- a/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java
@@ -36,6 +36,14 @@ public class FormplayerDatadog {
             this.value = value;
         }
 
+        public String getValue() {
+            return value;
+        }
+
+        public String getName() {
+            return name;
+        }
+
         public String formatted() {
             return name + ":" + value;
         }
@@ -72,6 +80,15 @@ public class FormplayerDatadog {
 
     public List<Tag> getRequestScopedTags() {
         return new ArrayList<>(this.requestScopedTags.values());
+    }
+
+    public Map<String, String> getRequestScopedTagNameAndValue() {
+        Map<String, String> tagNameAndValueMap = new HashMap<>();
+        for (Map.Entry<String, Tag> entry : requestScopedTags.entrySet()) {
+            Tag tag = entry.getValue();
+            tagNameAndValueMap.put(tag.getName(), tag.getValue());
+        }
+        return tagNameAndValueMap;
     }
 
     public Set<String> getDetailedTagNames() {


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
For the metric `formplayer.metrics.timings`
- Datadog tag `category` is separated into multiple tags that are in the form `request_includes_<action>` with the value "true" if applicable. For example, `category` with the value `app_install` will now be the tag `request_includes_app_install` with the value `true`.
- Adds `request_includes_autoselect` tag

![Screen Shot 2024-03-18 at 4 56 00 PM](https://github.com/dimagi/formplayer/assets/88759246/1453f7d9-1007-450a-8c76-c05b5b822f3b)


For the metric `formplayer.metrics.granular.timings`
- for `category` `complete_restore`: adds associated tag for `module_name` and `request_includes_autoselect`
- adds `category` `form_entry` with associated tag for `form_name` and `request_includes_autoselect`

![Screen Shot 2024-03-18 at 4 56 53 PM](https://github.com/dimagi/formplayer/assets/88759246/49f00db2-7667-4328-ab87-76ba2de3a50f)

![Screen Shot 2024-03-18 at 4 57 32 PM](https://github.com/dimagi/formplayer/assets/88759246/db2c2afe-b32c-4fd0-8c31-26a06b07820d)



## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4243)

The `category` tag was introduced previously to metric `formplayer.metrics.timings` from this [PR](https://github.com/dimagi/formplayer/pull/1538). However, I now want to also include "autoselect" as a value. However, `category` with the value `autoselect` doesn't make sense in the context of metric `formplayer.metrics.granular.timings` because category is conveys that the timing measures the specific category. For this reason, I am changing the tag key to `request_includes_<action>`. 

Separate tag keys are created for each action instead of having one tag key with multiple values. This is because with the implementation of [addRequestScopedTag](https://github.com/dimagi/formplayer/blob/1bdce0757d05e9a1325f12b7d24055184deabc21/src/main/java/org/commcare/formplayer/util/FormplayerDatadog.java#L90), only the last value saved to the tag would be recorded. However, multiple actions of interest could occur in the same request. See this [PR](https://github.com/dimagi/formplayer/pull/1551) for a similar change.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
tested on staging.  The logic added only involves adding datadog tags which is already extensively used.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
No explicit testing for datadog tags, but testing exists for menu navigation.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
