### PR TITLE
Inline Case Search Breadcrumb Display Bug Fix

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
@@ -65,6 +65,18 @@ public class CaseSearchHelper {
     private FormplayerStorageFactory storageFactory;
     private final Log log = LogFactory.getLog(CaseSearchHelper.class);
 
+    public IStorageUtilityIndexed<Case> getCaseSearchStorage(ExternalDataInstanceSource source)
+            throws InvalidStructureException {
+        Multimap<String, String> requestData = source.getRequestData();
+        String cacheKey = getCacheKey(source.getSourceUri(), requestData);
+
+        CaseSearchDB caseSearchDb = initCaseSearchDB();
+        String caseSearchTableName = evalCaseSearchTableName(cacheKey);
+        UserSqlSandbox caseSearchSandbox = new CaseSearchSqlSandbox(caseSearchTableName, caseSearchDb);
+        IStorageUtilityIndexed<Case> caseSearchStorage = caseSearchSandbox.getCaseStorage();
+        return caseSearchStorage;
+    }
+
     public AbstractTreeElement getExternalRoot(String instanceId, ExternalDataInstanceSource source,
             boolean skipCache)
             throws UnfullfilledRequirementsException, XmlPullParserException, InvalidStructureException,

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionFactory.java
@@ -184,6 +184,7 @@ public class MenuSessionFactory {
                                 false
                             );
                             queryScreen.updateSession(searchDataInstance);
+                            queryScreen.setCaseSearchStorage(caseSearchHelper.getCaseSearchStorage(searchDataInstance.getSource()));
                             screen = menuSession.getNextScreen(needsFullInit, entityScreenContext);
                             currentStep = NEXT_SCREEN;
                             break;

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -523,6 +523,7 @@ public class MenuSessionRunnerService {
                         queryParams,
                         skipCache);
                 screen.updateSession(searchDataInstance);
+                screen.setCaseSearchStorage(caseSearchHelper.getCaseSearchStorage(searchDataInstance.getSource()));
                 return true;
             } catch (InvalidStructureException | IOException
                      | XmlPullParserException | UnfullfilledRequirementsException e) {

--- a/src/test/java/org/commcare/formplayer/mocks/FormPlayerPropertyManagerMock.java
+++ b/src/test/java/org/commcare/formplayer/mocks/FormPlayerPropertyManagerMock.java
@@ -64,4 +64,12 @@ public class FormPlayerPropertyManagerMock extends FormplayerPropertyManager {
         propertyManagerMock.enableAutoAdvanceMenu(enable);
         when(storageFactoryMock.getPropertyManager()).thenReturn(propertyManagerMock);
     }
+
+    public static void mockIndexCaseSearchResults(FormplayerStorageFactory storageFactoryMock, boolean enable) {
+        SQLiteDB db = storageFactoryMock.getSQLiteDB();
+        FormPlayerPropertyManagerMock propertyManagerMock = new FormPlayerPropertyManagerMock(
+                new SqlStorage(db, Property.class, PropertyManager.STORAGE_KEY));
+        propertyManagerMock.enableIndexCaseSearchResults(enable);
+        when(storageFactoryMock.getPropertyManager()).thenReturn(propertyManagerMock);
+    }
 }

--- a/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
@@ -107,15 +107,7 @@ public class CaseSearchResultsInStorageTests {
         cacheManager.getCache("case_search").clear();
         mockRequest = new MockRequestUtils(webClientMock, restoreFactoryMock);
         FileSystemUtils.deleteRecursively(new File("tmp_dbs"));
-        enableIndexCaseSearchResults();
-    }
-
-    private void enableIndexCaseSearchResults() {
-        SQLiteDB db = storageFactoryMock.getSQLiteDB();
-        FormPlayerPropertyManagerMock propertyManagerMock = new FormPlayerPropertyManagerMock(
-                new SqlStorage(db, Property.class, PropertyManager.STORAGE_KEY));
-        propertyManagerMock.enableIndexCaseSearchResults(true);
-        when(storageFactoryMock.getPropertyManager()).thenReturn(propertyManagerMock);
+        FormPlayerPropertyManagerMock.mockIndexCaseSearchResults(storageFactoryMock, true);
     }
 
     @Test

--- a/src/test/resources/query_responses/case_search_multi_select_response.xml
+++ b/src/test/resources/query_responses/case_search_multi_select_response.xml
@@ -17,4 +17,10 @@
         <last_modified>2017-04-21T14:25:39.125000Z</last_modified>
         <date_opened>2017-04-21</date_opened>
     </case>
+    <case case_id="83f2e030-c6f9-49e0-bc3f-5e0cdbf10c16" case_type="case" owner_id="84c246edf58bfa69e03bdecc39692e1f"
+        status="open">
+        <case_name>The Fellowship of the Ring</case_name>
+        <last_modified>2017-04-21T14:25:39.125000Z</last_modified>
+        <date_opened>2017-04-21</date_opened>
+    </case>
 </results>


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->
[See CC-core PR](https://github.com/dimagi/commcare-core/pull/1488)
## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->
This PR is in coordination with this [commcare-core PR](https://github.com/dimagi/commcare-core/pull/1488)

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->
locally tested. This PR change only creates a getter and setter function.
### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->
No automated test

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->
[QA-7869](https://dimagi.atlassian.net/browse/QA-7869)

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [X] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

This PR is in coordination with the [commcare-core PR](https://github.com/dimagi/commcare-core/pull/1488) so if this is reverted, that one will also need to be reverted.

### Review

- [X] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[QA-7869]: https://dimagi.atlassian.net/browse/QA-7869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ