### PR TITLE
Log instead of blocking app for EoF errors

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -115,7 +115,7 @@ public class MenuSessionFactory {
                     }
                 }
                 if (currentStep == null && processedStepsCount != steps.size()) {
-                    checkAndThrowCommandIDMatchError(steps, processedSteps, options);
+                    checkAndLogCommandIDMatchError(steps, processedSteps, options);
                 }
             } else if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen)screen;
@@ -247,7 +247,7 @@ public class MenuSessionFactory {
         );
     }
 
-    private void checkAndThrowCommandIDMatchError(Vector<StackFrameStep> steps, List<StackFrameStep> processedSteps,
+    private void checkAndLogCommandIDMatchError(Vector<StackFrameStep> steps, List<StackFrameStep> processedSteps,
         MenuDisplayable[] options) throws CommCareSessionException {
         Vector<StackFrameStep> unprocessedSteps = new Vector<>();
         for (StackFrameStep step : steps) {
@@ -266,7 +266,7 @@ public class MenuSessionFactory {
                 for (StackFrameStep step : steps) {
                     stepIDJoiner.add(step.getId());
                 }
-                throw new CommCareSessionException(
+                log.error(
                     "Match Error: Steps " + stepIDJoiner.toString() +
                     " do not contain a valid option " + optionsIDJoiner.toString()
                 );


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Context:
This https://github.com/dimagi/formplayer/pull/1560 introduces validation during session rebuilding. If there's a discrepancy during this process, it will now raise an exception and show an error to the user. Before this PR, the session would simply revert to the last valid step without raising any exceptions. In terms of End of Form (EoF), this means the user would be directed to the last valid screen without any error prompts.

Issue:
There were previously working EoF navigation configurations that are now displaying an error and blocking the app workflow.

It is currently unknown what specifically about those app configurations are conflicting with this error check. However, due to the urgency, this change logs the error instead of blocking the app. The logging will aid in investigation.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[Jira Ticket ](https://dimagi.atlassian.net/browse/QA-6438)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
locally tested. This change only changes raising an exception to logging. This change removes blocking errors that were recently introduced.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Basic end of form navigation tests exists and the response is as expected

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
