### PR TITLE
USH-4497: Do not append domain to username with @

### DIFF
--- a/src/main/java/org/commcare/formplayer/util/StringUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/StringUtils.java
@@ -5,6 +5,9 @@ package org.commcare.formplayer.util;
  */
 public class StringUtils {
     public static String getFullUsername(String user, String domain, String host) {
+        if (user.contains("@")) {
+            return user;
+        }
         return user + "@" + domain + "." + host;
     }
 


### PR DESCRIPTION
## Technical Summary

https://dimagi.atlassian.net/browse/USH-4497

Users now can login as web users which already have the complete username used for couch. Do not append domain and host it that case. Without this change the claim-case request has a non-existing username in the body and will fail silently.

We do the same in hq: https://github.com/dimagi/commcare-hq/pull/34351/files#diff-b5520648dffd5a4f57530e5e1c36f90cd022db2cbf59bfef9bb3d65997d6f316R64-R74

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
