### PR TITLE
End of Form Error Handling

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -212,7 +212,7 @@ public class FormSubmissionHelper {
         return Optional.of(response);
     }
 
-    private SubmitResponseBean validateAnswers(FormSubmissionContext context) {
+    private SubmitResponseBean validateAnswers(FormSubmissionContext context) throws Exception {
         Map<String, ErrorBean> errors = categoryTimingHelper.timed(
                 Constants.TimingCategories.VALIDATE_SUBMISSION,
                 () -> validateSubmitAnswers(context),
@@ -348,7 +348,7 @@ public class FormSubmissionHelper {
     }
 
     @Trace
-    private SubmitResponseBean doEndOfFormNav(FormSubmissionContext context) {
+    private SubmitResponseBean doEndOfFormNav(FormSubmissionContext context) throws Exception{
         Object nextScreen = categoryTimingHelper.timed(
                 Constants.TimingCategories.END_OF_FORM_NAV,
                 () -> {

--- a/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CategoryTimingHelper.java
@@ -86,7 +86,7 @@ public class CategoryTimingHelper {
     }
 
     @SneakyThrows
-    public <T> T timed(String category, CheckedSupplier<T> timed, Map<String, String> extras) {
+    public <T> T timed(String category, CheckedSupplier<T> timed, Map<String, String> extras) throws Exception{
         SimpleTimer timer = new SimpleTimer();
         timer.start();
         try {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -125,6 +125,9 @@ public class MenuSessionFactory {
                             currentStep = step.getValue();
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
+                        } else {
+                            throw new CommCareSessionException("Value " + step.getValue() +" is not found in " +
+                                entityScreen.toString());
                         }
                         break;
                     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -151,7 +151,6 @@ public class MenuSessionFactory {
                         try {
                             uri = new URI(step.getValue());
                             processedSteps.add(step);
-                            processedStepsCount++;
                         } catch (URISyntaxException e) {
                             e.printStackTrace();
                             throw new CommCareSessionException("Query URL format error: " + e.getMessage(), e);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.StringJoiner;
 import java.util.Vector;
 
 import datadog.trace.api.Trace;
@@ -105,6 +106,17 @@ public class MenuSessionFactory {
                             needsFullInit = ++processedStepsCount == steps.size();
                         }
                     }
+                }
+                if (currentStep == null) {
+                    StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
+                    StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
+                    for (MenuDisplayable option : options) {
+                        optionsIDJoiner.add(option.getCommandID());
+                    }
+                    for (StackFrameStep step : steps) {
+                        stepIDJoiner.add(step.getId());
+                    }
+                    throw new CommCareSessionException("Match Error: Steps " + stepIDJoiner.toString() + " do not contain a valid option " + optionsIDJoiner.toString());
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen)screen;

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -121,7 +121,8 @@ public class MenuSessionFactory {
                 }
                 if (currentStep == null && processedStepsCount != steps.size()) {
                     for (StackFrameStep unprocessedStep : unprocessedSteps) {
-                        if (unprocessedStep.getType().equals(SessionFrame.STATE_COMMAND_ID)) {
+                        if (unprocessedStep.getType().equals(SessionFrame.STATE_COMMAND_ID) &&
+                            !unprocessedStep.getId().startsWith("claim_command")) {
                             StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
                             StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
                             for (MenuDisplayable option : options) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -128,16 +128,7 @@ public class MenuSessionFactory {
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
                         } else {
-                            // This block constructs the message to display then throws the exception
-                            List<String> refsList = entityScreen.getReferences().stream()
-                            .map(ref -> EntityScreen.getReturnValueFromSelection(ref, (EntityDatum) neededDatum, entityScreen.getEvalContext()))
-                            .toList();
-
-                            String referencesString = String.join(",\n  ", refsList);
-                            String nodeSetString = ((EntityDatum) neededDatum).getNodeset().toString();
-
-                            throw new CommCareSessionException(String.format("Could not get %s=%s from entity screen.\nNode set: %s\nReferences: \n[%s]",
-                            neededDatum.getDataId(), step.getValue(), nodeSetString, referencesString));
+                            throwStepNotInEntityScreenException(entityScreen, neededDatum, step);
                         }
                         break;
                     }
@@ -303,5 +294,19 @@ public class MenuSessionFactory {
                 );
             }
         }
+    }
+
+    private void throwStepNotInEntityScreenException(EntityScreen entityScreen, SessionDatum neededDatum, StackFrameStep step) throws CommCareSessionException {
+        // This block constructs the message to display then throws the exception
+        List<String> refsList = entityScreen.getReferences().stream()
+        .map(ref -> EntityScreen.getReturnValueFromSelection(ref, (EntityDatum) neededDatum, entityScreen.getEvalContext()))
+        .toList();
+
+        String referencesString = String.join(",\n  ", refsList);
+        String nodeSetString = ((EntityDatum) neededDatum).getNodeset().toString();
+
+        throw new CommCareSessionException(String.format("Could not get %s=%s from entity screen.\nNode set: %s\nReferences: \n[%s]",
+        neededDatum.getDataId(), step.getValue(), nodeSetString, referencesString));
+
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -12,6 +12,7 @@ import org.commcare.formplayer.engine.FormplayerConfigEngine;
 import org.commcare.formplayer.objects.SerializableMenuSession;
 import org.commcare.formplayer.session.MenuSession;
 import org.commcare.session.CommCareSession;
+import org.commcare.session.SessionFrame;
 import org.commcare.suite.model.MenuDisplayable;
 import org.commcare.suite.model.RemoteQueryDatum;
 import org.commcare.suite.model.SessionDatum;
@@ -33,7 +34,9 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.StringJoiner;
 import java.util.Vector;
 
@@ -83,6 +86,7 @@ public class MenuSessionFactory {
             boolean respectRelevancy)
             throws CommCareSessionException, RemoteInstanceFetcher.RemoteInstanceException {
         Vector<StackFrameStep> steps = menuSession.getSessionWrapper().getFrame().getSteps();
+        List<StackFrameStep> processedSteps = new ArrayList<>();
         menuSession.resetSession();
         EntityScreenContext entityScreenContext = new EntityScreenContext();
         Screen screen = menuSession.getNextScreen(false, entityScreenContext);
@@ -102,21 +106,33 @@ public class MenuSessionFactory {
                     for (StackFrameStep step : steps) {
                         if (step.getId().equals(options[i].getCommandID())) {
                             currentStep = String.valueOf(i);
+                            processedSteps.add(step);
                             // final step, needs to init fully to show to screen
                             needsFullInit = ++processedStepsCount == steps.size();
                         }
                     }
                 }
+
+                Vector<StackFrameStep> unprocessedSteps = new Vector<>();
+                for (StackFrameStep step : steps) {
+                    if (!processedSteps.contains(step)) {
+                        unprocessedSteps.add(step);
+                    }
+                }
                 if (currentStep == null && processedStepsCount != steps.size()) {
-                    StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
-                    StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
-                    for (MenuDisplayable option : options) {
-                        optionsIDJoiner.add(option.getCommandID());
+                    for (StackFrameStep unprocessedStep : unprocessedSteps) {
+                        if (unprocessedStep.getType().equals(SessionFrame.STATE_COMMAND_ID)) {
+                            StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
+                            StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
+                            for (MenuDisplayable option : options) {
+                                optionsIDJoiner.add(option.getCommandID());
+                            }
+                            for (StackFrameStep step : steps) {
+                                stepIDJoiner.add(step.getId());
+                            }
+                            throw new CommCareSessionException("Match Error: Steps " + stepIDJoiner.toString() + " do not contain a valid option " + optionsIDJoiner.toString());
+                        }
                     }
-                    for (StackFrameStep step : steps) {
-                        stepIDJoiner.add(step.getId());
-                    }
-                    throw new CommCareSessionException("Match Error: Steps " + stepIDJoiner.toString() + " do not contain a valid option " + optionsIDJoiner.toString());
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen)screen;
@@ -126,6 +142,7 @@ public class MenuSessionFactory {
                     if (step.getId().equals(neededDatum.getDataId())) {
                         if (entityScreen.referencesContainStep(step.getValue())) {
                             currentStep = step.getValue();
+                            processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
                         }
                         break;
@@ -152,6 +169,7 @@ public class MenuSessionFactory {
                         URI uri = null;
                         try {
                             uri = new URI(step.getValue());
+                            processedSteps.add(step);
                             processedStepsCount++;
                         } catch (URISyntaxException e) {
                             e.printStackTrace();

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -152,6 +152,7 @@ public class MenuSessionFactory {
                         URI uri = null;
                         try {
                             uri = new URI(step.getValue());
+                            processedStepsCount++;
                         } catch (URISyntaxException e) {
                             e.printStackTrace();
                             throw new CommCareSessionException("Query URL format error: " + e.getMessage(), e);

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -107,7 +107,7 @@ public class MenuSessionFactory {
                         }
                     }
                 }
-                if (currentStep == null) {
+                if (currentStep == null && processedStepsCount != steps.size()) {
                     StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
                     StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
                     for (MenuDisplayable option : options) {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -112,28 +112,8 @@ public class MenuSessionFactory {
                         }
                     }
                 }
-
-                Vector<StackFrameStep> unprocessedSteps = new Vector<>();
-                for (StackFrameStep step : steps) {
-                    if (!processedSteps.contains(step)) {
-                        unprocessedSteps.add(step);
-                    }
-                }
                 if (currentStep == null && processedStepsCount != steps.size()) {
-                    for (StackFrameStep unprocessedStep : unprocessedSteps) {
-                        if (unprocessedStep.getType().equals(SessionFrame.STATE_COMMAND_ID) &&
-                            !unprocessedStep.getId().startsWith("claim_command")) {
-                            StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
-                            StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
-                            for (MenuDisplayable option : options) {
-                                optionsIDJoiner.add(option.getCommandID());
-                            }
-                            for (StackFrameStep step : steps) {
-                                stepIDJoiner.add(step.getId());
-                            }
-                            throw new CommCareSessionException("Match Error: Steps " + stepIDJoiner.toString() + " do not contain a valid option " + optionsIDJoiner.toString());
-                        }
-                    }
+                    checkAndThrowCommandIDMatchError(steps, processedSteps, options);
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen)screen;
@@ -259,5 +239,32 @@ public class MenuSessionFactory {
                 bean.getRestoreAs(),
                 bean.getPreview()
         );
+    }
+
+    private void checkAndThrowCommandIDMatchError(Vector<StackFrameStep> steps, List<StackFrameStep> processedSteps,
+        MenuDisplayable[] options) throws CommCareSessionException {
+        Vector<StackFrameStep> unprocessedSteps = new Vector<>();
+        for (StackFrameStep step : steps) {
+            if (!processedSteps.contains(step)) {
+                unprocessedSteps.add(step);
+            }
+        }
+        for (StackFrameStep unprocessedStep : unprocessedSteps) {
+            if (unprocessedStep.getType().equals(SessionFrame.STATE_COMMAND_ID) &&
+                !unprocessedStep.getId().startsWith("claim_command")) {
+                StringJoiner optionsIDJoiner = new StringJoiner(", ", "[", "]");
+                StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
+                for (MenuDisplayable option : options) {
+                    optionsIDJoiner.add(option.getCommandID());
+                }
+                for (StackFrameStep step : steps) {
+                    stepIDJoiner.add(step.getId());
+                }
+                throw new CommCareSessionException(
+                    "Match Error: Steps " + stepIDJoiner.toString() +
+                    " do not contain a valid option " + optionsIDJoiner.toString()
+                );
+            }
+        }
     }
 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -131,7 +131,7 @@ public class MenuSessionFactory {
                             // This block constructs the message to display then throws the exception
                             List<String> refsList = entityScreen.getReferences().stream()
                             .map(ref -> EntityScreen.getReturnValueFromSelection(ref, (EntityDatum) neededDatum, entityScreen.getEvalContext()))
-                            .collect(Collectors.toList());
+                            .toList();
 
                             String referencesString = String.join(",\n  ", refsList);
                             String nodeSetString = ((EntityDatum) neededDatum).getNodeset().toString();

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -145,6 +145,9 @@ public class MenuSessionFactory {
                     screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
                     continue;
                 }
+                if (currentStep == null && processedStepsCount != steps.size()) {
+                    checkAndThrowCaseIDMatchError(steps, processedSteps, neededDatum.getDataId());
+                }
             } else if (screen instanceof QueryScreen) {
                 QueryScreen queryScreen = (QueryScreen)screen;
                 RemoteQueryDatum neededDatum = (RemoteQueryDatum) menuSession.getSessionWrapper().getNeededDatum();
@@ -265,6 +268,28 @@ public class MenuSessionFactory {
                 throw new CommCareSessionException(
                     "Match Error: Steps " + stepIDJoiner.toString() +
                     " do not contain a valid option " + optionsIDJoiner.toString()
+                );
+            }
+        }
+    }
+
+    private void checkAndThrowCaseIDMatchError(Vector<StackFrameStep> steps, List<StackFrameStep> processedSteps,
+        String neededDatumID) throws CommCareSessionException {
+        Vector<StackFrameStep> unprocessedSteps = new Vector<>();
+        for (StackFrameStep step : steps) {
+            if (!processedSteps.contains(step)) {
+                unprocessedSteps.add(step);
+            }
+        }
+        for (StackFrameStep unprocessedStep : unprocessedSteps) {
+            if (unprocessedStep.getType().equals(SessionFrame.STATE_DATUM_VAL)) {
+                StringJoiner stepIDJoiner = new StringJoiner(", ", "[", "]");
+                for (StackFrameStep step : steps) {
+                    stepIDJoiner.add(step.getId());
+                }
+                throw new CommCareSessionException(
+                    "Match Error: Steps " + stepIDJoiner.toString() +
+                    " do not contain a valid datum ID " + neededDatumID
                 );
             }
         }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This PR does two things: 
- Displays errors while rebuilding session from frame that were previously caught but not displayed. Namely, errors resulting from end of form navigation but that is not the only feature where rebuilding session is done.
- Adds error handling for when no matches are found between steps and menu options.
![Screen Shot 2024-03-21 at 10 26 19 PM](https://github.com/dimagi/formplayer/assets/88759246/0fa01df6-704e-46d1-9152-c925441a0822)


## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4176)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
tested locally, will test on staging

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Basic end of form navigation tests exists and the response is as expected

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
