### PR TITLE
Always user unique cache key

### DIFF
--- a/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
@@ -49,8 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.commcare.formplayer.util.Constants.TOGGLE_CASE_SEARCH_CACHE_KEY;
-
 @CacheConfig(cacheNames = "case_search")
 @Component
 public class CaseSearchHelper {
@@ -121,10 +119,7 @@ public class CaseSearchHelper {
         if (caseSearchStorage.isStorageExists()) {
             // return root as CaseInstanceTreeElement
             InstanceBase instanceBase = new InstanceBase(instanceId);
-            if (FeatureFlagChecker.isToggleEnabled(TOGGLE_CASE_SEARCH_CACHE_KEY)) {
-                return new CaseInstanceTreeElement(instanceBase, caseSearchStorage, caseSearchIndexTable, caseSearchTableName);
-            }
-            return new CaseInstanceTreeElement(instanceBase, caseSearchStorage, caseSearchIndexTable);
+            return new CaseInstanceTreeElement(instanceBase, caseSearchStorage, caseSearchIndexTable, caseSearchTableName);
         }
 
         throw new IOException("No response from server for case search query");

--- a/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
+++ b/src/main/java/org/commcare/formplayer/services/CaseSearchHelper.java
@@ -10,7 +10,6 @@ import org.commcare.cases.model.Case;
 import org.commcare.core.parse.CaseInstanceXmlTransactionParserFactory;
 import org.commcare.core.parse.ParseUtils;
 import org.commcare.formplayer.DbUtils;
-import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
 import org.commcare.formplayer.database.models.FormplayerCaseIndexTable;
 import org.commcare.formplayer.sandbox.CaseSearchSqlSandbox;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -202,7 +202,6 @@ public class Constants {
     public static final String TOGGLE_SESSION_ENDPOINTS = "SESSION_ENDPOINTS";
     public static final String TOGGLE_SPLIT_SCREEN_CASE_SEARCH = "SPLIT_SCREEN_CASE_SEARCH";
     public static final String TOGGLE_INCLUDE_STATE_HASH = "FORMPLAYER_INCLUDE_STATE_HASH";
-    public static final String TOGGLE_CASE_SEARCH_CACHE_KEY = "CASE_SEARCH_CACHE_KEY";
 
     public static final String AUTHORITY_COMMCARE = "COMMCARE";
 }

--- a/src/test/java/org/commcare/formplayer/tests/CaseSearchCacheCollisionTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseSearchCacheCollisionTest.java
@@ -1,16 +1,12 @@
 package org.commcare.formplayer.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.commcare.cases.instance.CaseInstanceTreeElement;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.query.QueryContext;
 import org.commcare.formplayer.sandbox.SqlStorage;
-import org.commcare.formplayer.util.Constants;
-import org.commcare.formplayer.utils.WithHqUser;
-import org.commcare.formplayer.utils.WithHqUserSecurityContextFactory;
 import org.commcare.modern.engine.cases.RecordObjectCache;
 import org.javarosa.core.model.instance.InstanceBase;
 import org.javarosa.core.services.storage.IStorageUtilityIndexed;
@@ -21,9 +17,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.util.HashMap;
-
-import org.commcare.formplayer.utils.HqUserDetails;
 
 /**
  * Reproduces USH-6370: CaseInstanceTreeElement.getStorageCacheName() returns "casedb"

--- a/src/test/java/org/commcare/formplayer/tests/CaseSearchCacheCollisionTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseSearchCacheCollisionTest.java
@@ -55,7 +55,6 @@ public class CaseSearchCacheCollisionTest {
      * This shared cache key is the root cause of USH-6370.
      */
     @Test
-    @WithHqUser(enabledToggles = Constants.TOGGLE_CASE_SEARCH_CACHE_KEY)
     public void testStorageCacheNameCollision() {
         SqlStorage<Case> casedbStorage = new SqlStorage<>(
                 () -> connection, Case.class, "user_casedb");

--- a/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
@@ -13,7 +13,6 @@ import org.commcare.cases.instance.CaseInstanceTreeElement;
 import org.commcare.cases.instance.StorageInstanceTreeElement;
 import org.commcare.cases.model.Case;
 import org.commcare.cases.query.QueryContext;
-import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.utils.*;
 import org.commcare.modern.engine.cases.RecordObjectCache;
 import org.commcare.formplayer.application.MenuController;
@@ -313,11 +312,10 @@ public class CaseSearchResultsInStorageTests {
 
     /**
      * Gap 2: Verifies the full case claim flow (entity list → case selection → claim POST → sync →
-     * storage cleared) with the CASE_SEARCH_CACHE_KEY FF enabled. Ensures the unique cache key
-     * doesn't break any step of the claim workflow.
+     * storage cleared). Ensures the unique cache key doesn't break any step of the claim workflow.
      */
     @Test
-    public void testCaseClaimFlowWithFfOn() throws Exception {
+    public void testCaseClaimFlow() throws Exception {
 
         try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery(
                 "query_responses/case_claim_response.xml")) {

--- a/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseSearchResultsInStorageTests.java
@@ -241,8 +241,7 @@ public class CaseSearchResultsInStorageTests {
      * under the same "casedb" key, causing cross-instance data pollution (USH-6370).
      */
     @Test
-    @WithHqUser(enabledToggles = Constants.TOGGLE_CASE_SEARCH_CACHE_KEY)
-    public void testCaseSearchResultsHaveUniqueStorageCacheNameWithFfOn() throws Exception {
+    public void testCaseSearchResultsHaveUniqueStorageCacheName() throws Exception {
 
         ImmutableMultimap<String, String> requestData = ImmutableMultimap.of(
                 "case_type", "case1",
@@ -268,62 +267,6 @@ public class CaseSearchResultsInStorageTests {
                     "Storage cache name should be prefixed with 'casedb:'");
         }
     }
-
-    @Test
-//    @WithHqUser(enabledToggles = Constants.TOGGLE_CASE_SEARCH_CACHE_KEY)
-    public void testCaseSearchResultsHaveUniqueStorageCacheNameWithFfOff() throws Exception {
-
-        ImmutableMultimap<String, String> requestData = ImmutableMultimap.of(
-                "case_type", "case1",
-                "case_type", "case2",
-                "case_type", "case3",
-                "include_closed", "False");
-
-        try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery(
-                "query_responses/case_claim_response.xml")) {
-            var instance = caseSearchHelper.getRemoteDataInstance(
-                    "results", true,
-                    new java.net.URL("http://localhost:8000/a/test/phone/search/"),
-                    requestData, false);
-
-            var root = instance.getRoot();
-            assertTrue(root instanceof CaseInstanceTreeElement,
-                    "Expected CaseInstanceTreeElement for indexed case search results");
-
-            String cacheName = ((CaseInstanceTreeElement) root).getStorageCacheName();
-            assertEquals(CaseInstanceTreeElement.MODEL_NAME, cacheName,
-                    "Case search results uses plain 'casedb' as storage cache name");
-        }
-    }
-
-
-    @Test
-    public void testCaseSearchResultsStorageCacheNameClashes() throws Exception {
-
-        ImmutableMultimap<String, String> requestData = ImmutableMultimap.of(
-                "case_type", "case1",
-                "case_type", "case2",
-                "case_type", "case3",
-                "include_closed", "False");
-
-        try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery(
-                "query_responses/case_claim_response.xml")) {
-            var instance = caseSearchHelper.getRemoteDataInstance(
-                    "results", true,
-                    new java.net.URL("http://localhost:8000/a/test/phone/search/"),
-                    requestData, false);
-
-            var root = instance.getRoot();
-            assertTrue(root instanceof CaseInstanceTreeElement,
-                    "Expected CaseInstanceTreeElement for indexed case search results");
-
-            String cacheName = ((CaseInstanceTreeElement) root).getStorageCacheName();
-            assertEquals(CaseInstanceTreeElement.MODEL_NAME, cacheName,
-                    "Case search results should use 'casedb' as storage cache name without FF");
-        }
-    }
-
-
 
     /**
      * Functional regression test for USH-6370.
@@ -374,7 +317,6 @@ public class CaseSearchResultsInStorageTests {
      * doesn't break any step of the claim workflow.
      */
     @Test
-    @WithHqUser(enabledToggles = Constants.TOGGLE_CASE_SEARCH_CACHE_KEY)
     public void testCaseClaimFlowWithFfOn() throws Exception {
 
         try (MockRequestUtils.VerifiedMock ignore = mockRequest.mockQuery(
@@ -436,7 +378,6 @@ public class CaseSearchResultsInStorageTests {
      */
     @Test
     @SuppressWarnings("unchecked")
-    @WithHqUser(enabledToggles = Constants.TOGGLE_CASE_SEARCH_CACHE_KEY)
     public void testUniqueStorageKeyPreventsRecordObjectCacheCollision() throws Exception {
         ImmutableMultimap<String, String> requestData = ImmutableMultimap.of(
                 "case_type", "case1",


### PR DESCRIPTION
## Product Description

Remove usage of cache key FF. Defaults to the FF behavior now.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6540

## Safety Assurance

FF has been released in production, enabling it for all projects. This just removes the check.

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage

Yes

### QA Plan

None

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
