### PR TITLE
End of Form Error Handling

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -128,7 +128,7 @@ public class MenuSessionFactory {
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
                         } else {
-                            LogStepNotInEntityScreenError(entityScreen, neededDatum, step);
+                            logStepNotInEntityScreenError(entityScreen, neededDatum, step);
                         }
                         break;
                     }
@@ -296,7 +296,7 @@ public class MenuSessionFactory {
         }
     }
 
-    private void LogStepNotInEntityScreenError(EntityScreen entityScreen, SessionDatum neededDatum, StackFrameStep step) throws CommCareSessionException {
+    private void logStepNotInEntityScreenError(EntityScreen entityScreen, SessionDatum neededDatum, StackFrameStep step) throws CommCareSessionException {
         // This block constructs the message to display then throws the exception
         List<String> refsList = entityScreen.getReferences().stream()
         .map(ref -> EntityScreen.getReturnValueFromSelection(ref, (EntityDatum) neededDatum, entityScreen.getEvalContext()))

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -128,7 +128,7 @@ public class MenuSessionFactory {
                             processedSteps.add(step);
                             needsFullInit = ++processedStepsCount == steps.size();
                         } else {
-                            throwStepNotInEntityScreenException(entityScreen, neededDatum, step);
+                            LogStepNotInEntityScreenError(entityScreen, neededDatum, step);
                         }
                         break;
                     }
@@ -147,7 +147,7 @@ public class MenuSessionFactory {
                     continue;
                 }
                 if (currentStep == null && processedStepsCount != steps.size()) {
-                    checkAndThrowCaseIDMatchError(steps, processedSteps, neededDatum.getDataId());
+                    checkAndLogCaseIDMatchError(steps, processedSteps, neededDatum.getDataId());
                 }
             } else if (screen instanceof QueryScreen) {
                 QueryScreen queryScreen = (QueryScreen)screen;
@@ -274,7 +274,7 @@ public class MenuSessionFactory {
         }
     }
 
-    private void checkAndThrowCaseIDMatchError(Vector<StackFrameStep> steps, List<StackFrameStep> processedSteps,
+    private void checkAndLogCaseIDMatchError(Vector<StackFrameStep> steps, List<StackFrameStep> processedSteps,
         String neededDatumID) throws CommCareSessionException {
         Vector<StackFrameStep> unprocessedSteps = new Vector<>();
         for (StackFrameStep step : steps) {
@@ -288,7 +288,7 @@ public class MenuSessionFactory {
                 for (StackFrameStep step : steps) {
                     stepIDJoiner.add(step.getId());
                 }
-                throw new CommCareSessionException(
+                log.error(
                     "Match Error: Steps " + stepIDJoiner.toString() +
                     " do not contain a valid datum ID " + neededDatumID
                 );
@@ -296,7 +296,7 @@ public class MenuSessionFactory {
         }
     }
 
-    private void throwStepNotInEntityScreenException(EntityScreen entityScreen, SessionDatum neededDatum, StackFrameStep step) throws CommCareSessionException {
+    private void LogStepNotInEntityScreenError(EntityScreen entityScreen, SessionDatum neededDatum, StackFrameStep step) throws CommCareSessionException {
         // This block constructs the message to display then throws the exception
         List<String> refsList = entityScreen.getReferences().stream()
         .map(ref -> EntityScreen.getReturnValueFromSelection(ref, (EntityDatum) neededDatum, entityScreen.getEvalContext()))
@@ -305,7 +305,7 @@ public class MenuSessionFactory {
         String referencesString = String.join(",\n  ", refsList);
         String nodeSetString = ((EntityDatum) neededDatum).getNodeset().toString();
 
-        throw new CommCareSessionException(String.format("Could not get %s=%s from entity screen.\nNode set: %s\nReferences: \n[%s]",
+        log.error(String.format("Could not get %s=%s from entity screen.\nNode set: %s\nReferences: \n[%s]",
         neededDatum.getDataId(), step.getValue(), nodeSetString, referencesString));
 
     }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Context:
This [PR](https://github.com/dimagi/formplayer/pull/1560) introduces validation during session rebuilding. If there's a discrepancy during this process, it will now raise an exception and show an error to the user. Before this PR, the session would simply revert to the last valid step without raising any exceptions. In terms of End of Form (EoF), this means the user would be directed to the last valid screen without any error prompts.

Issue:
However, some apps have been configured to rely on this EoF behavior, where the user is directed to the last valid screen, even if it's not explicitly defined in the app configuration. Take for example this app set up/workflow:

`Home → Application → My Cases Case List→ <casefirst_name case_last_name> → My Cases Case List (Form selection) -> Case Investigation Form`

- "My Cases Case List" is default filtered to only show open cases
- "Case Investigation Form" has EoF set to "Previous Screen"
If "Case Investigation Form" closes the case, then the path from `My Cases Case List→ <casefirst_name case_last_name> → My Cases Case List (Form selection)` is broken and would throw an exception. However, the prior behavior would navigate the user to `My Cases Case List` since it can't reach "My Cases Case List (Form Selection).

Additional note: This was configured to go to the "Previous Screen" instead of specifying the specific case list because there are various shadow modules from which the Case Investigation Form is accessible and we want to take the user back to whatever case list they came from.

Solution from this PR:
For now, instead of throwing the error, we will just log it so we can continue to use this information for debugging any real EoF bugs.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket](https://dimagi.atlassian.net/browse/USH-4505?atlOrigin=eyJpIjoiYTU2YjE3YzgyMWUwNGZmYTkyOTJmYTA4NDE1ZTY4M2QiLCJwIjoiaiJ9)
[Sentry Error
](https://dimagi.sentry.io/issues/5176121153/events/c83aac6cc1e74083b628ce8a8da05b2d/?project=136860)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
locally tested. This change only changes raising an exception to logging.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Basic end of form navigation tests exists and the response is as expected

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
