### PR TITLE
Set the type to html when exceptions have html msg

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/GlobalDefaultExceptionHandler.java
+++ b/src/main/java/org/commcare/formplayer/application/GlobalDefaultExceptionHandler.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.application;
 
 import org.apache.catalina.connector.ClientAbortException;
+import org.commcare.core.interfaces.WithHtmlMessage;
 import org.commcare.core.process.CommCareInstanceInitializer;
 import org.commcare.formplayer.aspects.LockAspect;
 import org.commcare.formplayer.beans.exceptions.ExceptionResponseBean;
@@ -66,6 +67,9 @@ public class GlobalDefaultExceptionHandler {
             message = "The case sharing settings for your user are incorrect. " +
                     "This user must be in exactly one case sharing group. " +
                     "Please contact your supervisor.";
+        }
+        if (exception instanceof WithHtmlMessage) {
+            return new ExceptionResponseBean(message, request.getRequestURL().toString(), Constants.ERROR_TYPE_HTML);
         }
         return new ExceptionResponseBean(message, request.getRequestURL().toString());
     }

--- a/src/main/java/org/commcare/formplayer/beans/exceptions/ExceptionResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/exceptions/ExceptionResponseBean.java
@@ -11,11 +11,16 @@ public class ExceptionResponseBean extends BaseExceptionResponseBean {
     }
 
     public ExceptionResponseBean(String exception, String url) {
+        this(exception, url, Constants.ERROR_TYPE_TEXT);
+    }
+
+    public ExceptionResponseBean(String exception, String url, String type) {
         this.exception = exception;
         this.url = url;
         this.status = Constants.ERROR_STATUS;
-        this.type = Constants.ERROR_TYPE_TEXT;
+        this.type = type;
     }
+
 
     public ExceptionResponseBean(String exception, String url, Integer statusCode) {
         this.exception = exception;


### PR DESCRIPTION
## Product Description
<!--
Delete this section if the PR does not contain any visible changes.
For non-invisible changes, describe the user-facing effects.
-->

## Technical Summary
<!--
- Provide a link to the ticket or document which prompted this change.
- Describe the rationale and design decisions.
-->

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Migrations
<!-- Delete this section if the PR does not contain any migrations. -->

- [ ] The migrations in this code can be safely applied first independently of the code.

<!-- Please link to any past code changes that are coordinated with this migration -->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [ ] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [ ] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
