### PR TITLE
Fix Smartlink with End of Form Navigation Compatibility

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -813,7 +813,10 @@ public class MenuSessionRunnerService {
                 try {
                     screen.init(sessionWrapper);
                     doPostAndSync(menuSession, (FormplayerSyncScreen)screen);
-                    executeAndRebuildSession(menuSession);
+                    Screen nextScreen = menuSession.getNextScreen(false, new EntityScreenContext());
+                    if (nextScreen == null && menuSession.getSessionWrapper().getForm() == null) {
+                        executeAndRebuildSession(menuSession);
+                    }
                 } catch (CommCareSessionException ccse) {
                     throw new RuntimeException("Unable to claim case.");
                 }


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Navigating to form’s smartlink lands the user all the way to the form’s defined End of Form instead of to the form. This PR fixes that and lands the user at the defined smartlink form.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[USH-3901 ](https://dimagi.atlassian.net/browse/USH-3901)
The problem is that on advanceSessionWithEndpoint → executeAndRebuildSession, [ops](https://github.com/dimagi/commcare-core/blob/d09e72adeab33cff86a324da2fa0d542a62bf2c3/src/main/java/org/commcare/session/CommCareSession.java#L880) contain the stack operation of EoF nav and this is being executed.

The fix here checks if the screen after a Formplayer Sync is a form. If it is a form, then that should be the end of the navigation and it skips adding post entry stack operations to the stack.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Locally tested and the change is restricted to smartlinks that require a formplayer sync.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
Will QA different smartlinks

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
