### PR TITLE
Reinstate auto select revert

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -142,11 +142,11 @@ public class MenuSessionFactory {
                 }
 
                 if (currentStep != null && currentStep != NEXT_SCREEN && entityScreen.shouldBeSkipped()) {
-                    if (((EntityScreen)screen).autoSelectEntities(menuSession.getSessionWrapper())) {
-                        screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
-                        continue;
-                    }
+                    menuSession.handleInput(screen, currentStep, needsFullInit, true, false, entityScreenContext);
+                    screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
+                    continue;
                 }
+
                 if (currentStep == null && processedStepsCount != steps.size()) {
                     checkAndLogCaseIDMatchError(steps, processedSteps, neededDatum.getDataId());
                 }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -142,9 +142,10 @@ public class MenuSessionFactory {
                 }
 
                 if (currentStep != null && currentStep != NEXT_SCREEN && entityScreen.shouldBeSkipped()) {
-                    menuSession.handleInput(screen, currentStep, needsFullInit, true, false, entityScreenContext);
-                    screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
-                    continue;
+                    if (((EntityScreen)screen).autoSelectEntities(menuSession.getSessionWrapper())) {
+                        screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
+                        continue;
+                    }
                 }
                 if (currentStep == null && processedStepsCount != steps.size()) {
                     checkAndLogCaseIDMatchError(steps, processedSteps, neededDatum.getDataId());

--- a/src/main/java/org/commcare/formplayer/session/MenuSession.java
+++ b/src/main/java/org/commcare/formplayer/session/MenuSession.java
@@ -184,7 +184,7 @@ public class MenuSession implements HereFunctionHandlerListener {
             if (screen instanceof EntityScreen) {
                 EntityScreen entityScreen = (EntityScreen)screen;
                 boolean autoLaunch = entityScreen.getAutoLaunchAction() != null && allowAutoLaunch;
-                addBreadcrumb = !autoLaunch;
+                addBreadcrumb = !(autoLaunch || entityScreen.shouldBeSkipped());
                 if (input.startsWith("action ") || (autoLaunch) || !inputValidated) {
                     screen.init(sessionWrapper);
                     // auto-launch takes preference over auto-select
@@ -224,11 +224,13 @@ public class MenuSession implements HereFunctionHandlerListener {
              *  current index based selections[] to contain menu ids instead of indexes.
               */
             if (entityScreenContext.isRespectRelevancy()) {
-                if (screen instanceof EntityScreen) {
+                if (screen instanceof EntityScreen && !screen.shouldBeSkipped()) {
                     String breadcrumb = screen.getBreadcrumb(input, sandbox, getSessionWrapper());
                     persistentMenuHelper.addEntitySelection(persistentMenuId, breadcrumb);
+                    persistentMenuHelper.advanceCurrentMenuWithInput(screen, persistentMenuId);
+                } else if (screen instanceof MenuScreen) {
+                    persistentMenuHelper.advanceCurrentMenuWithInput(screen, persistentMenuId);
                 }
-                persistentMenuHelper.advanceCurrentMenuWithInput(screen, persistentMenuId);
             }
             return true;
         } catch (ArrayIndexOutOfBoundsException | NullPointerException e) {

--- a/src/test/java/org/commcare/formplayer/tests/CaseListAutoSelectTests.kt
+++ b/src/test/java/org/commcare/formplayer/tests/CaseListAutoSelectTests.kt
@@ -2,9 +2,11 @@ package org.commcare.formplayer.tests
 
 import org.commcare.formplayer.beans.NewFormResponse
 import org.commcare.formplayer.beans.menus.EntityListResponse
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+
 
 @WebMvcTest
 class CaseListAutoSelectTests : BaseTestClass() {
@@ -28,7 +30,24 @@ class CaseListAutoSelectTests : BaseTestClass() {
     fun testAutoSelection() {
         // We directly go to the form without selecting the case
         val selections = arrayOf("0", "2")
-        sessionNavigate(selections, APP, NewFormResponse::class.java)
+        var response = sessionNavigate(selections, APP, NewFormResponse::class.java)
+
+        // test breadcrumb
+        assertEquals( 3, response.breadcrumbs.size)
+        assertEquals( "Untitled Application", response.breadcrumbs[0])
+        assertEquals( "Case List", response.breadcrumbs[1])
+        assertEquals( "Followup Form 1", response.breadcrumbs[2])
+
+        // test persistent menu
+        val persistentMenu = response.persistentMenu
+        assertEquals(2, persistentMenu.size)
+        assertEquals("Case List", persistentMenu[0].displayText)
+        assertEquals("Case List 1", persistentMenu[1].displayText)
+        val zeroSelectionMenu = persistentMenu[0].commands
+        assertEquals(3, zeroSelectionMenu.size)
+        assertEquals("Registration Form", zeroSelectionMenu[0].displayText)
+        assertEquals("Followup Form", zeroSelectionMenu[1].displayText)
+        assertEquals("Followup Form 1", zeroSelectionMenu[2].displayText)
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -224,6 +224,10 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
         assertEquals("Close", subMenu.get(0).getDisplayText());
         assertEquals(ImmutableList.of("Case Claim", "Follow Up", "Close"),
                 Arrays.stream(formResponse.getBreadcrumbs()).toList());
+        String[] selectedValues = new String[]{"94f8d030-c6f9-49e0-bc3f-5e0cdbf10c18",
+                "0156fa3e-093e-4136-b95c-01b13dae66c7",
+                "0156fa3e-093e-4136-b95c-01b13dae66c8"};
+        checkForSelectedEntitiesInstance(formResponse.getSessionId(), selectedValues);
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseClaimTest.java
@@ -17,6 +17,7 @@ import org.commcare.formplayer.beans.FormEntryResponseBean;
 import org.commcare.formplayer.beans.NewFormResponse;
 import org.commcare.formplayer.beans.menus.CommandListResponseBean;
 import org.commcare.formplayer.beans.menus.EntityListResponse;
+import org.commcare.formplayer.beans.menus.PersistentCommand;
 import org.commcare.formplayer.mocks.FormPlayerPropertyManagerMock;
 import org.commcare.formplayer.utils.MockRequestUtils;
 import org.commcare.formplayer.utils.WithHqUser;
@@ -202,6 +203,13 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
             assertEquals(reponse.getSelections().length, 1);
             assertEquals(reponse.getSelections()[0], "2");
             assertEquals("Close", reponse.getCommands()[0].getDisplayText());
+
+            // Persistent Menu And Breadcrumbs should not contain the auto-selected entities
+            ArrayList<PersistentCommand> subMenu = reponse.getPersistentMenu().get(2).getCommands();
+            assertEquals(1, subMenu.size());
+            assertEquals("Close", subMenu.get(0).getDisplayText()); // directly contains the form instead of entity selection
+            assertEquals(ImmutableList.of("Case Claim", "Follow Up"),
+                    Arrays.stream(reponse.getBreadcrumbs()).toList());
         }
 
         ArrayList<String> updatedSelections = new ArrayList<>(Arrays.asList(reponse.getSelections()));
@@ -211,6 +219,11 @@ public class MultiSelectCaseClaimTest extends BaseTestClass {
                 APP_NAME,
                 null,
                 NewFormResponse.class);
+        ArrayList<PersistentCommand> subMenu = formResponse.getPersistentMenu().get(2).getCommands();
+        assertEquals(1, subMenu.size());
+        assertEquals("Close", subMenu.get(0).getDisplayText());
+        assertEquals(ImmutableList.of("Case Claim", "Follow Up", "Close"),
+                Arrays.stream(formResponse.getBreadcrumbs()).toList());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -241,6 +241,7 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         expectedMenu.add(new PersistentCommand("0", "Case List", "jr://file/commcare/image/m0customicon_en.png", NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
         expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
         assertEquals(expectedMenu, menuResponse.getPersistentMenu());
 
         selections = new String[]{"0"};
@@ -264,6 +265,44 @@ public class MultiSelectCaseListTest extends BaseTestClass {
         PersistentCommand firstSecondMenu = firstMenu.getCommands().get(1);
         String guid = formResponse.getSelections()[2];
         firstSecondMenu.addCommand(new PersistentCommand(guid, "(2) 123, ...", null, NavIconState.ENTITY_SELECT));
+        assertEquals(expectedMenu, formResponse.getPersistentMenu());
+    }
+
+    @Test
+    public void testPersistentMenuWithAutoSelect() throws Exception {
+        ArrayList<PersistentCommand> expectedMenu = new ArrayList<>();
+        expectedMenu.add(new PersistentCommand("0", "Case List", "jr://file/commcare/image/m0customicon_en.png", NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
+        PersistentCommand firstMenu = expectedMenu.get(0);
+        firstMenu.addCommand(new PersistentCommand("0","Registration Form", null, NavIconState.JUMP));
+        firstMenu.addCommand(new PersistentCommand("1","Followup Form", null, NavIconState.JUMP));
+        firstMenu.addCommand(new PersistentCommand("2","Followup Form with AutoSelect Datum", "jr://file/commcare/image/m0f2customicon_en.png", NavIconState.NEXT));
+        firstMenu.addCommand(new PersistentCommand("3","Followup Form with AutoSelect Datum", null, NavIconState.NEXT));
+        String[] selections = new String[]{"0", "2"};
+        NewFormResponse formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
+        assertEquals(expectedMenu, formResponse.getPersistentMenu());
+    }
+
+    @Test
+    public void testPersistentMenuWithAutoAdvance() throws Exception {
+        ArrayList<PersistentCommand> expectedMenu = new ArrayList<>();
+        expectedMenu.add(new PersistentCommand("0", "Case List", "jr://file/commcare/image/m0customicon_en.png", NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("1", "Case List", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("2", "Menu with Auto Submit Form", null, NavIconState.NEXT));
+        expectedMenu.add(new PersistentCommand("3", "Single Form Auto Select", null, NavIconState.NEXT));
+
+        // Auto-Advance in a Auto Select Case List
+        String[] selections = new String[]{"3"};
+        NewFormResponse formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
+        assertEquals(expectedMenu, formResponse.getPersistentMenu());
+
+        FormPlayerPropertyManagerMock.mockAutoAdvanceMenu(storageFactoryMock, false);
+        selections = new String[]{"3", "0"};
+        formResponse = sessionNavigate(selections, APP, NewFormResponse.class);
+        expectedMenu.get(3).addCommand(new PersistentCommand("0", "Followup Form with AutoSelect Datum",
+                "jr://file/commcare/image/m0f2customicon_en.png", NavIconState.JUMP));
         assertEquals(expectedMenu, formResponse.getPersistentMenu());
     }
 }

--- a/src/test/resources/archives/case_claim_with_multi_select/profile.ccpr
+++ b/src/test/resources/archives/case_claim_with_multi_select/profile.ccpr
@@ -72,7 +72,7 @@
 
     <!-- end -->
 
-
+    <property key="cc-persistent-menu" value="yes" force="true"/>
 
     <features>
         <checkoff active="true"/>

--- a/src/test/resources/archives/case_list_auto_select/profile.ccpr
+++ b/src/test/resources/archives/case_list_auto_select/profile.ccpr
@@ -21,6 +21,10 @@
     <property key="jr_openrosa_api" value="1.0" force="true"/>
     
     <property key="heartbeat-url" value="http://localhost:8000/a/shubham/phone/heartbeat/6e7eb8d05a214872b5ed416a1e5fe313/?build_profile_id=" force="true"/>
+
+
+    <property key="cc-persistent-menu" value="yes" force="true"/>
+    <property key="cc-auto-advance-menu" value="yes" force="true"/>
     
 
     <!-- Properties configured on CommCare HQ 1.0 -->

--- a/src/test/resources/archives/case_list_auto_select/suite.xml
+++ b/src/test/resources/archives/case_list_auto_select/suite.xml
@@ -118,9 +118,7 @@
   <entry>
     <form>http://openrosa.org/formdesigner/99F89DA7-E568-4952-9BAF-717263F2C5DD</form>
     <command id="m0-f2">
-      <text>
-        <locale id="forms.m0f1"/>
-      </text>
+      <text>Followup Form 1</text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
     <session>
@@ -148,9 +146,7 @@
     <command id="m0-f2"/>
   </menu>
   <menu id="m1">
-    <text>
-      <locale id="modules.m0"/>
-    </text>
+    <text>Case List 1</text>
     <command id="m0-f3"/>
   </menu>
 </suite>

--- a/src/test/resources/archives/multi_select_case_list/suite.xml
+++ b/src/test/resources/archives/multi_select_case_list/suite.xml
@@ -199,6 +199,11 @@
     <text>Menu with Auto Submit Form</text>
     <command id="m0-auto-submit-form"/>
   </menu>
+  <menu id="single-form-auto-select-menu">
+    <text>Single Form Auto Select</text>
+    <command id="m0-f2"/>
+    <command id="m0-f3" relevant="false()"/>
+  </menu>
   <endpoint id="case_list">
     <argument id="selected_cases" instance-id="selected_cases" instance-src="jr://instance/selected-entities"/>
     <stack>


### PR DESCRIPTION
## Product Description

Alternate implementation for skipping auto-select menu from contextual menus

[Original PR](https://github.com/dimagi/formplayer/pull/1638/files)
[Revert PR](https://github.com/dimagi/formplayer/pull/1642)
[Jira](https://dimagi.atlassian.net/browse/USH-5121)

## Technical Summary

Reverts [original solution](https://github.com/dimagi/formplayer/pull/1638) implemented in favor of a simple check before adding the entity list menu to contextual menus. 

## Safety Assurance

In addition to the unit test, I tested the correspondix fix on staging as per the steps outlined in [this comment](https://dimagi.atlassian.net/browse/USH-5100?focusedCommentId=354489). 

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

PR adds a regression test for the issue that caused the revert. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
None

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
