### PR TITLE
Remove cc-skip-fixtures-after-submit code

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -385,8 +385,7 @@ public class FormSubmissionHelper {
             //Need to do before end of form nav triggers, since the new data might change the
             //validity of the form
 
-            boolean skipFixtures = storageFactory.getPropertyManager().skipFixturesAfterSubmit();
-            restoreFactory.performTimedSync(true, skipFixtures, false);
+            restoreFactory.performTimedSync(true, false);
         }
         return context.success();
     }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -495,7 +495,7 @@ public class MenuSessionRunnerService {
 
             requestScopedTagNameAndValueMap.computeIfPresent(Constants.REQUEST_INCLUDES_AUTOSELECT_TAG, extraTags::put);
             extraTags.put(Constants.MODULE_NAME_TAG, moduleName);
-            restoreFactory.performTimedSync(false, true, false, extraTags);
+            restoreFactory.performTimedSync(false, true, extraTags);
             menuSession.getSessionWrapper().clearVolatiles();
         }
     }

--- a/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/NewFormResponseFactory.java
@@ -66,7 +66,7 @@ public class NewFormResponseFactory {
         }
         // Don't purge when restoring as a case
         boolean shouldPurge = bean.getRestoreAsCaseId() == null;
-        UserSqlSandbox sandbox = restoreFactory.performTimedSync(shouldPurge, false, false);
+        UserSqlSandbox sandbox = restoreFactory.performTimedSync(shouldPurge, false);
 
         storageFactory.configure(bean.getUsername(),
                 bean.getDomain(),

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -197,7 +197,7 @@ public class RestoreFactory {
 
     // This function will only wipe user DBs when they have expired, otherwise will incremental sync
     public UserSqlSandbox performTimedSync() throws SyncRestoreException {
-        return performTimedSync(true, false, false);
+        return performTimedSync(true, false);
     }
     public UserSqlSandbox performTimedSync(boolean shouldPurge, boolean isResponseTo412)
             throws SyncRestoreException {
@@ -273,7 +273,7 @@ public class RestoreFactory {
             return getSqlSandbox();
         } else {
             getSQLiteDB().createDatabaseFolder();
-            return performTimedSync(false, false, false);
+            return performTimedSync(false, false);
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
+++ b/src/main/java/org/commcare/formplayer/util/FormplayerPropertyManager.java
@@ -18,7 +18,6 @@ public class FormplayerPropertyManager extends PropertyManager {
     public static final String POST_FORM_SYNC = "cc-sync-after-form";
     public static final String FUZZY_SEARCH_ENABLED = "cc-fuzzy-search-enabled";
 
-    public static final String SKIP_FIXTURES_AFTER_SUBMIT = "cc-skip-fixtures-after-submit";
     public static final String AUTO_ADVANCE_MENU = "cc-auto-advance-menu";
 
     public static final String INDEX_CASE_SEARCH_RESULTS = "cc-index-case-search-results";
@@ -58,10 +57,6 @@ public class FormplayerPropertyManager extends PropertyManager {
 
     public boolean isFuzzySearchEnabled() {
         return doesPropertyMatch(FUZZY_SEARCH_ENABLED, NO, YES);
-    }
-
-    public boolean skipFixturesAfterSubmit() {
-        return doesPropertyMatch(SKIP_FIXTURES_AFTER_SUBMIT, NO, YES);
     }
 
     public boolean isAutoAdvanceMenu() {

--- a/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
+++ b/src/test/java/org/commcare/formplayer/junit/RestoreFactoryExtension.kt
@@ -110,6 +110,6 @@ class RestoreFactoryExtension(
 
     private fun mockGetRestoreXml() {
         val answer = RestoreFactoryAnswer(restorePath)
-        doAnswer(answer).`when`(restoreFactory).getRestoreXml(anyBoolean())
+        doAnswer(answer).`when`(restoreFactory).getRestoreXml()
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -294,7 +294,7 @@ public class CaseClaimTests extends BaseTestClass {
 
         // When we sync afterwards, include new case and case-claim
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim2.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         CommandListResponseBean commandResponse = sessionNavigateWithQuery(
                 new String[]{"1", "action 1", "0156fa3e-093e-4136-b95c-01b13dae66c6"},
@@ -545,7 +545,7 @@ public class CaseClaimTests extends BaseTestClass {
 
         // When we sync afterwards, include new case and case-claim
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim2.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         NewFormResponse formResponse = sessionNavigateWithQuery(
                 new String[]{"2", "0156fa3e-093e-4136-b95c-01b13dae66c6", "0"},
@@ -727,7 +727,7 @@ public class CaseClaimTests extends BaseTestClass {
         configureQueryMockOwned();
         configureSyncMock();
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim.xml");
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         Hashtable<String, String> inputs = new Hashtable<>();
         inputs.put("name", "Burt");

--- a/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
@@ -157,7 +157,7 @@ public class CaseSearchResultsInStorageTests {
 
             // When we sync afterwards, include new case and case-claim
             RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/caseclaim2.xml");
-            Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+            Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
             CommandListResponseBean response = navigate(
                     new String[]{"1", "action 1", "0156fa3e-093e-4136-b95c-01b13dae66c6"},

--- a/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/MultiSelectCaseListTest.java
@@ -189,7 +189,7 @@ public class MultiSelectCaseListTest extends BaseTestClass {
     @Test
     public void testAutoSelectionWithMultiSelectCaseList_NoCaseSelection() throws Exception {
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer("restores/nocases.xml");
-        doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         // Since there are no cases to select we see the empty case list
         String[] selections = new String[]{"0", "2"};

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -319,16 +319,16 @@ public class RestoreFactoryTest extends BaseTestClass {
     @Test
     public void testChecksForLocationChanges() throws Exception {
         RestoreFactoryAnswer beforeChange = new RestoreFactoryAnswer("restores/location_update1.xml");
-        Mockito.doAnswer(beforeChange).when(restoreFactoryMock).getRestoreXml(false);
+        Mockito.doAnswer(beforeChange).when(restoreFactoryMock).getRestoreXml();
 
-        UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false);
         Assertions.assertFalse(restoreFactoryMock.getHasLocationChanged());
         Assertions.assertEquals("testLocationId1", UserUtils.getUserLocationsByDomain(domain, beforeSandbox));
 
         RestoreFactoryAnswer afterChange = new RestoreFactoryAnswer("restores/location_update2.xml");
-        Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml(false);
+        Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml();
 
-        UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false);
         Assertions.assertTrue(restoreFactoryMock.getHasLocationChanged());
         Assertions.assertEquals("testLocationId2", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
     }
@@ -336,15 +336,15 @@ public class RestoreFactoryTest extends BaseTestClass {
     @Test
     public void testSameLocationsDoesntFlagChange() throws Exception {
         RestoreFactoryAnswer beforeChange = new RestoreFactoryAnswer("restores/location_update3.xml");
-        Mockito.doAnswer(beforeChange).when(restoreFactoryMock).getRestoreXml(false);
+        Mockito.doAnswer(beforeChange).when(restoreFactoryMock).getRestoreXml();
 
-        UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false);
         Assertions.assertEquals("testLocationId1 testLocationId2", UserUtils.getUserLocationsByDomain(domain, beforeSandbox));
 
         RestoreFactoryAnswer afterChange = new RestoreFactoryAnswer("restores/location_update4.xml");
-        Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml(false);
+        Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml();
 
-        UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false);
         Assertions.assertFalse(restoreFactoryMock.getHasLocationChanged());
         Assertions.assertEquals("testLocationId2 testLocationId1", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
     }

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -163,7 +163,7 @@ public class RestoreFactoryTest {
     public void testGetUserRestoreUrl() {
         assertEquals(
                 BASE_URL + "?version=2.0&device_id=WebAppsLogin",
-                restoreFactorySpy.getUserRestoreUrl(false).toString()
+                restoreFactorySpy.getUserRestoreUrl().toString()
         );
     }
 
@@ -176,7 +176,7 @@ public class RestoreFactoryTest {
                         + ".commcarehq.org"
                         +
                         "&as=asUser%40domain1.commcarehq.org",
-                restoreFactorySpy.getUserRestoreUrl(false).toString()
+                restoreFactorySpy.getUserRestoreUrl().toString()
         );
     }
 
@@ -189,7 +189,7 @@ public class RestoreFactoryTest {
                         + "%40domain1.commcarehq.org"
                         +
                         "&as=asUser%2Btest-encoding%40domain1.commcarehq.org",
-                restoreFactorySpy.getUserRestoreUrl(false).toString()
+                restoreFactorySpy.getUserRestoreUrl().toString()
         );
     }
 
@@ -201,7 +201,7 @@ public class RestoreFactoryTest {
                 BASE_URL + "?version=2.0" +
                         "&device_id=WebAppsLogin%2Arestore-dude%2Aas%2AasUser" +
                         "&as=asUser%40restore-domain.commcarehq.org",
-                restoreFactorySpy.getUserRestoreUrl(false).toString()
+                restoreFactorySpy.getUserRestoreUrl().toString()
         );
     }
 
@@ -214,7 +214,7 @@ public class RestoreFactoryTest {
                     BASE_URL + "?version=2.0" +
                             "&device_id=WebAppsLogin" +
                             "&state=ccsh%3A123",
-                    restoreFactorySpy.getUserRestoreUrl(false).toString()
+                    restoreFactorySpy.getUserRestoreUrl().toString()
             );
         }
     }
@@ -226,7 +226,7 @@ public class RestoreFactoryTest {
             assertEquals(
                     BASE_URL + "?version=2.0" +
                             "&device_id=WebAppsLogin",
-                    restoreFactorySpy.getUserRestoreUrl(false).toString()
+                    restoreFactorySpy.getUserRestoreUrl().toString()
             );
         }
     }
@@ -238,7 +238,7 @@ public class RestoreFactoryTest {
             mockUtils.when(() -> CaseDBUtils.computeCaseDbHash(any())).thenReturn("");
             assertEquals(
                     BASE_URL + "?version=2.0&device_id=WebAppsLogin",
-                    restoreFactorySpy.getUserRestoreUrl(false).toString()
+                    restoreFactorySpy.getUserRestoreUrl().toString()
             );
         }
     }

--- a/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
+++ b/src/test/java/org/commcare/formplayer/utils/MockRequestUtils.java
@@ -71,10 +71,10 @@ public class MockRequestUtils {
     public VerifiedMock mockRestore(String restoreFile, int times) {
         Mockito.reset(restoreFactoryMock);
         RestoreFactoryAnswer answer = new RestoreFactoryAnswer(restoreFile);
-        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml(anyBoolean());
+        Mockito.doAnswer(answer).when(restoreFactoryMock).getRestoreXml();
 
         return () -> {
-            verify(restoreFactoryMock, Mockito.times(times)).getRestoreXml(anyBoolean());
+            verify(restoreFactoryMock, Mockito.times(times)).getRestoreXml();
         };
     }
 


### PR DESCRIPTION
This feature is no longer used

## Product Description

The `cc-skip-fixtures-after-submit` feature is no longer used. This removes the code associated with it.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-5376

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
