### PR TITLE
Update USH-6370 debug logging for new app version

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -184,7 +184,7 @@ public class MenuController extends AbstractBaseController {
 
         String domain = sessionNavigationBean.getDomain();
         if (domain != null && domain.startsWith("co-carecoordination")) {
-            log4Hashes(response);
+            logUSH6370(response);
         }
         setResponseMetaData(response);
 
@@ -198,21 +198,22 @@ public class MenuController extends AbstractBaseController {
         }
     }
 
-    private void log4Hashes(BaseResponseBean response) {
+    private void logUSH6370(BaseResponseBean response) {
 
         if (response instanceof EntityListResponse entityListResponse &&
                 entityListResponse.getEntities().length > 0 &&
                 entityListResponse.getHeaders().length > 0
         ) {
-            int fourHashCount = 0;
+            int blankEntities = 0;
             for (EntityBean entity : entityListResponse.getEntities()) {
                 Object[] data = entity.getData();
-                if (data.length > 0 && data[0] != null && data[0].toString().equals("####")) {
-                    fourHashCount++;
+                // An easy signal for missing data is the first column having only formatting, no data
+                if (data.length > 0 && data[0] != null && data[0].toString().equals("****")) {
+                    blankEntities++;
                 }
             }
-            if (fourHashCount > 0) {
-                log.error("USH-6370 response with " + fourHashCount + " leading #### in first column");
+            if (blankEntities > 0) {
+                log.error("USH-6370 response with " + blankEntities + " leading **** in first column");
             }
         }
     }


### PR DESCRIPTION
## Technical Summary

Updates the [USH-6370](https://dimagi.atlassian.net/browse/USH-6370) diagnostic logging to check for `****` instead of `####`, matching the new app version's rendering of blank data in case search results.

## Safety Assurance

### Safety story

Only changes a diagnostic log check string. No behavior change.

### Automated test coverage

None (logging only)

### QA Plan

None

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.

[USH-6370]: https://dimagi.atlassian.net/browse/USH-6370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ