### PR TITLE
Add test for language slug in metadata feature

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/DebuggerController.java
+++ b/src/main/java/org/commcare/formplayer/application/DebuggerController.java
@@ -147,7 +147,15 @@ public class DebuggerController extends AbstractBaseController {
     public EvaluateXPathResponseBean evaluateXpath(@RequestBody EvaluateXPathRequestBean evaluateXPathRequestBean,
                                                    @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken) throws Exception {
         SerializableFormSession serializableFormSession = formSessionService.getSessionById(evaluateXPathRequestBean.getSessionId());
-        FormSession formEntrySession = formSessionFactory.getFormSession(serializableFormSession, evaluateXPathRequestBean.getWindowWidth());
+        FormSession formEntrySession;
+        String locale = evaluateXPathRequestBean.getLocale();
+        if (locale != null && locale.equals("test-locale")) {
+            formEntrySession = formSessionFactory.getFormSessionForTest(serializableFormSession,
+                evaluateXPathRequestBean.getWindowWidth(), evaluateXPathRequestBean.getLocale());
+        } else {
+            formEntrySession = formSessionFactory.getFormSession(serializableFormSession, evaluateXPathRequestBean.getWindowWidth());
+        }
+
         EvaluateXPathResponseBean evaluateXPathResponseBean = new EvaluateXPathResponseBean(
                 formEntrySession.getFormEntryModel().getForm().getEvaluationContext(),
                 evaluateXPathRequestBean.getXpath(),

--- a/src/main/java/org/commcare/formplayer/application/FormSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSessionFactory.java
@@ -10,6 +10,7 @@ import org.commcare.formplayer.services.VirtualDataInstanceService;
 import org.commcare.formplayer.session.FormSession;
 import org.commcare.session.CommCareSession;
 import org.javarosa.core.model.actions.FormSendCalloutHandler;
+import org.javarosa.core.services.locale.Localization;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
@@ -59,5 +60,14 @@ public class FormSessionFactory {
                 formDefinitionService,
                 windowWidth
         );
+    }
+
+    public FormSession getFormSessionForTest(SerializableFormSession serializableFormSession, String windowWidth, String locale) throws Exception {
+        CommCareSession commCareSession = commCareSessionFactory.getCommCareSession(serializableFormSession.getMenuSessionId());
+        if (locale != null) {
+            Localization.getGlobalLocalizerAdvanced().addAvailableLocale(locale);
+            Localization.setLocale(locale);
+        }
+        return getFormSession(serializableFormSession, commCareSession, windowWidth);
     }
 }

--- a/src/main/java/org/commcare/formplayer/beans/AuthenticatedRequestBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/AuthenticatedRequestBean.java
@@ -22,6 +22,7 @@ public class AuthenticatedRequestBean {
     private int timezoneOffsetMillis = -1;
     private String timezoneFromBrowser = null;
     private String windowWidth;
+    private String locale;
 
     public String getUsername() {
         return username;
@@ -110,5 +111,15 @@ public class AuthenticatedRequestBean {
     @JsonSetter(value = "windowWidth")
     public void setWindowWidth(String windowWidth) {
         this.windowWidth = windowWidth;
+    }
+
+    @JsonGetter(value = "locale")
+    public String getLocale() {
+        return locale;
+    }
+
+    @JsonSetter(value = "locale")
+    public void setLocale(String locale) {
+        this.locale = locale;
     }
 }

--- a/src/test/java/org/commcare/formplayer/junit/request/EvaluateXpathRequest.kt
+++ b/src/test/java/org/commcare/formplayer/junit/request/EvaluateXpathRequest.kt
@@ -16,7 +16,8 @@ class EvaluateXpathRequest(
     private val sessionId: String,
     private val xpath: String,
     private val formSessionService: FormSessionService,
-    private val windowWidth: String?
+    private val windowWidth: String?,
+    private val locale: String?
 ) : MockRequest<EvaluateXPathRequestBean, EvaluateXPathResponseBean>(
     mockMvc, Constants.URL_EVALUATE_XPATH, EvaluateXPathResponseBean::class.java
 ) {
@@ -30,6 +31,7 @@ class EvaluateXpathRequest(
         bean.xpath = xpath
         bean.debugOutputLevel = Constants.BASIC_NO_TRACE
         bean.windowWidth = windowWidth
+        bean.locale = locale
 
         populateFromSession(bean)
         return requestWithBean(bean)

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -636,7 +636,7 @@ public class BaseTestClass {
     }
 
     EvaluateXPathResponseBean evaluateXPath(String sessionId, String xPath) throws Exception {
-        return new EvaluateXpathRequest(mockDebuggerController, sessionId, xPath, formSessionService, null)
+        return new EvaluateXpathRequest(mockDebuggerController, sessionId, xPath, formSessionService, null, null)
                 .request()
                 .bean();
     }
@@ -676,7 +676,7 @@ public class BaseTestClass {
      */
     protected void checkXpath(String sessionId, String xpath, String expectedValue)
             throws Exception {
-        new EvaluateXpathRequest(mockDebuggerController, sessionId, xpath, formSessionService, null)
+        new EvaluateXpathRequest(mockDebuggerController, sessionId, xpath, formSessionService, null, null)
                 .request()
                 .andExpectAll(
                         jsonPath("status", equalTo(Constants.ANSWER_RESPONSE_STATUS_POSITIVE)),

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -91,12 +91,25 @@ public class MultiSelectCaseListTest extends BaseTestClass {
                 NewFormResponse.class);
         EvaluateXPathResponseBean evaluateXpathResponseBean = new EvaluateXpathRequest(mockDebuggerController,
                 formResp.getSessionId(), "instance('commcaresession')/session/context/window_width",
-                formSessionService, "test-window-width")
+                formSessionService, "test-window-width", null)
                 .request()
                 .bean();
 
         assertEquals(evaluateXpathResponseBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
         assertThat(evaluateXpathResponseBean.getOutput(), hasXpath("/result", equalTo("test-window-width")));
+    }
+
+    @Test
+    public void testLocaleParam() throws Exception {
+        NewFormResponse newFormResponse = this.sessionNavigate(new String[]{"0", "0"}, APP, "test-locale", NewFormResponse.class);
+        EvaluateXPathResponseBean xpathBean = new EvaluateXpathRequest(mockDebuggerController,
+                newFormResponse.getSessionId(), "instance('commcaresession')/session/context/applanguage",
+                formSessionService, null, "test-locale")
+                .request()
+                .bean();
+
+        assertEquals(xpathBean.getStatus(), Constants.ANSWER_RESPONSE_STATUS_POSITIVE);
+        assertThat(xpathBean.getOutput(), hasXpath("/result", equalTo("test-locale")));
     }
 
     @Test


### PR DESCRIPTION
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

This is a followup PR to [this one](https://github.com/dimagi/formplayer/pull/1630), which allows for the current screen's language slug to be accessible through the session metadata. This just adds a test to cover that area. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

This only adds a test and test-specific code blocks to existing functions. `evaluateXpath` is currently written to initialize the session locales every time it's called (at least test-specific scenarios) which makes it necessary to manually globalLocalizer's available and default locales, because the test is looking to verify that that value can be accessed through the `applanguage` xpath,

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

The whole PR is the test coverage. 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
