### PR TITLE
Check that oldSandboxLocations is not null for first time app users

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -317,7 +317,7 @@ public class RestoreFactory {
                 );
                 sandbox.writeSyncToken();
 
-                if (!shouldPurge && !oldSandboxLocations.isEmpty()) {
+                if (!shouldPurge && oldSandboxLocations != null && !oldSandboxLocations.isEmpty()) {
                     String newSandboxLocations = UserUtils.getUserLocationsByDomain(domain, sandbox);
                     String[] oldArray = oldSandboxLocations.split(" ");
                     String[] newArray = newSandboxLocations.split(" ");


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

[Fix for this bug](https://dimagi.atlassian.net/browse/SUPPORT-23193)

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

I put in the condition `!oldSandboxLocations.isEmpty()` mostly so tests can pass but forgot that first time users won't even have that field initialized before calling `parseIntoSandbox` for the first time. This makes sure that that field isn't null. 

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Tested locally. 

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
