### PR TITLE
Add log for missing entity when navigating to next menu

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -127,22 +127,21 @@ public class MenuSessionFactory {
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
                         } else {
-                            StringBuilder sb = new StringBuilder();
+                            StringBuilder refsSb = new StringBuilder("[");
                             entityScreen.getReferences().forEach(ref -> {
                                 String refStr =
                                         EntityScreen.getReturnValueFromSelection(
                                                 ref,
                                                 (EntityDatum) neededDatum,
                                                 entityScreen.getEvalContext());
-                                sb.append("  ");
-                                sb.append(refStr);
-                                sb.append(",\n");
+                                refsSb.append("  ");
+                                refsSb.append(refStr);
+                                refsSb.append(",\n");
                             });
-                            sb.append("]");
+                            refsSb.append("]");
 
-                            String refs = entityScreen.getReferences().toString();
-                            log.error("could not get %s=%s from entity screen references: \n%s"
-                                    .formatted(neededDatum.getDataId(), step.getValue(), sb.toString()));
+                            log.error("could not get %s=%s from entity screen.\nnode set: %s\nreferences: \n%s"
+                                    .formatted(neededDatum.getDataId(), step.getValue(), ((EntityDatum) neededDatum).getNodeset().toString(), refsSb.toString()));
                         }
                         break;
                     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -12,6 +12,7 @@ import org.commcare.formplayer.engine.FormplayerConfigEngine;
 import org.commcare.formplayer.objects.SerializableMenuSession;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.session.CommCareSession;
+import org.commcare.suite.model.EntityDatum;
 import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.RemoteQueryDatum;
@@ -126,8 +127,20 @@ public class MenuSessionFactory {
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
                         } else {
-                            log.error("could not get %s=%s from entity screen references"
-                                    .formatted(neededDatum.getDataId(), step.getValue()));
+                            StringBuilder sb = new StringBuilder();
+                            entityScreen.getReferences().forEach(ref -> {
+                                String refStr =
+                                        EntityScreen.getReturnValueFromSelection(
+                                                ref,
+                                                (EntityDatum) neededDatum,
+                                                entityScreen.getEvalContext());
+                                sb.append(refStr);
+                                sb.append("\n");
+                            });
+
+                            String refs = entityScreen.getReferences().toString();
+                            log.error("could not get %s=%s from entity screen references: \n%s"
+                                    .formatted(neededDatum.getDataId(), step.getValue(), sb.toString()));
                         }
                         break;
                     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -125,6 +125,9 @@ public class MenuSessionFactory {
                             currentStep = step.getValue();
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
+                        } else {
+                            log.error("could not get %s=%s from entity screen references"
+                                    .formatted(neededDatum.getDataId(), step.getValue()));
                         }
                         break;
                     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -134,9 +134,11 @@ public class MenuSessionFactory {
                                                 ref,
                                                 (EntityDatum) neededDatum,
                                                 entityScreen.getEvalContext());
+                                sb.append("  ");
                                 sb.append(refStr);
-                                sb.append("\n");
+                                sb.append(",\n");
                             });
+                            sb.append("]");
 
                             String refs = entityScreen.getReferences().toString();
                             log.error("could not get %s=%s from entity screen references: \n%s"


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [ ] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [ ] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
