### PR TITLE
Update boot launcher target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ COPY --from=builder application/application/ ./
 COPY scripts/docker_entrypoint.sh /entrypoint
 RUN chmod +x /entrypoint
 ENTRYPOINT ["/entrypoint"]
-CMD ["java", "org.springframework.boot.loader.JarLauncher"]
+CMD ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## Technical Summary
The Spring Boot launch jar target changed in Spring Boot 3.2, so running the HQ Dev setup doesn't currently work. 

Error running the current container:
```
Attaching to formplayer-1
formplayer-1  | Error: Could not find or load main class org.springframework.boot.loader.JarLauncher
formplayer-1  | Caused by: java.lang.ClassNotFoundException: org.springframework.boot.loader.JarLauncher
formplayer-1 exited with code 1
```

## Safety Assurance

### Safety story
I tested this locally by extending the formplayer file and rebuilding my container, and the service started correctly. 

### Special deploy instructions
The Formplayer docker template will need to be rebuilt if this change is rolled back

### Rollback instructions
The Formplayer docker template will need to be rebuilt if this change is rolled back

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
