### PR TITLE
Add more supported filetypes

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/MediaValidator.kt
+++ b/src/main/java/org/commcare/formplayer/services/MediaValidator.kt
@@ -18,6 +18,12 @@ object MediaValidator {
         "jpeg",
         "png",
         "pdf",
+        "docx",
+        "xlsx",
+        "txt",
+        "html",
+        "rtf",
+        "msg",
         "3gpp",
         "3gp",
         "3ga",
@@ -35,7 +41,7 @@ object MediaValidator {
         "qcp",
         "ogg"
     )
-    private val SUPPORTED_MIME_TYPES = ImmutableList.of("image", "application/pdf", "audio", "video")
+    private val SUPPORTED_MIME_TYPES = ImmutableList.of("image", "application", "text", "msg", "audio", "video")
 
 
     @JvmStatic

--- a/src/test/java/org/commcare/formplayer/tests/MediaCaptureTest.kt
+++ b/src/test/java/org/commcare/formplayer/tests/MediaCaptureTest.kt
@@ -198,9 +198,9 @@ class MediaCaptureTest {
     fun testImageCapture_FileWithInvalidExtensionErrors() {
         val formResponse = startImageCaptureForm()
         val exception = assertThrows<java.lang.Exception> {
-            saveImage(formResponse, "media/invalid_extension.txt", "invalid_extension.txt")
+            saveImage(formResponse, "media/invalid_extension.ttf", "invalid_extension.ttf")
         }
-        val expectedErr = Localization.get("form.attachment.invalid.error", "invalid_extension.txt")
+        val expectedErr = Localization.get("form.attachment.invalid.error", "invalid_extension.ttf")
         assertEquals(
             expectedErr,
             exception.cause!!.message,


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

Allows users to upload a variety of file types (docx, xlsx, txt, rtf, html, msg), without formplayer complaining that they're invalid.

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

[Jira ticket](https://dimagi.atlassian.net/browse/USH-5366)

This is just the formplayer side changes. HQ PR to follow.


## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

Tested locally and on staging


### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
