### PR TITLE
Set session cookie for user's preferred language

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -2,6 +2,7 @@ package org.commcare.formplayer.application;
 
 import static org.commcare.formplayer.util.Constants.PART_ANSWER;
 import static org.commcare.formplayer.util.Constants.PART_FILE;
+import static org.commcare.formplayer.util.Constants.SESSION_PREFERRED_LANGUAGE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -55,6 +56,8 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.annotation.Resource;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 
 import io.sentry.Sentry;
 
@@ -135,8 +138,11 @@ public class FormController extends AbstractBaseController {
     @UserRestore
     @ConfigureStorageFromSession
     public FormEntryResponseBean changeLocale(@RequestBody ChangeLocaleRequestBean changeLocaleBean,
-            @CookieValue(name = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken)
+                   @CookieValue(name = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken,
+                   HttpServletResponse response)
             throws Exception {
+        response.addCookie(new Cookie(SESSION_PREFERRED_LANGUAGE,changeLocaleBean.getLocale()));
+
         SerializableFormSession serializableFormSession = formSessionService.getSessionById(
                 changeLocaleBean.getSessionId());
         FormSession formEntrySession = formSessionFactory.getFormSession(serializableFormSession, changeLocaleBean.getWindowWidth());

--- a/src/main/java/org/commcare/formplayer/application/FormController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormController.java
@@ -2,7 +2,7 @@ package org.commcare.formplayer.application;
 
 import static org.commcare.formplayer.util.Constants.PART_ANSWER;
 import static org.commcare.formplayer.util.Constants.PART_FILE;
-import static org.commcare.formplayer.util.Constants.SESSION_PREFERRED_LANGUAGE;
+import static org.commcare.formplayer.util.Constants.FORMPLAYER_SESSION_LANGUAGE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -141,7 +141,7 @@ public class FormController extends AbstractBaseController {
                    @CookieValue(name = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken,
                    HttpServletResponse response)
             throws Exception {
-        response.addCookie(new Cookie(SESSION_PREFERRED_LANGUAGE,changeLocaleBean.getLocale()));
+        response.addCookie(new Cookie(FORMPLAYER_SESSION_LANGUAGE, changeLocaleBean.getLocale()));
 
         SerializableFormSession serializableFormSession = formSessionService.getSessionById(
                 changeLocaleBean.getSessionId());

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -1,6 +1,6 @@
 package org.commcare.formplayer.application;
 
-import static org.commcare.formplayer.util.Constants.SESSION_PREFERRED_LANGUAGE;
+import static org.commcare.formplayer.util.Constants.FORMPLAYER_SESSION_LANGUAGE;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.apache.commons.logging.Log;
@@ -167,12 +167,12 @@ public class MenuController extends AbstractBaseController {
     @AppInstall
     public BaseResponseBean navigateSessionWithAuth(@RequestBody SessionNavigationBean sessionNavigationBean,
                         @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-                        @CookieValue(value = SESSION_PREFERRED_LANGUAGE, required = false) String sessionPrefLang,
+                        @CookieValue(value = FORMPLAYER_SESSION_LANGUAGE, required = false) String sessionPrefLang,
                         HttpServletRequest request,
                         HttpServletResponse response) throws Exception {
 
         if (sessionPrefLang == null || !sessionPrefLang.equals(sessionNavigationBean.getLocale())) {
-            response.addCookie(new Cookie(SESSION_PREFERRED_LANGUAGE, sessionNavigationBean.getLocale()));
+            response.addCookie(new Cookie(FORMPLAYER_SESSION_LANGUAGE, sessionNavigationBean.getLocale()));
         }
         String[] selections = sessionNavigationBean.getSelections();
         if (selections == null) {
@@ -186,7 +186,7 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getSelectedValues(),
                 null,
                 storageFactory.getPropertyManager().isFuzzySearchEnabled());
-        BaseResponseBean response = runnerService.advanceSessionWithSelections(
+        BaseResponseBean responseBean = runnerService.advanceSessionWithSelections(
                 menuSession,
                 selections,
                 sessionNavigationBean.getQueryData(),
@@ -194,15 +194,15 @@ public class MenuController extends AbstractBaseController {
                 sessionNavigationBean.getFormSessionId()
         );
 
-        setResponseMetaData(response);
+        setResponseMetaData(responseBean);
 
         SubmitResponseBean formSubmissionResponse = handleAutoFormSubmission(request, sessionNavigationBean,
-                response);
+                responseBean);
         if (formSubmissionResponse != null) {
             return formSubmissionResponse;
         } else {
-            notificationLogger.logNotification(response.getNotification(), request);
-            return setLocationNeeds(response, menuSession);
+            notificationLogger.logNotification(responseBean.getNotification(), request);
+            return setLocationNeeds(responseBean, menuSession);
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -1,5 +1,6 @@
 package org.commcare.formplayer.application;
 
+import static org.commcare.formplayer.util.Constants.SESSION_PREFERRED_LANGUAGE;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.apache.commons.logging.Log;
@@ -36,7 +37,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Controller (API endpoint) containing all session navigation functionality.
@@ -163,8 +166,14 @@ public class MenuController extends AbstractBaseController {
     @UserRestore
     @AppInstall
     public BaseResponseBean navigateSessionWithAuth(@RequestBody SessionNavigationBean sessionNavigationBean,
-            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
-            HttpServletRequest request) throws Exception {
+                        @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+                        @CookieValue(value = SESSION_PREFERRED_LANGUAGE, required = false) String sessionPrefLang,
+                        HttpServletRequest request,
+                        HttpServletResponse response) throws Exception {
+
+        if (sessionPrefLang == null || !sessionPrefLang.equals(sessionNavigationBean.getLocale())) {
+            response.addCookie(new Cookie(SESSION_PREFERRED_LANGUAGE, sessionNavigationBean.getLocale()));
+        }
         String[] selections = sessionNavigationBean.getSelections();
         if (selections == null) {
             selections = new String[0];

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -200,4 +200,6 @@ public class Constants {
     public static final String TOGGLE_INCLUDE_STATE_HASH = "FORMPLAYER_INCLUDE_STATE_HASH";
 
     public static final String AUTHORITY_COMMCARE = "COMMCARE";
+
+    public static final String SESSION_PREFERRED_LANGUAGE = "session_preferred_lang";
 }

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -201,5 +201,5 @@ public class Constants {
 
     public static final String AUTHORITY_COMMCARE = "COMMCARE";
 
-    public static final String SESSION_PREFERRED_LANGUAGE = "session_preferred_lang";
+    public static final String FORMPLAYER_SESSION_LANGUAGE = "formplayer_session_lang";
 }


### PR DESCRIPTION
## Product Description
This PR sets a session cookie to store the user's preferred language for the current session. This cookie is to be used to override the user's favourite language in subsequent HTTP requests, making sure that the chosen language persists throughout the session.
This change also requires changes to the _frontend_, so another PR will be linked to this one.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
