### PR TITLE
Ensure Unique Menu Entries in Persistent Menu

### DIFF
--- a/src/main/java/org/commcare/formplayer/session/PersistentMenuHelper.kt
+++ b/src/main/java/org/commcare/formplayer/session/PersistentMenuHelper.kt
@@ -70,10 +70,17 @@ class PersistentMenuHelper(val isPersistentMenuEnabled: Boolean) {
     private fun addPersistentCommand(command: PersistentCommand) {
         // currentMenu!=null implies that we must have added items to persistent menu
         check(currentMenu == null || persistentMenu.size > 0)
-        if (currentMenu == null) {
-            persistentMenu.add(command)
-        } else {
-            currentMenu!!.addCommand(command)
+        if (isCommandNotPresent(command)) {
+            if (currentMenu == null) {
+                persistentMenu.add(command)
+            } else {
+                currentMenu!!.addCommand(command)
+            }
         }
+    }
+
+    private fun isCommandNotPresent(command: PersistentCommand): Boolean {
+        val currentCommands = if (currentMenu == null) persistentMenu else currentMenu!!.commands
+        return currentCommands.firstOrNull { persistentCommand -> persistentCommand.index == command.index } == null
     }
 }

--- a/src/test/java/org/commcare/formplayer/mocks/FormPlayerPropertyManagerMock.java
+++ b/src/test/java/org/commcare/formplayer/mocks/FormPlayerPropertyManagerMock.java
@@ -57,11 +57,11 @@ public class FormPlayerPropertyManagerMock extends FormplayerPropertyManager {
     }
 
     // convenience method to set auto advance menu as true
-    public static void mockAutoAdvanceMenu(FormplayerStorageFactory storageFactoryMock) {
+    public static void mockAutoAdvanceMenu(FormplayerStorageFactory storageFactoryMock, boolean enable) {
         SQLiteDB db = storageFactoryMock.getSQLiteDB();
         FormPlayerPropertyManagerMock propertyManagerMock = new FormPlayerPropertyManagerMock(
                 new SqlStorage(db, Property.class, PropertyManager.STORAGE_KEY));
-        propertyManagerMock.enableAutoAdvanceMenu(true);
+        propertyManagerMock.enableAutoAdvanceMenu(enable);
         when(storageFactoryMock.getPropertyManager()).thenReturn(propertyManagerMock);
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/AutoAdvanceMenuInNestedMultiSelectList.kt
+++ b/src/test/java/org/commcare/formplayer/tests/AutoAdvanceMenuInNestedMultiSelectList.kt
@@ -41,7 +41,7 @@ class AutoAdvanceMenuInNestedMultiSelectList : BaseTestClass() {
 
     @Test
     fun testAutoAdvanceMenuInNestedMultiSelectList() {
-        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock)
+        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock, true)
         mockRequest.mockQuery(
             "query_responses/case_search_multi_select_response.xml", 2
         ).use {

--- a/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
@@ -43,7 +43,7 @@ public class EndpointLaunchTest extends BaseTestClass {
         super.setUp();
         configureRestoreFactory("endpointdomain", "endpointusername");
         storageFactoryMock.configure("endpointusername", "endpointdomain", "app_id", "asUser");
-        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock);
+        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock, true);
         mockRequest = new MockRequestUtils(webClientMock, restoreFactoryMock);
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -241,7 +241,7 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
 
     @Test
     public void testAutoAdvanceMenuWithCaseSearch() throws Exception {
-        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock);
+        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock, true);
         try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery(
                 "query_responses/case_search_multi_select_response.xml")) {
             EntityListResponse entityResp = sessionNavigateWithQuery(new String[]{"1"},

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -207,17 +208,22 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
             ArrayList<PersistentCommand> subMenu = reponse.getPersistentMenu().get(2).getCommands();
             assertEquals(1, subMenu.size());
             assertEquals("Close", subMenu.get(0).getDisplayText()); // directly contains the form instead of entity selection
-            assertEquals(2, reponse.getBreadcrumbs().length);
+            assertEquals(ImmutableList.of("Case Claim", "Follow Up"),
+                    Arrays.stream(reponse.getBreadcrumbs()).toList());
         }
 
-        ArrayList<String> updatedSelections = new ArrayList<>();
-        updatedSelections.addAll(Arrays.asList(reponse.getSelections()));
+        ArrayList<String> updatedSelections = new ArrayList<>(Arrays.asList(reponse.getSelections()));
         updatedSelections.add("0");
 
-        sessionNavigateWithQuery(updatedSelections.toArray(new String[0]),
+        NewFormResponse formResponse = sessionNavigateWithQuery(updatedSelections.toArray(new String[0]),
                 APP_NAME,
                 null,
-                FormEntryResponseBean.class);
+                NewFormResponse.class);
+        ArrayList<PersistentCommand> subMenu = formResponse.getPersistentMenu().get(2).getCommands();
+        assertEquals(1, subMenu.size());
+        assertEquals("Close", subMenu.get(0).getDisplayText());
+        assertEquals(ImmutableList.of("Case Claim", "Follow Up", "Close"),
+                Arrays.stream(formResponse.getBreadcrumbs()).toList());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -275,20 +275,34 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
+        PersistentCommand firstMenu = expectedMenu.get(0);
+        firstMenu.addCommand(new PersistentCommand("0","Registration Form", null, NavIconState.JUMP));
+        firstMenu.addCommand(new PersistentCommand("1","Followup Form", null, NavIconState.JUMP));
+        firstMenu.addCommand(new PersistentCommand("2","Followup Form with AutoSelect Datum", "jr://file/commcare/image/m0f2customicon_en.png", NavIconState.NEXT));
+        firstMenu.addCommand(new PersistentCommand("3","Followup Form with AutoSelect Datum", null, NavIconState.NEXT));
+        String[] selections = new String[]{"0", "2"};
+        NewFormResponse formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
+        assertEquals(expectedMenu, formResponse.getPersistentMenu());
+    }
+
+    @Test
+    public void testPersistentMenuWithAutoAdvance() throws Exception {
+        ArrayList<PersistentCommand> expectedMenu = new ArrayList<>();
+        expectedMenu.add(new PersistentCommand("0", "Case List", "jr://file/commcare/image/m0customicon_en.png", NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
 
         // Auto-Advance in a Auto Select Case List
         String[] selections = new String[]{"3"};
         NewFormResponse formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
         assertEquals(expectedMenu, formResponse.getPersistentMenu());
 
-
-        PersistentCommand firstMenu = expectedMenu.get(0);
-        firstMenu.addCommand(new PersistentCommand("0","Registration Form", null, NavIconState.JUMP));
-        firstMenu.addCommand(new PersistentCommand("1","Followup Form", null, NavIconState.JUMP));
-        firstMenu.addCommand(new PersistentCommand("2","Followup Form with AutoSelect Datum", "jr://file/commcare/image/m0f2customicon_en.png", NavIconState.NEXT));
-        firstMenu.addCommand(new PersistentCommand("3","Followup Form with AutoSelect Datum", null, NavIconState.NEXT));
-        selections = new String[]{"0", "2"};
+        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock, false);
+        selections = new String[]{"3", "0"};
         formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
+        expectedMenu.get(3).addCommand(new PersistentCommand("0", "Followup Form with AutoSelect Datum",
+                "jr://file/commcare/image/m0f2customicon_en.png", NavIconState.JUMP));
         assertEquals(expectedMenu, formResponse.getPersistentMenu());
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -47,7 +47,7 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         super.setUp();
         configureRestoreFactory("caseclaimdomain", "caseclaimusername");
         storageFactoryMock.configure("user", "domain", "app_id", "asUser");
-        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock);
+        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock, true);
     }
 
     @Override


### PR DESCRIPTION
## Product Description

https://dimagi.atlassian.net/browse/USH-5045?focusedCommentId=353249

## Technical Summary

In some cases involving case search and claim, we run the call to `getNextScreen` multiple times which can result into peristent menu having duplicate entries. This change ensures uniqueness of persistent menu items by adding a `exists` check before `add` . 

## Safety Assurance

### Safety story

Relying on tests and staging testing

### Automated test coverage

Added with the PR

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
No QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
