### PR TITLE
Add Timing for high level Submit Form and Report Long timing to Sentry

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionController.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionController.java
@@ -1,11 +1,15 @@
 package org.commcare.formplayer.application;
 
+import io.sentry.SentryLevel;
+
 import org.commcare.formplayer.annotations.ConfigureStorageFromSession;
 import org.commcare.formplayer.annotations.UserLock;
 import org.commcare.formplayer.annotations.UserRestore;
 import org.commcare.formplayer.beans.SubmitRequestBean;
 import org.commcare.formplayer.beans.SubmitResponseBean;
+import org.commcare.formplayer.services.CategoryTimingHelper;
 import org.commcare.formplayer.util.Constants;
+import org.commcare.formplayer.util.FormplayerSentry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -28,6 +32,9 @@ public class FormSubmissionController extends AbstractBaseController {
     @Autowired
     private FormSubmissionHelper formSubmissionHelper;
 
+    @Autowired
+    private CategoryTimingHelper categoryTimingHelper;
+
     @RequestMapping(value = Constants.URL_SUBMIT_FORM, method = RequestMethod.POST)
     @ResponseBody
     @UserLock
@@ -36,7 +43,18 @@ public class FormSubmissionController extends AbstractBaseController {
     public SubmitResponseBean submitForm(@RequestBody SubmitRequestBean submitRequestBean,
             @CookieValue(name = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken,
             HttpServletRequest request) throws Exception {
-        return formSubmissionHelper.processAndSubmitForm(request, submitRequestBean.getSessionId(), submitRequestBean.getDomain(),
+            CategoryTimingHelper.RecordingTimer timer = categoryTimingHelper.newTimer(Constants.TimingCategories.PROCESS_AND_SUBMIT_FORM, submitRequestBean.getDomain());
+            timer.start();
+            try {
+                return formSubmissionHelper.processAndSubmitForm(request, submitRequestBean.getSessionId(), submitRequestBean.getDomain(),
                 submitRequestBean.isPrevalidated(), submitRequestBean.getAnswers(), submitRequestBean.getWindowWidth());
+            } finally {
+                timer.end().record();
+                int timingThreshold = 5000;
+                if (timer.durationInMs() > timingThreshold) {
+                    Exception e = new Exception("Form submission took longer than " + timingThreshold + "ms");
+                    FormplayerSentry.captureException(e, SentryLevel.WARNING);
+                };
+            }
     }
 }

--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -252,6 +252,8 @@ public class FormSubmissionHelper {
     }
 
     private SubmitResponseBean processFormXml(FormSubmissionContext context) throws Exception {
+        CategoryTimingHelper.RecordingTimer timer = categoryTimingHelper.newTimer(Constants.TimingCategories.PROCESS_FORM_XML);
+        timer.start();
         try {
             restoreFactory.setAutoCommit(false);
             processXmlInner(context);
@@ -284,6 +286,7 @@ public class FormSubmissionHelper {
                 // rollback sets autoCommit back to `true`
                 restoreFactory.rollback();
             }
+            timer.end().record();
         }
         return context.success();
     }

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -163,6 +163,7 @@ public class Constants {
         public static final String FORM_ENTRY = "form_entry";
         public static final String UPDATE_VOLATILITY = "update_volatility";
         public static final String CREATE_FORM_CONTEXT = "create_form_context";
+        public static final String PROCESS_AND_SUBMIT_FORM = "process_and_submit_form";
 
         public static final String GET_SESSION = "get_session";
         public static final String INITIALIZE_SESSION = "initialize_session";

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -164,6 +164,7 @@ public class Constants {
         public static final String UPDATE_VOLATILITY = "update_volatility";
         public static final String CREATE_FORM_CONTEXT = "create_form_context";
         public static final String PROCESS_AND_SUBMIT_FORM = "process_and_submit_form";
+        public static final String PROCESS_FORM_XML = "process_form_xml";
 
         public static final String GET_SESSION = "get_session";
         public static final String INITIALIZE_SESSION = "initialize_session";


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
No user facing changes


## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
Continuation of https://github.com/dimagi/formplayer/pull/1697
[USH-5896](https://dimagi.atlassian.net/browse/USH-5896)

This is to aid in investigating increases to submit-all timings. This PR adds timing to the high level `processAndSubmitForm` function and raises a warning on Sentry if the timing exceeds 5 seconds (typically the threshold for where we consider performance in the unacceptable range). The sentry issue will include breadcrumbs of other subtimings.

These specific timings can most likely be removed once its confirmed to not be large contributors to performance.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
Tested on staging. There is no functional change, only addition of timing.

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
no QA

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [X] This PR can be reverted after deploy with no further considerations.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[USH-5896]: https://dimagi.atlassian.net/browse/USH-5896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ