### PR TITLE
Fix Smartlink with End of Form Navigation Compatibility

### DIFF
--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimNavigationTests.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.google.common.collect.ImmutableMultimap;
 
 import org.commcare.data.xml.VirtualInstances;
+import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.QuestionBean;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
@@ -216,6 +217,40 @@ public class CaseClaimNavigationTests extends BaseTestClass {
                 NewFormResponse.class);
         // post should not be fired due to relevant condition evaluating to false
         verifyNoInteractions(webClientMock);
+    }
+
+    @Test
+    public void testNormalClaimWithPostInEntry() throws Exception {
+        ArrayList<String> selections = new ArrayList<>();
+        // It is relevant in the app set up that the selected menu contains a registration form
+        selections.add("3");  // select menu
+        selections.add("1");  // select form
+        selections.add("action 1");  // load case search
+
+        QueryData queryData = new QueryData();
+        queryData.setExecute("case_search.m1_results", true);
+        EntityListResponse entityListResponse;
+        try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery("query_responses/case_claim_response.xml")) {
+            entityListResponse = sessionNavigateWithQuery(selections,
+                    APP_PATH,
+                    queryData,
+                    EntityListResponse.class);
+        }
+        assertEquals(1, entityListResponse.getEntities().length);
+        assertEquals("0156fa3e-093e-4136-b95c-01b13dae66c6",
+                entityListResponse.getEntities()[0].getId());
+
+        selections.add("0156fa3e-093e-4136-b95c-01b13dae66c6");
+        FormEntryResponseBean formEntryResponseBean;
+        try (
+                MockRequestUtils.VerifiedMock ignoredPostMock = mockRequest.mockPost(true, 2);
+                MockRequestUtils.VerifiedMock ignoredRestoreMock = mockRequest.mockRestore("restores/caseclaim3.xml", 2);
+        ) {
+            formEntryResponseBean = sessionNavigateWithQuery(selections,
+                    APP_PATH,
+                    queryData,
+                    FormEntryResponseBean.class);
+        }
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
@@ -149,6 +149,20 @@ public class EndpointLaunchTest extends BaseTestClass {
 
     @Test
     @WithHqUser(enabledToggles = {TOGGLE_SESSION_ENDPOINTS})
+    public void testEndpointsWithEndOfForm() throws Exception {
+        configureQueryMock();
+        HashMap<String, String> endpointArgs = new HashMap<>();
+        endpointArgs.put("case_id", "0156fa3e-093e-4136-b95c-01b13dae66c6");
+        NewFormResponse formResponse = sessionNavigateWithEndpoint(APP_NAME,
+                "inline_w_eof_form",
+                endpointArgs,
+                NewFormResponse.class);
+        assert formResponse.getTitle().contentEquals("Update Child Health");
+        assertArrayEquals(formResponse.getSelections(), new String[]{"2", "0156fa3e-093e-4136-b95c-01b13dae66c6"});
+    }
+
+    @Test
+    @WithHqUser(enabledToggles = {TOGGLE_SESSION_ENDPOINTS})
     public void testEndpointsRelevancy() throws Exception {
         // With respect-relevancy set to false, we can navigate to the hidden form
         HashMap<String, String> endpointArgs = new HashMap<>();

--- a/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
@@ -16,6 +16,7 @@ import org.commcare.formplayer.beans.menus.PersistentCommand;
 import org.commcare.formplayer.beans.menus.CommandUtils.NavIconState;
 import org.commcare.formplayer.mocks.FormPlayerPropertyManagerMock;
 import org.commcare.formplayer.utils.FileUtils;
+import org.commcare.formplayer.utils.MockRequestUtils;
 import org.commcare.formplayer.utils.WithHqUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,8 @@ public class EndpointLaunchTest extends BaseTestClass {
 
     private final String APP_NAME = "endpoint";
 
+    private MockRequestUtils mockRequest;
+
     @Override
     @BeforeEach
     public void setUp() throws Exception {
@@ -41,6 +44,7 @@ public class EndpointLaunchTest extends BaseTestClass {
         configureRestoreFactory("endpointdomain", "endpointusername");
         storageFactoryMock.configure("endpointusername", "endpointdomain", "app_id", "asUser");
         FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock);
+        mockRequest = new MockRequestUtils(webClientMock, restoreFactoryMock);
     }
 
     @Override
@@ -273,6 +277,20 @@ public class EndpointLaunchTest extends BaseTestClass {
         expectedMenu.add(new PersistentCommand("1", "Parents", null, NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("2", "Case List With Display Conditions", null, NavIconState.NEXT));
         assertEquals(expectedMenu, formResponse.getPersistentMenu());
+    }
+
+    @Test
+    @WithHqUser(enabledToggles = {TOGGLE_SESSION_ENDPOINTS})
+    public void testEndpointsWithSync() throws Exception {
+        mockRequest.mockPostandUpdateRestore("restores/caseclaim3.xml");
+        HashMap<String, String> endpointArgs = new HashMap<>();
+        endpointArgs.put("case_id", "0156fa3e-093e-4136-b95c-01b13dae66c6"); // from case claim response
+
+        NewFormResponse formResponse = sessionNavigateWithEndpoint(APP_NAME,
+        "add_child",
+        endpointArgs,
+        NewFormResponse.class);
+        assert formResponse.getTitle().contentEquals("Add Child");
     }
 
     private void configureQueryMock() {

--- a/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
+++ b/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
@@ -12,6 +12,7 @@ import org.commcare.formplayer.junit.RestoreFactoryAnswer;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.web.client.WebClient;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 
 /**
@@ -40,6 +41,22 @@ public class MockRequestUtils {
 
         return () -> {
             verify(webClientMock, Mockito.times(times)).caseClaimPost(anyString(), any());
+        };
+    }
+
+    /**
+     * Mock the post request, verifies it happened, and updates the mocked restore.
+     */
+    public VerifiedMock mockPostandUpdateRestore(String restoreFile) {
+        Mockito.reset(webClientMock);
+        Answer<Boolean> answer = invocation -> {
+            mockRestore(restoreFile);
+            return true;
+        };
+        Mockito.doAnswer(answer).when(webClientMock).caseClaimPost(anyString(), any());
+
+        return () -> {
+            verify(webClientMock, Mockito.times(1)).caseClaimPost(anyString(), any());
         };
     }
 

--- a/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
+++ b/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
@@ -31,26 +31,33 @@ public class MockRequestUtils {
      * Mock the post request and verify it happened
      */
     public VerifiedMock mockPost(boolean returnValue) {
+        return mockPost(returnValue, 1);
+    }
+
+    public VerifiedMock mockPost(boolean returnValue, int times) {
         Mockito.reset(webClientMock);
         when(webClientMock.caseClaimPost(anyString(), any())).thenReturn(returnValue);
 
         return () -> {
-            VerificationMode once = Mockito.times(1);
-            verify(webClientMock, once).caseClaimPost(anyString(), any());
+            verify(webClientMock, Mockito.times(times)).caseClaimPost(anyString(), any());
         };
     }
 
     /**
      * Mock the restore and verify it happened
      */
+
     public VerifiedMock mockRestore(String restoreFile) {
+        return mockRestore(restoreFile, 1);
+    }
+
+    public VerifiedMock mockRestore(String restoreFile, int times) {
         Mockito.reset(restoreFactoryMock);
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer(restoreFile);
         Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
 
         return () -> {
-            VerificationMode once = Mockito.times(1);
-            verify(restoreFactoryMock, once).getRestoreXml(anyBoolean());
+            verify(restoreFactoryMock, Mockito.times(times)).getRestoreXml(anyBoolean());
         };
     }
 

--- a/src/test/resources/archives/case_claim_post_in_entry/default/app_strings.txt
+++ b/src/test/resources/archives/case_claim_post_in_entry/default/app_strings.txt
@@ -37,6 +37,7 @@ m1.case_short.title=Cases
 modules.m0=Registration
 modules.m1=Follow Up
 modules.m2=Follow Up with Post
+modules.m3=Follow Up with Case Search and Post
 search_property.m1.name=Name
 search_property.m1.state=State
 search_property.m1.district=District

--- a/src/test/resources/archives/case_claim_post_in_entry/suite.xml
+++ b/src/test/resources/archives/case_claim_post_in_entry/suite.xml
@@ -329,6 +329,33 @@
       <datum id="case_id" nodeset="instance('results')/results/case[@case_type='case']" value="./@case_id" detail-select="m0_search_short" detail-confirm="m1_case_long"/>
     </session>
   </entry>
+  <entry>
+    <form>http://openrosa.org/formdesigner/5CCB1614-68B3-44C0-A166-D63AA7C1D4FB</form>
+    <command id="m3-f0">
+      <text>
+        <locale id="forms.m1f1"/>
+      </text>
+    </command>
+    <session>
+      <datum id="case_id_new_case_0" function="uuid()"/>
+    </session>
+  </entry>
+  <entry>
+    <form>http://openrosa.org/formdesigner/52D111C9-79C6-403F-BF4C-D24B64A872E2</form>
+    <post url="http://localhost:8000/a/test/phone/claim-case/" relevant="true()">
+      <data ref="instance('commcaresession')/session/data/case_id" key="case_id"/>
+    </post>
+    <command id="m3-f1">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='case'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+    </session>
+  </entry>
   <menu id="root">
     <text>
       <locale id="modules.m0"/>
@@ -350,6 +377,13 @@
     <command id="m2-f1"/>
     <command id="m2-f2"/>
     <command id="m2-f3"/>
+  </menu>
+  <menu id="m3">
+    <text>
+      <locale id="modules.m3"/>
+    </text>
+    <command id="m3-f0"/>
+    <command id="m3-f1"/>
   </menu>
   <remote-request>
     <post url="http://localhost:8000/a/test/phone/claim-case/" relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">

--- a/src/test/resources/archives/endpoint/suite.xml
+++ b/src/test/resources/archives/endpoint/suite.xml
@@ -501,6 +501,11 @@
       </query>
       <datum id="case_id" nodeset="instance('results:inline')/results/case[@case_type='case'][@status='open'][not(commcare_is_related_case=true())]" value="./@case_id" detail-select="m5_case_short"/>
     </session>
+    <stack>
+       <create>
+         <command value="'m4'"/>
+       </create>
+     </stack>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/6C3F2B4A-9E8D-45C7-AF23-1D9B5F6A7C8E</form>
@@ -785,6 +790,21 @@
           <data key="case_id" ref="$case_id"/>
         </query>
         <datum id="case_id" value="$case_id"/>
+      </push>
+    </stack>
+  </endpoint>
+
+  <endpoint id="inline_w_eof_form">
+    <argument id="case_id"/>
+    <stack>
+      <push>
+        <command value="'m5'"/>
+        <query id="results:inline" value="http://localhost:8000/a/test-1/phone/case_fixture/343af03494944cf4affdf775964eba54/">
+          <data key="case_type" ref="'case'"/>
+          <data key="case_id" ref="$case_id"/>
+        </query>
+        <datum id="case_id" value="$case_id"/>
+        <command value="'m5-f0'"/>
       </push>
     </stack>
   </endpoint>

--- a/src/test/resources/archives/endpoint/suite.xml
+++ b/src/test/resources/archives/endpoint/suite.xml
@@ -671,6 +671,22 @@
       </push>
     </stack>
   </remote-request>
+  <remote-request>
+    <post url="http://localhost:8000/a/test-1/phone/claim-case/" relevant="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]) = 0">
+      <data key="case_id" ref="instance('commcaresession')/session/data/case_id"/>
+    </post>
+    <command id="claim_command.add_child.case_id">
+      <display>
+        <text/>
+      </display>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id" function="instance('commcaresession')/session/data/case_id"/>
+    </session>
+    <stack/>
+  </remote-request>
   <endpoint id="caselist">
     <stack>
       <push>
@@ -708,6 +724,10 @@
   <endpoint id="add_child">
     <argument id="case_id"/>
     <stack>
+      <push>
+        <datum id="case_id" value="$case_id"/>
+        <command value="'claim_command.add_child.case_id'"/>
+      </push>
       <push>
         <command value="'m1'"/>
         <datum id="case_id" value="$case_id"/>


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
Navigating to form’s smartlink lands the user all the way to the form’s defined End of Form instead of to the form. This PR fixes that and lands the user at the defined smartlink form.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[USH-3901](https://dimagi.atlassian.net/browse/USH-3901) and [USH-5001](https://dimagi.atlassian.net/browse/USH-5001)
The problem is that on advanceSessionWithEndpoint → executeAndRebuildSession, [ops](https://github.com/dimagi/commcare-core/blob/d09e72adeab33cff86a324da2fa0d542a62bf2c3/src/main/java/org/commcare/session/CommCareSession.java#L880) contain the stack operation of EoF nav and this is being executed. 

The solution here depends on the fact that only the last stack defined in the `<endpoint>` stack definition defines the navigation. While the stacks prior define only case claim. Meaning that when processing the last stack, we do not want to pop new frames into the stack (meaning that we skip `executeAndRebuildSession`). 


Additional context: An initial attempt to resolving this issue (https://github.com/dimagi/formplayer/pull/1622) resulted in this [bug](https://dimagi.atlassian.net/browse/USH-4975) and subsequently a [revert](https://github.com/dimagi/formplayer/pull/1627). The 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Locally tested and the change is restricted to smartlinks that require a Formplayer sync.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
There exists tests surrounding smartlinking. I added tests that would catch
-  The bug involving smartlinking to a form that defines an EOF nav
-  Scenarios where both rebuildSessionFromFrame and autoAdvanceSession post https://github.com/dimagi/formplayer/pull/1628/commits/3e129e754e5f4460a7949baf21c690ce83072aef. This occurs with changes in this reverted PR https://github.com/dimagi/formplayer/pull/1622 where `FormplayerSyncScreen` is processed in `rebuildSessionFromFrame`. Consequently, it is not an existing logic flow but I kept the test here to future proof this regression.
- Smartlinking to a case that is not yet claimed in user's `casedb` (which occured in this [ticket](https://dimagi.atlassian.net/browse/USH-4975))


### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
will QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.

[USH-3901]: https://dimagi.atlassian.net/browse/USH-3901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[USH-5001]: https://dimagi.atlassian.net/browse/USH-5001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ