### PR TITLE
Simplify default error message

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -268,8 +268,7 @@ public class FormSubmissionHelper {
         } catch (HttpClientErrorException e) {
             return getErrorResponse(
                     context.getHttpRequest(), Constants.SUBMIT_RESPONSE_ERROR,
-                    String.format("Form submission failed with error response: %s, %s, %s",
-                            e.getMessage(), e.getResponseBodyAsString(), e.getResponseHeaders()),
+                    String.format("Form submission failed with error response: %s", e.getResponseBodyAsString()),
                     e);
         } finally {
             // If autoCommit hasn't been reset to `true` by the commit() call then an error occurred

--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -268,7 +268,7 @@ public class FormSubmissionHelper {
         } catch (HttpClientErrorException e) {
             return getErrorResponse(
                     context.getHttpRequest(), Constants.SUBMIT_RESPONSE_ERROR,
-                    String.format("Form submission failed with error response: %s", e.getResponseBodyAsString()),
+                    String.format("Form submission failed with error response: %s", e.getMessage()),
                     e);
         } finally {
             // If autoCommit hasn't been reset to `true` by the commit() call then an error occurred


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
This results in the following difference:

![image](https://github.com/user-attachments/assets/3ef67a71-6109-4afd-ac29-f5964c4aa525)

vs
![image](https://github.com/user-attachments/assets/9e068260-6fd3-4f6c-939b-e56e3c784f16)

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
The first example doesn't seem ideal to display to users. I believe `getResponseBodyAsString` should be sufficient to display the error to the user with enough information to take action or get help. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
This only impacts general errors on form submissions. I would assume that if a typical user comes across an error like this, they would be overwhelmed and potentially not even see the useful part of the message.

The risk is that we return errors with empty messages, in which case it will render like this:
![image](https://github.com/user-attachments/assets/f4786871-a391-4556-9d75-15b8c9b65a05)

Perhaps including the http status code at the very least would be helpful in the event the user receives an empty error message and reports it to us.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
