### PR TITLE
Limit Dependabot alerts to major version updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,17 @@ updates:
     schedule:
       interval: "daily"
     labels:
-    - product/invisible
-    - dependencies
+      - product/invisible
+      - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
   - package-ecosystem: pip
     directory: "/scripts"
     schedule:
       interval: daily
     labels:
-    - product/invisible
-    - dependencies
+      - product/invisible
+      - dependencies


### PR DESCRIPTION
## Technical Summary

Configures Dependabot to ignore patch and minor semver updates for GitHub Actions dependencies. Only major version updates will trigger Dependabot PRs going forward, reducing noise from low-risk automated PRs.

- Add `ignore` rules to `.github/dependabot.yml` filtering out `version-update:semver-patch` and `version-update:semver-minor`

## Safety Assurance

### Safety story

This only affects Dependabot's PR creation behavior — no application code is changed. Major version updates will still be reported.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.