### PR TITLE
Remove SPLIT_SCREEN_CASE_SEARCH feature flag

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/EntityListResponse.java
@@ -1,11 +1,8 @@
 package org.commcare.formplayer.beans.menus;
 
-import static org.commcare.formplayer.util.Constants.TOGGLE_SPLIT_SCREEN_CASE_SEARCH;
-
 import org.commcare.cases.entity.Entity;
 import org.commcare.core.graph.model.GraphData;
 import org.commcare.core.graph.util.GraphException;
-import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
 import org.commcare.formplayer.util.FormplayerGraphUtil;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.modern.util.Pair;
@@ -126,9 +123,7 @@ public class EntityListResponse extends MenuBean {
             QueryScreen queryScreen = nextScreen.getQueryScreen();
             if (queryScreen != null) {
                 setQueryKey(queryScreen.getQueryKey());
-                if (FeatureFlagChecker.isToggleEnabled(TOGGLE_SPLIT_SCREEN_CASE_SEARCH)) {
-                    queryResponse = new QueryResponseBean(queryScreen);
-                }
+                queryResponse = new QueryResponseBean(queryScreen);
             }
         }
     }

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -200,7 +200,6 @@ public class Constants {
 
     public static final String TOGGLE_DETAILED_TAGGING = "DETAILED_TAGGING";
     public static final String TOGGLE_SESSION_ENDPOINTS = "SESSION_ENDPOINTS";
-    public static final String TOGGLE_SPLIT_SCREEN_CASE_SEARCH = "SPLIT_SCREEN_CASE_SEARCH";
     public static final String TOGGLE_INCLUDE_STATE_HASH = "FORMPLAYER_INCLUDE_STATE_HASH";
 
     public static final String AUTHORITY_COMMCARE = "COMMCARE";

--- a/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/CaseClaimTests.java
@@ -29,9 +29,7 @@ import org.commcare.formplayer.objects.QueryData;
 import org.commcare.formplayer.sandbox.SqlStorage;
 import org.commcare.formplayer.sandbox.UserSqlSandbox;
 import org.commcare.formplayer.utils.FileUtils;
-import org.commcare.formplayer.utils.HqUserDetails;
 import org.commcare.formplayer.utils.MockRequestUtils;
-import org.commcare.formplayer.utils.WithHqUserSecurityContextFactory;
 import org.commcare.suite.model.QueryPrompt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -731,17 +729,8 @@ public class CaseClaimTests extends BaseTestClass {
                 "caseclaim",
                 null,
                 EntityListResponse.class);
-        assertNull(responseBean.getQueryResponse(),
-                "Query response attached to entity response when split screen is disabled");
-        WithHqUserSecurityContextFactory.setSecurityContext(
-                HqUserDetails.builder().enabledToggles(new String[]{"SPLIT_SCREEN_CASE_SEARCH"}).build()
-        );
-        responseBean = sessionNavigateWithQuery(new String[]{"1", "action 1"},
-                "caseclaim",
-                null,
-                EntityListResponse.class);
         assertNotNull(responseBean.getQueryResponse(),
-                "No query response attached to entity response when split screen is enabled");
+                "Query response should always be attached to entity response");
     }
 
     private void configureSyncMock() {


### PR DESCRIPTION
## Product Description

Split screen case search is now the default behavior for case search. So if there is a QueryScreen always include the QueryResponseBean.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6544

## Safety Assurance

The SPLIT_SCREEN_CASE_SEARCH has been rolled into SYNC_SEARCH_CASE_CLAIM for a while. HQ always sets SPLIT_SCREEN_CASE_SEARCH at the moment. So there is no new behavior.

### Safety story
<!--
Describe:
- how you became confident in this change (such as local testing).
- why the change is inherently safe, and/or plans to limit the defect blast radius.

In particular consider how existing data may be impacted by this change.
-->

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan

Sanity checked different case search case lists on staging.

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
