### PR TITLE
Enable APM by domain

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/DatadogTraceInterceptor.java
+++ b/src/main/java/org/commcare/formplayer/application/DatadogTraceInterceptor.java
@@ -1,0 +1,30 @@
+package org.commcare.formplayer.application;
+
+import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
+import datadog.trace.api.interceptor.TraceInterceptor;
+import datadog.trace.api.interceptor.MutableSpan;
+import java.util.Collection;
+import java.util.Collections;
+
+public class DatadogTraceInterceptor implements TraceInterceptor {
+
+    @Override
+    public Collection<? extends MutableSpan> onTraceComplete(Collection<? extends MutableSpan> trace) {
+        boolean shouldKeepTrace = false;
+        if (!trace.isEmpty()) {
+            MutableSpan firstSpan = trace.iterator().next();
+            MutableSpan localRootSpan = firstSpan.getLocalRootSpan();
+            Object apmEnabledTag = localRootSpan.getTag("feature_flag.apm_enabled");
+            shouldKeepTrace = apmEnabledTag != null && (Boolean) apmEnabledTag;
+            if (shouldKeepTrace) {
+                return trace;
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int priority() {
+        return 100;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -13,6 +13,7 @@ import org.commcare.formplayer.aspects.LockAspect;
 import org.commcare.formplayer.aspects.LoggingAspect;
 import org.commcare.formplayer.aspects.MetricsAspect;
 import org.commcare.formplayer.aspects.SetBrowserValuesAspect;
+import org.commcare.formplayer.aspects.TagTracingDisabledAspect;
 import org.commcare.formplayer.aspects.UserRestoreAspect;
 import org.commcare.formplayer.engine.FormplayerArchiveFileRoot;
 import org.commcare.formplayer.objects.FormVolatilityRecord;
@@ -200,6 +201,11 @@ public class WebAppContext implements WebMvcConfigurer {
     @Bean
     public ConfigureStorageFromSessionAspect configureStorageAspect() {
         return new ConfigureStorageFromSessionAspect();
+    }
+
+    @Bean
+    public TagTracingDisabledAspect tagTracingDisabledAspect() {
+        return new TagTracingDisabledAspect();
     }
 
     @Bean

--- a/src/main/java/org/commcare/formplayer/aspects/TagTracingDisabledAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/TagTracingDisabledAspect.java
@@ -1,0 +1,31 @@
+package org.commcare.formplayer.aspects;
+
+import io.opentracing.Tracer;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.JoinPoint;
+import org.springframework.core.annotation.Order;
+import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
+import datadog.trace.api.interceptor.MutableSpan;
+
+/**
+ * Aspect to tag the tracing disabled flag on the local root span
+ */
+@Aspect
+@Order(8)
+public class TagTracingDisabledAspect {
+
+    @Before(value = "@annotation(org.springframework.web.bind.annotation.RequestMapping)")
+    public void setValues(JoinPoint joinPoint) throws Throwable {
+        final Tracer tracer = GlobalTracer.get();
+        final Span span = tracer.activeSpan(); 
+        boolean isToggleEnabled = FeatureFlagChecker.isToggleEnabled("ACTIVATE_DATADOG_APM_TRACES");
+
+        if (span != null && (span instanceof MutableSpan)) {
+            MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
+            localRootSpan.setTag("feature_flag.apm_enabled", isToggleEnabled);
+        }
+    }
+}

--- a/src/main/java/org/commcare/formplayer/configuration/DatadogConfig.java
+++ b/src/main/java/org/commcare/formplayer/configuration/DatadogConfig.java
@@ -1,0 +1,16 @@
+package org.commcare.formplayer.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.commcare.formplayer.application.DatadogTraceInterceptor;
+import datadog.trace.api.GlobalTracer;
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+public class DatadogConfig {
+
+    @PostConstruct
+    public void initializeDatadogInterceptors() {
+        DatadogTraceInterceptor interceptor = new DatadogTraceInterceptor();
+        GlobalTracer.get().addTraceInterceptor(interceptor);
+    }
+}


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
no user facing change

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
[USH-5218](https://dimagi.atlassian.net/browse/USH-5218)

This change introduces a `DatadogTraceInterceptor` to enable dynamic, per-request toggling of Datadog APM traces based on a `ACTIVATE_DATADOG_APM_TRACES` FF. This is so sampling rate can be changed to 100% for only certain domains.

The primary challenge in implementing this feature was controlling the Datadog Java Agent's trace sampling behavior at a granular, runtime level. I first tried using the active span's sampling priority using `activeSpan.setTag(Tags.SAMPLING_PRIORITY.getKey(), -1)` or `activeSpan.setTag(DDTags.MANUAL_DROP, true)`.

But this was unsuccessful due to the Datadog agent's internal lifecycle. It ran into error `samplingPriority locked at priority: 1. Refusing to set to priority: -1`, which means the agent makes and locks its initial sampling decision (often to keep the trace) very early in the request's processing lifecycle. At the point where the `samplingPriority` was modifiable, the feature flag setting was not yet accessible.

I also considered using`((datadog.opentracing.DDTracer) tracer).close()`. But that's intended for graceful shutdown of the entire tracer instance at application exit, not for per-request trace control. Repeatedly closing and potentially re-initializing the tracer per request would potentially lead to problems.

The chosen solution implements the Datadog `TraceInterceptor` interface (specifically `datadog.trace.TraceInterceptor`). This interceptor is invoked by the Datadog agent *after* a trace has been fully collected but *before* it is sent to the Datadog Agent. This allows us to:

1.  **Access the complete trace:** We can inspect all spans belonging to the trace.
2.  **Access the local root span:** We can retrieve the local root span and check for a custom tag (`feature_flag.apm_enabled`) that is set earlier in the request lifecycle based on the FF.
3.  **Conditionally drop the trace:** If `feature_flag.apm_enabled` is not true, the `onTraceComplete` method returns an empty collection, effectively dropping the entire trace before it consumes any Datadog credits or appears in the APM dashboards. If the flag is true, the original trace is returned, allowing it to be sent.

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
Tested it locally and on staging. 

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->
This PR can be reverted without any user facing effects. However, I imagine we will change `-Ddd.trace.sample.rate` to be 100%. In which case, we will want to revert that was well to not incur exorbitant DD costs.  https://github.com/dimagi/commcare-cloud/blob/1a3c66d5ff72ee6348e06a4553d1f4319ab70b1e/environments/production/app-processes.yml#L10

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.
