### PR TITLE
Avoid Re-calculating next screen again if we can

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -168,8 +168,10 @@ public class MenuController extends AbstractBaseController {
             @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
             HttpServletRequest request) throws Exception {
         String[] selections = sessionNavigationBean.getSelections();
-        MenuSession menuSession;
-        menuSession = menuSessionFactory.getMenuSessionFromBean(sessionNavigationBean);
+        if (selections == null) {
+            selections = new String[0];
+        }
+        MenuSession menuSession = menuSessionFactory.getMenuSessionFromBean(sessionNavigationBean);
         EntityScreenContext entityScreenContext = new EntityScreenContext(sessionNavigationBean.getOffset(),
                 sessionNavigationBean.getSearchText(),
                 sessionNavigationBean.getSortIndex(),

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -142,7 +142,7 @@ public class MenuSessionFactory {
                 }
 
                 if (currentStep != null && currentStep != NEXT_SCREEN && entityScreen.shouldBeSkipped()) {
-                    menuSession.handleInput(currentStep, needsFullInit, true, false, entityScreenContext, respectRelevancy);
+                    menuSession.handleInput(screen, currentStep, needsFullInit, true, false, entityScreenContext, respectRelevancy);
                     screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
                     continue;
                 }
@@ -196,7 +196,7 @@ public class MenuSessionFactory {
             if (currentStep == null) {
                 break;
             } else if (currentStep != NEXT_SCREEN) {
-                menuSession.handleInput(currentStep, needsFullInit, true, false, entityScreenContext, respectRelevancy);
+                menuSession.handleInput(screen, currentStep, needsFullInit, true, false, entityScreenContext, respectRelevancy);
                 menuSession.addSelection(currentStep);
                 screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
             }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -147,7 +147,7 @@ public class MenuSessionRunnerService {
 
     @Trace
     @VisibleForTesting
-    public BaseResponseBean getNextMenu(Screen nextScreen, MenuSession menuSession,
+    public BaseResponseBean getNextMenu(@Nullable Screen nextScreen, MenuSession menuSession,
             QueryData queryData,
             EntityScreenContext entityScreenContext) throws Exception {
 
@@ -265,7 +265,7 @@ public class MenuSessionRunnerService {
                 // i == selections.length => Response is Entity Screen or Entity Detail screen and we need full
                 // entity screen
                 boolean needsFullEntityScreen = i == selections.length;
-                boolean gotNextScreen = menuSession.handleInput(selection, needsFullEntityScreen, inputValidated,
+                boolean gotNextScreen = menuSession.handleInput(nextScreen, selection, needsFullEntityScreen, inputValidated,
                         true, entityScreenContext, respectRelevancy);
                 if (!gotNextScreen) {
                     notificationMessage = new NotificationMessage(

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -249,7 +249,7 @@ public class MenuSessionRunnerService {
         boolean nonAppNav = formSessionId != null;
         Screen nextScreen = null;
         try {
-            if (nonAppNav) {
+            if (nonAppNav && selections.length > 0) {
                 // User has navigated with a session ID. This means they have navigated 'back' or via
                 // another non-app mechanism. In this case remove the last selection so that they don't
                 // re-enter the form. This will have the effect of navigating to the screen prior to

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -245,14 +245,6 @@ public class MenuSessionRunnerService {
         NotificationMessage notificationMessage = null;
         boolean nonAppNav = formSessionId != null;
         try {
-            // If we have no selections, we're are the root screen.
-            if (selections == null) {
-                return getNextMenu(
-                        menuSession,
-                        queryData,
-                        entityScreenContext
-                );
-            }
             if (nonAppNav) {
                 // User has navigated with a session ID. This means they have navigated 'back' or via
                 // another non-app mechanism. In this case remove the last selection so that they don't

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.timgroup.statsd.StatsDClient;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.commcare.cases.util.CaseDBUtils;
@@ -741,10 +742,12 @@ public class RestoreFactory {
      * @param selections - Array of menu selections (e.g. ["1", "1", <case_id>])
      */
     public void cacheSessionSelections(String[] selections) {
-        String cacheKey = getSessionCacheKey();
-        String cacheValue = getSessionCacheValue(selections);
-        redisSessionCache.add(cacheKey, cacheValue);
-        redisSetTemplate.expire(cacheKey, 1, TimeUnit.HOURS);
+        if (!ArrayUtils.isEmpty(selections)) {
+            String cacheKey = getSessionCacheKey();
+            String cacheValue = getSessionCacheValue(selections);
+            redisSessionCache.add(cacheKey, cacheValue);
+            redisSetTemplate.expire(cacheKey, 1, TimeUnit.HOURS);
+        }
     }
 
     /**

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -55,6 +55,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import datadog.trace.api.Trace;
 
 
@@ -143,6 +145,7 @@ public class MenuSession implements HereFunctionHandlerListener {
     }
 
     /**
+     * @param screen                Current Screen if avaialble, null otherwise
      * @param input                 The user step input
      * @param needsFullEntityScreen Whether a full entity screen is required for this request
      *                              or if a list of references is sufficient
@@ -153,10 +156,13 @@ public class MenuSession implements HereFunctionHandlerListener {
      * @param respectRelevancy      Whether to respect display conditions on a module or form while
      *                              handling input
      */
-    public boolean handleInput(String input, boolean needsFullEntityScreen, boolean inputValidated,
+    public boolean handleInput(@Nullable Screen screen, String input, boolean needsFullEntityScreen, boolean inputValidated,
             boolean allowAutoLaunch, EntityScreenContext entityScreenContext, boolean respectRelevancy)
             throws CommCareSessionException {
-        Screen screen = getNextScreen(needsFullEntityScreen, entityScreenContext);
+        if (screen == null) {
+            screen = getNextScreen(needsFullEntityScreen, entityScreenContext);
+        }
+
         log.info("Screen " + screen + " handling input " + input);
         if (screen == null) {
             return false;
@@ -173,7 +179,7 @@ public class MenuSession implements HereFunctionHandlerListener {
                     // auto-launch takes preference over auto-select
                     if (screen.shouldBeSkipped() && !autoLaunch &&
                             entityScreen.autoSelectEntities(sessionWrapper)) {
-                        return handleInput(input, true, inputValidated, allowAutoLaunch, entityScreenContext, respectRelevancy);
+                        return handleInput(screen, input, true, inputValidated, allowAutoLaunch, entityScreenContext, respectRelevancy);
                     }
                     screen.handleInputAndUpdateSession(sessionWrapper, input, allowAutoLaunch, selectedValues,
                             respectRelevancy);

--- a/src/test/java/org/commcare/formplayer/junit/Installer.kt
+++ b/src/test/java/org/commcare/formplayer/junit/Installer.kt
@@ -64,7 +64,7 @@ class Installer(
                 bean.restoreAs,
                 bean.preview
             )
-            menuSessionRunnerService.getNextMenu(menuSession, null, EntityScreenContext()) as CommandListResponseBean
+            menuSessionRunnerService.getNextMenu(null, menuSession, null, EntityScreenContext()) as CommandListResponseBean
         }
         return mockInstallReference(install, refAndBean.first)
     }


### PR DESCRIPTION
## Technical Summary

Minor performance optimisation in session eval code. Earlier we were calculating the final screen in session navigation twice, once while processing the selection as part of [session advance](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java#L369) and then again while calling [getNextMenu](https://github.com/dimagi/formplayer/blob/master/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java#L153). 

This PR makes a simple change to avoid this re-calculation if we can utilise the existing screen again. 

## Safety Assurance

### Safety story

- Good test coverage arounf this code
- Did basic testing on staging, will let it go through a few round of QA automated tests as well.

### QA Plan

No

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
