### PR TITLE
Purge old cases more often

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -273,7 +273,7 @@ public class RestoreFactory {
             return getSqlSandbox();
         } else {
             getSQLiteDB().createDatabaseFolder();
-            return performTimedSync(false, false, false);
+            return performTimedSync(true, false, false);
         }
     }
 

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -64,6 +64,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -316,9 +317,13 @@ public class RestoreFactory {
                 );
                 sandbox.writeSyncToken();
 
-                if (!shouldPurge) {
+                if (!shouldPurge && !oldSandboxLocations.isEmpty()) {
                     String newSandboxLocations = UserUtils.getUserLocationsByDomain(domain, sandbox);
-                    hasLocationChanged = !oldSandboxLocations.isEmpty() && !oldSandboxLocations.equals(newSandboxLocations);
+                    String[] oldArray = oldSandboxLocations.split(" ");
+                    String[] newArray = newSandboxLocations.split(" ");
+                    Arrays.sort(oldArray);
+                    Arrays.sort(newArray);
+                    hasLocationChanged = !Arrays.equals(oldArray, newArray);
                 }
                 return sandbox;
             } catch (InvalidStructureException | SQLiteRuntimeException e) {

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -338,7 +338,7 @@ public class RestoreFactory {
                             break;
                         }
                     }
-                    if (!oldSandboxLocations.equals(newSandboxLocations)) {
+                    if (!oldSandboxLocations.isEmpty() && !oldSandboxLocations.equals(newSandboxLocations)) {
                         hasLocationChanged = true;
                     }
                 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -318,11 +318,7 @@ public class RestoreFactory {
 
                 if (!shouldPurge) {
                     String newSandboxLocations = UserUtils.getUserLocationsByDomain(domain, sandbox);
-                    if (!oldSandboxLocations.isEmpty() && !oldSandboxLocations.equals(newSandboxLocations)) {
-                        hasLocationChanged = true;
-                    } else {
-                        hasLocationChanged = false;
-                    }
+                    hasLocationChanged = !oldSandboxLocations.isEmpty() && !oldSandboxLocations.equals(newSandboxLocations);
                 }
                 return sandbox;
             } catch (InvalidStructureException | SQLiteRuntimeException e) {

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -237,7 +237,6 @@ public class RestoreFactory {
                         null,
                         extraTags
                 );
-                hasLocationChanged = false;
             } catch (InvalidCaseGraphException e) {
                 FormplayerSentry.captureException(e, SentryLevel.WARNING);
                 // if we have not already, do a fresh sync to try and resolve state
@@ -321,6 +320,8 @@ public class RestoreFactory {
                     String newSandboxLocations = UserUtils.getUserLocationsByDomain(domain, sandbox);
                     if (!oldSandboxLocations.isEmpty() && !oldSandboxLocations.equals(newSandboxLocations)) {
                         hasLocationChanged = true;
+                    } else {
+                        hasLocationChanged = false;
                     }
                 }
                 return sandbox;
@@ -372,6 +373,10 @@ public class RestoreFactory {
 
     public SQLiteDB getSQLiteDB() {
         return sqLiteDB;
+    }
+
+    public boolean getHasLocationChanged() {
+        return hasLocationChanged;
     }
 
     public String getWrappedUsername() {

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -332,12 +332,13 @@ public class RestoreFactory {
                     Iterator userIterator = userStorage.iterator();
                     while (userIterator.hasNext()) {
                         User uUser = (User)userIterator.next();
-                        if (uUser.getProperty("commcare_project").equals(domain)) {
+                        String userDomain = uUser.getProperty("commcare_project");
+                        if (userDomain != null && userDomain.equals(domain)) {
                             newSandboxLocations = uUser.getProperty("commcare_location_ids");
                             break;
                         }
                     }
-                    if (!oldSandboxLocations.isEmpty() && !oldSandboxLocations.equals(newSandboxLocations)) {
+                    if (oldSandboxLocations.equals(newSandboxLocations)) {
                         hasLocationChanged = true;
                     }
                 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -338,7 +338,7 @@ public class RestoreFactory {
                             break;
                         }
                     }
-                    if (oldSandboxLocations.equals(newSandboxLocations)) {
+                    if (!oldSandboxLocations.equals(newSandboxLocations)) {
                         hasLocationChanged = true;
                     }
                 }

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -60,6 +60,7 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -300,8 +301,12 @@ public class RestoreFactory {
                 FormplayerTransactionParserFactory factory = new FormplayerTransactionParserFactory(sandbox, true);
                 InputStream restoreStream = getRestoreXml(skipFixtures);
                 if (!shouldPurge) {
+                    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                    restoreStream.transferTo(outputStream);
+                    InputStream streamClone = new ByteArrayInputStream(outputStream.toByteArray());
+
                     // Extracting current location ids
-                    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(getRestoreXml(skipFixtures)));
+                    BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(streamClone));
                     String regex = Pattern.quote("<data key=\"commcare_location_ids\">") + "(.*?)" + Pattern.quote("</data>");
                     Pattern pattern = Pattern.compile(regex);
                     String restoreLocations = "";
@@ -329,6 +334,7 @@ public class RestoreFactory {
                     if (!sandboxLocations.isEmpty() && !sandboxLocations.equals(restoreLocations)) {
                         hasLocationChanged = true;
                     }
+                    restoreStream = new ByteArrayInputStream(outputStream.toByteArray());
                 }
 
                 SimpleTimer parseTimer = new SimpleTimer();

--- a/src/main/java/org/commcare/formplayer/util/UserUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/UserUtils.java
@@ -1,5 +1,11 @@
 package org.commcare.formplayer.util;
 
+import org.commcare.formplayer.sandbox.SqlStorage;
+import org.commcare.formplayer.sandbox.UserSqlSandbox;
+import org.javarosa.core.model.User;
+
+import java.util.Iterator;
+
 /**
  * Utility methods for dealing with users
  */
@@ -25,5 +31,18 @@ public class UserUtils {
         } else {
             return username;
         }
+    }
+
+    public static String getUserLocationsByDomain(String domain, UserSqlSandbox sandbox) {
+        SqlStorage<User> userStorage = sandbox.getUserStorage();
+        Iterator userIterator = userStorage.iterator();
+        while (userIterator.hasNext()) {
+            User uUser = (User)userIterator.next();
+            String userDomain = uUser.getProperty("commcare_project");
+            if (userDomain != null && userDomain.equals(domain)) {
+                return uUser.getProperty("commcare_location_ids");
+            }
+        }
+        return "";
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -322,14 +322,14 @@ public class RestoreFactoryTest extends BaseTestClass {
 
         UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false, false);
         Assertions.assertFalse(restoreFactoryMock.getHasLocationChanged());
-        Assertions.assertEquals("test_location_id1", UserUtils.getUserLocationsByDomain(domain, beforeSandbox));
+        Assertions.assertEquals("testLocationId1", UserUtils.getUserLocationsByDomain(domain, beforeSandbox));
 
         RestoreFactoryAnswer afterChange = new RestoreFactoryAnswer("restores/location_update2.xml");
         Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml(false);
 
         UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false, false);
         Assertions.assertTrue(restoreFactoryMock.getHasLocationChanged());
-        Assertions.assertEquals("test_location_id2", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
+        Assertions.assertEquals("testLocationId2", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
     }
 
     private void validateHeaders(HttpHeaders headers,

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -14,10 +14,14 @@ import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.configuration.CacheConfiguration;
+import org.commcare.formplayer.junit.RestoreFactoryAnswer;
+import org.commcare.formplayer.sandbox.SqlStorage;
+import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.services.RestoreFactory;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.RequestUtils;
 import org.commcare.formplayer.utils.TestContext;
+import org.commcare.formplayer.util.UserUtils;
 import org.commcare.formplayer.utils.WithHqUser;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -51,7 +55,7 @@ import jakarta.servlet.http.HttpServletRequest;
  */
 @WebMvcTest
 @ContextConfiguration(classes = {TestContext.class, CacheConfiguration.class})
-public class RestoreFactoryTest {
+public class RestoreFactoryTest extends BaseTestClass {
 
     private static final String BASE_URL = "http://localhost:8000/a/restore-domain/phone/restore/";
     private String username = "restore-dude";
@@ -309,6 +313,23 @@ public class RestoreFactoryTest {
                 hasEntry("X-OpenRosa-DeviceId", singletonList("WebAppsLogin")),
                 hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
         );
+    }
+
+    @Test
+    public void testChecksForLocationChanges() throws Exception {
+        RestoreFactoryAnswer beforeChange = new RestoreFactoryAnswer("restores/location_update1.xml");
+        Mockito.doAnswer(beforeChange).when(restoreFactoryMock).getRestoreXml(false);
+
+        UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        Assertions.assertFalse(restoreFactoryMock.getHasLocationChanged());
+        Assertions.assertEquals("test_location_id1", UserUtils.getUserLocationsByDomain(domain, beforeSandbox));
+
+        RestoreFactoryAnswer afterChange = new RestoreFactoryAnswer("restores/location_update2.xml");
+        Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml(false);
+
+        UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        Assertions.assertTrue(restoreFactoryMock.getHasLocationChanged());
+        Assertions.assertEquals("test_location_id2", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
     }
 
     private void validateHeaders(HttpHeaders headers,

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -78,6 +78,7 @@ public class RestoreFactoryTest extends BaseTestClass {
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
         Mockito.reset(restoreFactorySpy);
+        Mockito.reset(restoreFactoryMock);
         AuthenticatedRequestBean requestBean = new AuthenticatedRequestBean();
         requestBean.setRestoreAs(asUsername);
         requestBean.setUsername(username);
@@ -330,6 +331,22 @@ public class RestoreFactoryTest extends BaseTestClass {
         UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false, false);
         Assertions.assertTrue(restoreFactoryMock.getHasLocationChanged());
         Assertions.assertEquals("testLocationId2", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
+    }
+
+    @Test
+    public void testSameLocationsDoesntFlagChange() throws Exception {
+        RestoreFactoryAnswer beforeChange = new RestoreFactoryAnswer("restores/location_update3.xml");
+        Mockito.doAnswer(beforeChange).when(restoreFactoryMock).getRestoreXml(false);
+
+        UserSqlSandbox beforeSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        Assertions.assertEquals("testLocationId1 testLocationId2", UserUtils.getUserLocationsByDomain(domain, beforeSandbox));
+
+        RestoreFactoryAnswer afterChange = new RestoreFactoryAnswer("restores/location_update4.xml");
+        Mockito.doAnswer(afterChange).when(restoreFactoryMock).getRestoreXml(false);
+
+        UserSqlSandbox afterSandbox = restoreFactoryMock.performTimedSync(false, false, false);
+        Assertions.assertFalse(restoreFactoryMock.getHasLocationChanged());
+        Assertions.assertEquals("testLocationId2 testLocationId1", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
     }
 
     private void validateHeaders(HttpHeaders headers,

--- a/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
@@ -24,8 +24,8 @@ public class UserUtilsTests {
 
     @Test
     public void testGetUserLocations() {
-        String test_loc_id = "test_location_id";
-        String test_domain = "test_domain";
+        String test_loc_id = "testLocationId";
+        String test_domain = "testDomain";
         User user = new User("test_user", "password_hash", "test_uuid");
         user.setProperty("commcare_location_ids", test_loc_id);
         user.setProperty("commcare_project", test_domain);

--- a/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
@@ -2,7 +2,12 @@ package org.commcare.formplayer.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.commcare.formplayer.sandbox.SqlStorage;
+import org.commcare.formplayer.sandbox.UserSqlSandbox;
+import org.commcare.formplayer.sqlitedb.UserDB;
 import org.commcare.formplayer.util.UserUtils;
+
+import org.javarosa.core.model.User;
 import org.junit.jupiter.api.Test;
 
 public class UserUtilsTests {
@@ -15,5 +20,19 @@ public class UserUtilsTests {
                 UserUtils.getShortUsername("jfk", "us-gov"));
         assertEquals("dedicatedemployee@example.com",
                 UserUtils.getShortUsername("dedicatedemployee@example.com", "example"));
+    }
+
+    @Test
+    public void testGetUserLocations() {
+        String test_loc_id = "test_location_id";
+        String test_domain = "test_domain";
+        User user = new User("test_user", "password_hash", "test_uuid");
+        user.setProperty("commcare_location_ids", test_loc_id);
+        user.setProperty("commcare_project", test_domain);
+
+        UserSqlSandbox sandbox = new UserSqlSandbox(new UserDB("a", "b", null));
+        SqlStorage<User> userStorage = sandbox.getUserStorage();
+        userStorage.write(user);
+        assertEquals(test_loc_id, UserUtils.getUserLocationsByDomain(test_domain, sandbox));
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/UserUtilsTests.java
@@ -24,15 +24,15 @@ public class UserUtilsTests {
 
     @Test
     public void testGetUserLocations() {
-        String test_loc_id = "testLocationId";
-        String test_domain = "testDomain";
+        String testLocationId = "testLocationId";
+        String testDomain = "testDomain";
         User user = new User("test_user", "password_hash", "test_uuid");
-        user.setProperty("commcare_location_ids", test_loc_id);
-        user.setProperty("commcare_project", test_domain);
+        user.setProperty("commcare_location_ids", testLocationId);
+        user.setProperty("commcare_project", testDomain);
 
         UserSqlSandbox sandbox = new UserSqlSandbox(new UserDB("a", "b", null));
         SqlStorage<User> userStorage = sandbox.getUserStorage();
         userStorage.write(user);
-        assertEquals(test_loc_id, UserUtils.getUserLocationsByDomain(test_domain, sandbox));
+        assertEquals(testLocationId, UserUtils.getUserLocationsByDomain(testDomain, sandbox));
     }
 }

--- a/src/test/resources/restores/location_update1.xml
+++ b/src/test/resources/restores/location_update1.xml
@@ -15,8 +15,8 @@
             <data key="commcare_project">restore-domain</data>
             <data key="commcare_last_name"/>
             <data key="commcare_phone_number"/>
-            <data key="commcare_location_id">test_location_id1</data>
-            <data key="commcare_location_ids">test_location_id1</data>
+            <data key="commcare_location_id">testLocationId1</data>
+            <data key="commcare_location_ids">testLocationId1</data>
             <data key="commcare_first_name"/>
         </user_data>
     </Registration>

--- a/src/test/resources/restores/location_update1.xml
+++ b/src/test/resources/restores/location_update1.xml
@@ -1,0 +1,23 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account restore-gal!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>9e5bb063c1264e0fa93f560f481220ae</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>restore-dude</username>
+        <password>
+            sha1$4JSloCqp4bcl$9123edc2ac2fba8b403c7366b8c72806662a188c
+        </password>
+        <uuid>47ef5ea3cc348fb6538702449c855dcd</uuid>
+        <date>2025-01-28</date>
+        <user_data>
+            <data key="test">1</data>
+            <data key="commcare_project">restore-domain</data>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+            <data key="commcare_location_id">test_location_id1</data>
+            <data key="commcare_location_ids">test_location_id1</data>
+            <data key="commcare_first_name"/>
+        </user_data>
+    </Registration>
+</OpenRosaResponse>

--- a/src/test/resources/restores/location_update2.xml
+++ b/src/test/resources/restores/location_update2.xml
@@ -1,0 +1,23 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account restore-gal!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>9e5bb063c1264e0fa93f560f481220af</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>restore-dude</username>
+        <password>
+            sha1$4JSloCqp4bcl$9123edc2ac2fba8b403c7366b8c72806662a188c
+        </password>
+        <uuid>47ef5ea3cc348fb6538702449c855dcd</uuid>
+        <date>2025-01-28</date>
+        <user_data>
+            <data key="test">1</data>
+            <data key="commcare_project">restore-domain</data>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+            <data key="commcare_location_id">test_location_id2</data>
+            <data key="commcare_location_ids">test_location_id2</data>
+            <data key="commcare_first_name"/>
+        </user_data>
+    </Registration>
+</OpenRosaResponse>

--- a/src/test/resources/restores/location_update2.xml
+++ b/src/test/resources/restores/location_update2.xml
@@ -15,8 +15,8 @@
             <data key="commcare_project">restore-domain</data>
             <data key="commcare_last_name"/>
             <data key="commcare_phone_number"/>
-            <data key="commcare_location_id">test_location_id2</data>
-            <data key="commcare_location_ids">test_location_id2</data>
+            <data key="commcare_location_id">testLocationId2</data>
+            <data key="commcare_location_ids">testLocationId2</data>
             <data key="commcare_first_name"/>
         </user_data>
     </Registration>

--- a/src/test/resources/restores/location_update3.xml
+++ b/src/test/resources/restores/location_update3.xml
@@ -1,0 +1,23 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account restore-gal!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>9e5bb063c1264e0fa93f560f481220ae</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>restore-dude</username>
+        <password>
+            sha1$4JSloCqp4bcl$9123edc2ac2fba8b403c7366b8c72806662a188c
+        </password>
+        <uuid>47ef5ea3cc348fb6538702449c855dcd</uuid>
+        <date>2025-01-28</date>
+        <user_data>
+            <data key="test">1</data>
+            <data key="commcare_project">restore-domain</data>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+            <data key="commcare_location_id">testLocationId1</data>
+            <data key="commcare_location_ids">testLocationId1 testLocationId2</data>
+            <data key="commcare_first_name"/>
+        </user_data>
+    </Registration>
+</OpenRosaResponse>

--- a/src/test/resources/restores/location_update4.xml
+++ b/src/test/resources/restores/location_update4.xml
@@ -1,0 +1,23 @@
+<OpenRosaResponse xmlns="http://openrosa.org/http/response">
+    <message nature="ota_restore_success">Successfully restored account restore-gal!</message>
+    <Sync xmlns="http://commcarehq.org/sync">
+        <restore_id>9e5bb063c1264e0fa93f560f481220ae</restore_id>
+    </Sync>
+    <Registration xmlns="http://openrosa.org/user/registration">
+        <username>restore-dude</username>
+        <password>
+            sha1$4JSloCqp4bcl$9123edc2ac2fba8b403c7366b8c72806662a188c
+        </password>
+        <uuid>47ef5ea3cc348fb6538702449c855dcd</uuid>
+        <date>2025-01-28</date>
+        <user_data>
+            <data key="test">1</data>
+            <data key="commcare_project">restore-domain</data>
+            <data key="commcare_last_name"/>
+            <data key="commcare_phone_number"/>
+            <data key="commcare_location_id">testLocationId1</data>
+            <data key="commcare_location_ids">testLocationId2 testLocationId1</data>
+            <data key="commcare_first_name"/>
+        </user_data>
+    </Registration>
+</OpenRosaResponse>


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

Resolves a bug in which users were being shown cases that belonged to locations the user was not assigned to. In the specific reported scenario, users were initially assigned to a parent location (Organization) and then assigned to a child location (Facility) but still being shown all cases belonging to children of the parent location. This turned out to be happening because when a user data sync is triggered every five minutes (or at least five minutes after the last sync - they are currently using both the `cc-skip-fixtures-after-submit` and `cc-sync-after-form` custom properties), `shouldPurge` is always set to false, so even scenarios in which users switched between child locations were also accumulating cases belonging to locations they were previously assigned to. 

All this does it change that value to true to ensure old cases are purged, similar to what happens when you click the manual sync button in the web apps home page (which this specific domain has disabled... for some reason). 

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

[Jira Ticket](https://dimagi.atlassian.net/browse/USH-5143)
Thanks Ethan for inspiring me to have another look at what was going on in formplayer after I've been stuck looking at the fixture syncing side of things for a little while!!

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Tested locally. Should be safe as all it does is increase the scope of the sync to be similar to that of a manual sync. 

I'm not sure what the performance implication of this is, since this is part of a workflow that'll happen at most every 5 minutes, though since this is limited to specifically looking at a user's cases, I think it should be fine. 

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

N/a

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
