### PR TITLE
Persistent menu auto select fix

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -142,9 +142,10 @@ public class MenuSessionFactory {
                 }
 
                 if (currentStep != null && currentStep != NEXT_SCREEN && entityScreen.shouldBeSkipped()) {
-                    menuSession.handleInput(screen, currentStep, needsFullInit, true, false, entityScreenContext);
-                    screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
-                    continue;
+                    if (((EntityScreen)screen).autoSelectEntities(menuSession.getSessionWrapper())) {
+                        screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
+                        continue;
+                    }
                 }
                 if (currentStep == null && processedStepsCount != steps.size()) {
                     checkAndLogCaseIDMatchError(steps, processedSteps, neededDatum.getDataId());

--- a/src/test/java/org/commcare/formplayer/tests/CaseListAutoSelectTests.kt
+++ b/src/test/java/org/commcare/formplayer/tests/CaseListAutoSelectTests.kt
@@ -2,9 +2,11 @@ package org.commcare.formplayer.tests
 
 import org.commcare.formplayer.beans.NewFormResponse
 import org.commcare.formplayer.beans.menus.EntityListResponse
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+
 
 @WebMvcTest
 class CaseListAutoSelectTests : BaseTestClass() {
@@ -28,7 +30,24 @@ class CaseListAutoSelectTests : BaseTestClass() {
     fun testAutoSelection() {
         // We directly go to the form without selecting the case
         val selections = arrayOf("0", "2")
-        sessionNavigate(selections, APP, NewFormResponse::class.java)
+        var response = sessionNavigate(selections, APP, NewFormResponse::class.java)
+
+        // test breadcrumb
+        assertEquals( 3, response.breadcrumbs.size)
+        assertEquals( "Untitled Application", response.breadcrumbs[0])
+        assertEquals( "Case List", response.breadcrumbs[1])
+        assertEquals( "Followup Form 1", response.breadcrumbs[2])
+
+        // test persistent menu
+        val persistentMenu = response.persistentMenu
+        assertEquals(2, persistentMenu.size)
+        assertEquals("Case List", persistentMenu[0].displayText)
+        assertEquals("Case List 1", persistentMenu[1].displayText)
+        val zeroSelectionMenu = persistentMenu[0].commands
+        assertEquals(3, zeroSelectionMenu.size)
+        assertEquals("Registration Form", zeroSelectionMenu[0].displayText)
+        assertEquals("Followup Form", zeroSelectionMenu[1].displayText)
+        assertEquals("Followup Form 1", zeroSelectionMenu[2].displayText)
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -16,6 +16,7 @@ import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
+import org.commcare.formplayer.beans.menus.PersistentCommand;
 import org.commcare.formplayer.mocks.FormPlayerPropertyManagerMock;
 import org.commcare.formplayer.utils.MockRequestUtils;
 import org.commcare.formplayer.utils.WithHqUser;
@@ -200,8 +201,13 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
             // For auto-selection we should not add guid back to the selections.
             assertEquals(reponse.getSelections().length, 1);
             assertEquals(reponse.getSelections()[0], "2");
-
             assertEquals("Close", reponse.getCommands()[0].getDisplayText());
+
+            // Persistent Menu And Breadcrumbs should not contain the auto-selected entities
+            ArrayList<PersistentCommand> subMenu = reponse.getPersistentMenu().get(2).getCommands();
+            assertEquals(1, subMenu.size());
+            assertEquals("Close", subMenu.get(0).getDisplayText()); // directly contains the form instead of entity selection
+            assertEquals(2, reponse.getBreadcrumbs().length);
         }
 
         ArrayList<String> updatedSelections = new ArrayList<>();

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -241,6 +241,7 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         expectedMenu.add(new PersistentCommand("0", "Case List", "jr://file/commcare/image/m0customicon_en.png", NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
         assertEquals(expectedMenu, menuResponse.getPersistentMenu());
 
         selections = new String[]{"0"};
@@ -264,6 +265,30 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         PersistentCommand firstSecondMenu = firstMenu.getCommands().get(1);
         String guid = formResponse.getSelections()[2];
         firstSecondMenu.addCommand(new PersistentCommand(guid, "(2) 123, ...", null, NavIconState.ENTITY_SELECT));
+        assertEquals(expectedMenu, formResponse.getPersistentMenu());
+    }
+
+    @Test
+    public void testPersistentMenuWithAutoSelect() throws Exception {
+        ArrayList<PersistentCommand> expectedMenu = new ArrayList<>();
+        expectedMenu.add(new PersistentCommand("0", "Case List", "jr://file/commcare/image/m0customicon_en.png", NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
+
+        // Auto-Advance in a Auto Select Case List
+        String[] selections = new String[]{"3"};
+        NewFormResponse formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
+        assertEquals(expectedMenu, formResponse.getPersistentMenu());
+
+
+        PersistentCommand firstMenu = expectedMenu.get(0);
+        firstMenu.addCommand(new PersistentCommand("0","Registration Form", null, NavIconState.JUMP));
+        firstMenu.addCommand(new PersistentCommand("1","Followup Form", null, NavIconState.JUMP));
+        firstMenu.addCommand(new PersistentCommand("2","Followup Form with AutoSelect Datum", "jr://file/commcare/image/m0f2customicon_en.png", NavIconState.NEXT));
+        firstMenu.addCommand(new PersistentCommand("3","Followup Form with AutoSelect Datum", null, NavIconState.NEXT));
+        selections = new String[]{"0", "2"};
+        formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
         assertEquals(expectedMenu, formResponse.getPersistentMenu());
     }
 }

--- a/src/test/resources/archives/case_claim_with_multi_select/profile.ccpr
+++ b/src/test/resources/archives/case_claim_with_multi_select/profile.ccpr
@@ -72,7 +72,7 @@
 
     <!-- end -->
 
-    
+    <property key="cc-persistent-menu" value="yes" force="true"/>
 
     <features>
         <checkoff active="true"/>

--- a/src/test/resources/archives/case_list_auto_select/profile.ccpr
+++ b/src/test/resources/archives/case_list_auto_select/profile.ccpr
@@ -21,8 +21,10 @@
     <property key="jr_openrosa_api" value="1.0" force="true"/>
     
     <property key="heartbeat-url" value="http://localhost:8000/a/shubham/phone/heartbeat/6e7eb8d05a214872b5ed416a1e5fe313/?build_profile_id=" force="true"/>
-    
-    
+
+
+    <property key="cc-persistent-menu" value="yes" force="true"/>
+    <property key="cc-auto-advance-menu" value="yes" force="true"/>
     
 
     <!-- Properties configured on CommCare HQ 1.0 -->
@@ -38,7 +40,7 @@
         <property key="cc-show-saved" value="no" force="true"/>
     
         <property key="cc-show-incomplete" value="no" force="true"/>
-    
+
 
     <!-- end -->
 

--- a/src/test/resources/archives/case_list_auto_select/suite.xml
+++ b/src/test/resources/archives/case_list_auto_select/suite.xml
@@ -118,9 +118,7 @@
   <entry>
     <form>http://openrosa.org/formdesigner/99F89DA7-E568-4952-9BAF-717263F2C5DD</form>
     <command id="m0-f2">
-      <text>
-        <locale id="forms.m0f1"/>
-      </text>
+      <text>Followup Form 1</text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <session>
@@ -148,9 +146,7 @@
     <command id="m0-f2"/>
   </menu>
   <menu id="m1">
-    <text>
-      <locale id="modules.m0"/>
-    </text>
+    <text>Case List 1</text>
     <command id="m0-f3"/>
   </menu>
 </suite>

--- a/src/test/resources/archives/multi_select_case_list/suite.xml
+++ b/src/test/resources/archives/multi_select_case_list/suite.xml
@@ -199,6 +199,11 @@
     <text>Menu with Auto Submit Form</text>
     <command id="m0-auto-submit-form"/>
   </menu>
+  <menu id="single-form-auto-select-menu">
+    <text>Single Form Auto Select</text>
+    <command id="m0-f2"/>
+    <command id="m0-f3" relevant="false()"/>
+  </menu>
   <endpoint id="case_list">
     <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
     <stack>


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/USH-5045

Fixes an issue where a reference to case list auto-selection will get added to the persistent menu and breadcrumbs. This only happens in case search and claim workflows. 

## Technical Summary

With case search and claim, we were triggering `auto-selection` on the case list with the `handleInput` method when `autoselectEntities()` is a better method to do so as it skips un-needed handling like adding a reference to persistent menu/ breadcrumbs. 

## Safety Assurance

### Safety story

- Added tests  for persistent menus around various auto-select and auto-advance workflows
- Will test the exact workflow on staging before deploy. 


### QA Plan
NA


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
