### PR TITLE
Linear Repeat Structure Support for Formplayer

### DIFF
--- a/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
+++ b/src/main/java/org/commcare/formplayer/api/json/JsonActionUtils.java
@@ -37,14 +37,13 @@ public class JsonActionUtils {
      *
      * @param controller      the FormEntryController under consideration
      * @param model           the FormEntryModel under consideration
-     * @param formIndexString the form index of the repeat group to be deleted
+     * @param repeatIndexString the form index of the repeat group to be deleted
      * @return The JSON representation of the updated form tree
      */
     public static JSONObject deleteRepeatToJson(FormEntryController controller,
-            FormEntryModel model, String repeatIndexString, String formIndexString) {
-        FormIndex formIndex = indexFromString(formIndexString, model.getForm());
-        controller.jumpToIndex(formIndex);
-        controller.deleteRepeat(Integer.parseInt(repeatIndexString));
+            FormEntryModel model, String repeatIndexString) {
+        FormIndex indexToDelete = indexFromString(repeatIndexString, model.getForm());
+        controller.deleteRepeat(indexToDelete);
         return getCurrentJson(controller, model);
     }
 

--- a/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
+++ b/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
@@ -3,6 +3,8 @@ package org.commcare.formplayer.api.json;
 import org.commcare.formplayer.exceptions.ApplicationConfigException;
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
+import org.javarosa.core.model.GroupDef;
+import org.javarosa.core.model.IFormElement;
 import org.javarosa.core.model.SelectChoice;
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
@@ -112,6 +114,7 @@ public class PromptToJson {
                 obj.put("type", "sub-group");
                 obj.put("repeatable", true);
                 obj.put("exists", true);
+                obj.put("delete", model.isNonCountedRepeat());
                 break;
             case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
                 // we're in a subgroup, dummy node for user counted repeat group
@@ -120,6 +123,7 @@ public class PromptToJson {
                 obj.put("type", "sub-group");
                 obj.put("repeatable", true);
                 obj.put("exists", false);
+                obj.put("delete", false);
                 obj.put("add-choice", getRepeatAddText(prompt));
                 break;
         }

--- a/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
+++ b/src/main/java/org/commcare/formplayer/api/json/PromptToJson.java
@@ -10,6 +10,8 @@ import org.javarosa.core.model.data.SelectMultiData;
 import org.javarosa.core.model.data.helper.Selection;
 import org.javarosa.core.model.instance.TreeReference;
 import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.services.locale.Localization;
+import org.javarosa.core.util.NoLocalizedTextException;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryModel;
@@ -112,14 +114,33 @@ public class PromptToJson {
                 obj.put("exists", true);
                 break;
             case FormEntryController.EVENT_PROMPT_NEW_REPEAT:
-                // we're in a subgroup
-                parseCaption(model.getCaptionPrompt(), obj);
+                // we're in a subgroup, dummy node for user counted repeat group
+                FormEntryCaption prompt = model.getCaptionPrompt();
+                parseCaption(prompt, obj);
                 obj.put("type", "sub-group");
                 obj.put("repeatable", true);
                 obj.put("exists", false);
+                obj.put("add-choice", getRepeatAddText(prompt));
                 break;
         }
         return obj;
+    }
+
+    private static String getRepeatAddText(FormEntryCaption prompt) {
+        String promptText = prompt.getLongText();
+        if (prompt.getNumRepetitions() > 0) {
+            try {
+                return Localization.get("repeat.dialog.add.another", promptText);
+            } catch (NoLocalizedTextException e) {
+                return "Add another " + promptText;
+            }
+        } else {
+            try {
+                return Localization.get("repeat.dialog.add.new", promptText);
+            } catch (NoLocalizedTextException e) {
+                return "Add a new " + promptText;
+            }
+        }
     }
 
     private static void parseRepeatJuncture(FormEntryModel model, JSONObject obj, FormIndex ix) {

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -283,7 +283,7 @@ public class FormController extends AbstractBaseController {
         FormSession formEntrySession = formSessionFactory.getFormSession(serializableFormSession);
         JSONObject response = JsonActionUtils.deleteRepeatToJson(formEntrySession.getFormEntryController(),
                 formEntrySession.getFormEntryModel(),
-                deleteRepeatRequestBean.getRepeatIndex(), deleteRepeatRequestBean.getFormIndex());
+                deleteRepeatRequestBean.getRepeatIndex());
         updateSession(formEntrySession);
         FormEntryResponseBean responseBean = mapper.readValue(response.toString(), FormEntryResponseBean.class);
         responseBean.setTitle(serializableFormSession.getTitle());

--- a/src/main/java/org/commcare/formplayer/beans/QuestionBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/QuestionBean.java
@@ -34,6 +34,8 @@ public class QuestionBean {
     private String repeatable;
     private String exists;
     private String addChoice;
+
+    private boolean delete;
     private String header;
     private int control;
 
@@ -246,6 +248,14 @@ public class QuestionBean {
     @JsonSetter(value = "add-choice")
     public void setAddChoice(String addChoice) {
         this.addChoice = addChoice;
+    }
+
+    public boolean isDelete() {
+        return delete;
+    }
+
+    public void setDelete(boolean delete) {
+        this.delete = delete;
     }
 
     public String getHeader() {

--- a/src/main/java/org/commcare/formplayer/beans/RepeatRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/RepeatRequestBean.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RepeatRequestBean extends SessionRequestBean {
     private String repeatIndex;
-    private String formIndex;
 
     // our JSON-Object mapping lib (Jackson) requires a default constructor
     public RepeatRequestBean() {
@@ -30,15 +29,5 @@ public class RepeatRequestBean extends SessionRequestBean {
     @Override
     public String toString() {
         return "RepeatRequestBean [repeatIndex: " + repeatIndex + ", sessionId: " + sessionId + "]";
-    }
-
-    @JsonGetter(value = "form_ix")
-    public String getFormIndex() {
-        return formIndex;
-    }
-
-    @JsonSetter(value = "form_ix")
-    public void setFormIndex(String formIndex) {
-        this.formIndex = formIndex;
     }
 }

--- a/src/main/java/org/commcare/formplayer/session/FormSession.java
+++ b/src/main/java/org/commcare/formplayer/session/FormSession.java
@@ -180,7 +180,7 @@ public class FormSession {
 
     @Trace
     private void setupJavaRosaObjects() {
-        formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_NON_LINEAR);
+        formEntryModel = new FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_LINEAR);
         formEntryController = new FormEntryController(formEntryModel);
         formController = new FormController(formEntryController, false);
         langs = formEntryModel.getLanguages();

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -605,11 +605,10 @@ public class BaseTestClass {
         );
     }
 
-    FormEntryResponseBean newRepeatRequest(String sessionId) throws Exception {
-        String newRepeatRequestPayload = FileUtils.getFile(this.getClass(),
-                "requests/new_repeat/new_repeat.json");
-        RepeatRequestBean newRepeatRequestBean = mapper.readValue(newRepeatRequestPayload,
-                RepeatRequestBean.class);
+    FormEntryResponseBean newRepeatRequest(String sessionId, String repeatIndex) throws Exception {
+        RepeatRequestBean newRepeatRequestBean = new RepeatRequestBean();
+        newRepeatRequestBean.setRepeatIndex(repeatIndex);
+        newRepeatRequestBean.setSessionId(sessionId);
         populateFromSession(newRepeatRequestBean, sessionId);
 
         return generateMockQuery(
@@ -621,13 +620,11 @@ public class BaseTestClass {
         );
     }
 
-    FormEntryResponseBean deleteRepeatRequest(String sessionId) throws Exception {
-
-        String newRepeatRequestPayload = FileUtils.getFile(this.getClass(),
-                "requests/delete_repeat/delete_repeat.json");
-
-        RepeatRequestBean deleteRepeatRequest = mapper.readValue(newRepeatRequestPayload,
-                RepeatRequestBean.class);
+    FormEntryResponseBean deleteRepeatRequest(String sessionId, String repeatIndex)
+            throws Exception {
+        RepeatRequestBean deleteRepeatRequest = new RepeatRequestBean();
+        deleteRepeatRequest.setRepeatIndex(repeatIndex);
+        deleteRepeatRequest.setSessionId(sessionId);
         populateFromSession(deleteRepeatRequest, sessionId);
         return generateMockQuery(
                 ControllerType.FORM,

--- a/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
@@ -44,6 +44,7 @@ public class RepeatTests extends BaseTestClass {
         assert (tree.length == 2);
         QuestionBean dummyNode = tree[1];
         assertEquals("false", dummyNode.getExists());
+        assertEquals("Add a new question3", dummyNode.getAddChoice());
 
         String sessionId = newSessionResponse.getSessionId();
         FormEntryResponseBean newRepeatResponseBean = newRepeatRequest(sessionId, "1_0");
@@ -63,6 +64,7 @@ public class RepeatTests extends BaseTestClass {
         QuestionBean secondRepeat = tree[2];
         assertEquals("false", secondRepeat.getExists());
         assert (secondRepeat.getChildren().length == 0);
+        assertEquals("Add another question3", secondRepeat.getAddChoice());
 
         // Add another repeat and verify the form tree accordingly
         newRepeatResponseBean = newRepeatRequest(sessionId, "1_1");

--- a/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/RepeatTests.java
@@ -45,6 +45,8 @@ public class RepeatTests extends BaseTestClass {
         QuestionBean dummyNode = tree[1];
         assertEquals("false", dummyNode.getExists());
         assertEquals("Add a new question3", dummyNode.getAddChoice());
+        assertEquals("false", dummyNode.getExists());
+        assertEquals(false, dummyNode.isDelete());
 
         String sessionId = newSessionResponse.getSessionId();
         FormEntryResponseBean newRepeatResponseBean = newRepeatRequest(sessionId, "1_0");
@@ -54,6 +56,7 @@ public class RepeatTests extends BaseTestClass {
         assert (tree.length == 3);
         QuestionBean firstRepeat = tree[1];
         assertEquals("true", firstRepeat.getExists());
+        assertEquals(true, firstRepeat.isDelete());
         assert (firstRepeat.getChildren().length == 1);
         QuestionBean[] children = firstRepeat.getChildren();
         assert (children.length == 1);
@@ -63,6 +66,7 @@ public class RepeatTests extends BaseTestClass {
         // verify that a second dummy repeat node is added with "exists=false"
         QuestionBean secondRepeat = tree[2];
         assertEquals("false", secondRepeat.getExists());
+        assertEquals(false, secondRepeat.isDelete());
         assert (secondRepeat.getChildren().length == 0);
         assertEquals("Add another question3", secondRepeat.getAddChoice());
 
@@ -184,6 +188,10 @@ public class RepeatTests extends BaseTestClass {
     public void testRepeatModelIteration() throws Exception {
         NewFormResponse newSessionResponse = startNewForm("requests/new_form/new_form.json",
                 "xforms/repeat_model_iteration.xml");
+
+        // counted repeat group nodes can't be deleted
+        assertFalse(newSessionResponse.getTree()[1].isDelete());
+
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document doc = builder.parse(new ByteArrayInputStream(

--- a/src/test/resources/xforms/nested_repeat.xml
+++ b/src/test/resources/xforms/nested_repeat.xml
@@ -1,0 +1,51 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+    <h:head>
+        <h:title>Nested Non Counted</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/118CD69C-D541-49DB-BAA9-5F9BE5852782" uiVersion="1" version="49" name="Nested Non Counted">
+                    <rg_non_counted jr:template="">
+                        <nested_repeat jr:template="">
+                            <t/>
+                        </nested_repeat>
+                    </rg_non_counted>
+                </data>
+            </instance>
+            <instance id="commcaresession" src="jr://instance/session"/>
+            <bind nodeset="/data/rg_non_counted"/>
+            <bind nodeset="/data/rg_non_counted/nested_repeat"/>
+            <bind nodeset="/data/rg_non_counted/nested_repeat/t" type="xsd:string"/>
+            <itext>
+                <translation lang="en" default="">
+                    <text id="t1-label">
+                        <value>T1</value>
+                    </text>
+                    <text id="rg_non_counted-label">
+                        <value>RG Non Counted</value>
+                    </text>
+                    <text id="rg_non_counted/nested_repeat-label">
+                        <value>Nested Repeat</value>
+                    </text>
+                    <text id="rg_non_counted/nested_repeat/t-label">
+                        <value>T</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <group>
+            <label ref="jr:itext('rg_non_counted-label')"/>
+            <repeat nodeset="/data/rg_non_counted">
+                <group>
+                    <label ref="jr:itext('rg_non_counted/nested_repeat-label')"/>
+                    <repeat nodeset="/data/rg_non_counted/nested_repeat">
+                        <input ref="/data/rg_non_counted/nested_repeat/t">
+                            <label ref="jr:itext('rg_non_counted/nested_repeat/t-label')"/>
+                        </input>
+                    </repeat>
+                </group>
+            </repeat>
+        </group>
+    </h:body>
+</h:html>


### PR DESCRIPTION
## Product Description
[JIra](https://dimagi.atlassian.net/browse/USH-4333)

Adds support for using both counted and non counted repeat groups in a single form on Web Apps.

## Technical Summary

[Spec](https://docs.google.com/document/d/1j8NKF3nC3uZkcyqBiShZafOItPXQv-pdi3t783SK1G0/edit)

## Safety Assurance

### Safety story

- Will go through QA once supporting changes are done on Web Apps
- Unit tests are added to verify non counted repeat groups work correctly, there should not be any other impact of removing the non linear repeat strucuture

### Automated test coverage

- Added in PR

### QA Plan

[Notes here](https://docs.google.com/document/d/1j8NKF3nC3uZkcyqBiShZafOItPXQv-pdi3t783SK1G0/edit#heading=h.2m1ur8dtdbed)

[QA ticket](https://dimagi.atlassian.net/browse/QA-6548)


### Special deploy instructions

Should only be deployed after the corresponding Web Apps changes are deployed 

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

cross_request: https://github.com/dimagi/commcare-core/pull/1408
