### PR TITLE
Remove support for dynamic search

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
@@ -27,7 +27,6 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
     private String[] selections;
     private HashMap<String, String> translations;
     private String smartLinkRedirect;
-    private boolean dynamicSearch;
 
     private ArrayList<PersistentCommand> persistentMenu;
 
@@ -61,14 +60,6 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     public void setSmartLinkRedirect(String smartLinkRedirect) {
         this.smartLinkRedirect = smartLinkRedirect;
-    }
-
-    public boolean getDynamicSearch() {
-        return dynamicSearch;
-    }
-
-    public void setDynamicSearch(boolean dynamicSearch) {
-        this.dynamicSearch = dynamicSearch;
     }
 
     public NotificationMessage getNotification() {

--- a/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/QueryResponseBean.java
@@ -109,7 +109,6 @@ public class QueryResponseBean extends MenuBean {
         setTitle(queryScreen.getScreenTitle());
         setDescription(queryScreen.getDescriptionText());
         setQueryKey(queryScreen.getQueryKey());
-        setDynamicSearch(queryScreen.getDynamicSearch());
         setIsSearchOnClear(queryScreen.isSearchOnClear());
     }
 

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -89,32 +88,13 @@ public class CaseClaimTests extends BaseTestClass {
     }
 
     @Test
-    public void testDynamicSearch() throws Exception {
-        configureQueryMock();
-        // Run query with an app with dynamic_search true and verify
-        QueryData queryData = new QueryData();
-        queryData.setForceManualSearch("search_command.m1_results", true);
-        QueryResponseBean queryResponseBean = runQuery(queryData);
-        assertTrue(queryResponseBean.getDynamicSearch());
-
-        // Run query with an app with dynamic_search false and verify
-        queryResponseBean = sessionNavigateWithQuery(new String[]{"1"},
-                "case_claim_eof_navigation",
-                null,
-                QueryResponseBean.class);
-        assertFalse(queryResponseBean.getDynamicSearch());
-    }
-
-    @Test
     public void testSearchOnClear() throws Exception {
         configureQueryMock();
-        // Run query with an app with dynamic_search true and verify
         QueryData queryData = new QueryData();
         queryData.setForceManualSearch("search_command.m1_results", true);
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assertTrue(queryResponseBean.isSearchOnClear());
 
-        // Run query with an app with dynamic_search false and verify
         queryResponseBean = sessionNavigateWithQuery(new String[]{"1"},
                 "case_claim_eof_navigation",
                 null,
@@ -238,7 +218,6 @@ public class CaseClaimTests extends BaseTestClass {
         // forceManualAction true when default Search on should result in query screen
         QueryResponseBean queryResponseBean = runQuery(queryData);
         assert queryResponseBean.getDisplays().length == 5;
-        assertTrue(queryResponseBean.getDynamicSearch());
 
         // test default value
         assert queryResponseBean.getDisplays()[0].getValue().contentEquals("Formplayer");

--- a/src/test/resources/archives/caseclaim/suite.xml
+++ b/src/test/resources/archives/caseclaim/suite.xml
@@ -378,7 +378,7 @@
     <instance id="state" src="jr://fixture/item-list:state"/>
     <instance id="my-search-input" src="jr://instance/search-input/results"/>
     <session>
-      <query url="http://localhost:8000/a/test/phone/search/" template="case" storage-instance="results" default_search="true" dynamic_search="true" search_on_clear="true">
+      <query url="http://localhost:8000/a/test/phone/search/" template="case" storage-instance="results" default_search="true" search_on_clear="true">
         <data ref="'case1'" key="case_type"/>
         <data ref="'case2'" key="case_type"/>
         <data ref="'case3'" key="case_type"/>

--- a/src/test/resources/archives/endpoint/suite.xml
+++ b/src/test/resources/archives/endpoint/suite.xml
@@ -489,7 +489,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="results:inline" src="jr://instance/remote/results:inline"/>
     <session>
-      <query url="http://localhost:8000/a/test-1/phone/search/343af03494944cf4affdf775964eba54/" storage-instance="results:inline" template="case" default_search="true" dynamic_search="false">
+      <query url="http://localhost:8000/a/test-1/phone/search/343af03494944cf4affdf775964eba54/" storage-instance="results:inline" template="case" default_search="true">
         <data key="case_type" ref="'case'"/>
         <prompt key="name">
           <display>
@@ -520,7 +520,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <instance id="results:inline" src="jr://instance/remote/results:inline"/>
     <session>
-      <query url="http://localhost:8000/a/test-1/phone/search/343af03494944cf4affdf775964eba54/" storage-instance="results:inline" template="case" default_search="true" dynamic_search="false">
+      <query url="http://localhost:8000/a/test-1/phone/search/343af03494944cf4affdf775964eba54/" storage-instance="results:inline" template="case" default_search="true">
         <data key="case_type" ref="'case'"/>
         <prompt key="name">
           <display>


### PR DESCRIPTION
## Product Description

Commcare HQ does not set the dynamic search flag anymore. It has been removed in this PR: https://github.com/dimagi/commcare-hq/pull/37634. Formplayer should behave the same way as
if the flag is set to false.

commcare-core PR: https://github.com/dimagi/commcare-core/pull/1537

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6541

## Safety Assurance

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations. HQ code already has been deployed.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
