### PR TITLE
Public Webforms authentication and deep-link handling

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/MenuController.java
+++ b/src/main/java/org/commcare/formplayer/application/MenuController.java
@@ -250,7 +250,7 @@ public class MenuController extends AbstractBaseController {
     @UserRestore
     @AppInstall
     public BaseResponseBean navigateToEndpoint(@RequestBody SessionNavigationBean sessionNavigationBean,
-            @CookieValue(Constants.POSTGRES_DJANGO_SESSION_ID) String authToken,
+            @CookieValue(value = Constants.POSTGRES_DJANGO_SESSION_ID, required = false) String authToken,
             HttpServletRequest request) throws Exception {
         // Apps using aggressive syncs are likely to hit a sync whenever using endpoint-based navigation,
         // since they use it to jump between different sandboxes. Turn it off.

--- a/src/main/java/org/commcare/formplayer/application/WebAppContext.java
+++ b/src/main/java/org/commcare/formplayer/application/WebAppContext.java
@@ -12,6 +12,7 @@ import org.commcare.formplayer.aspects.ConfigureStorageFromSessionAspect;
 import org.commcare.formplayer.aspects.LockAspect;
 import org.commcare.formplayer.aspects.LoggingAspect;
 import org.commcare.formplayer.aspects.MetricsAspect;
+import org.commcare.formplayer.aspects.PublicSessionLockAspect;
 import org.commcare.formplayer.aspects.SetBrowserValuesAspect;
 import org.commcare.formplayer.aspects.TagTracingDisabledAspect;
 import org.commcare.formplayer.aspects.UserRestoreAspect;
@@ -196,6 +197,11 @@ public class WebAppContext implements WebMvcConfigurer {
     @Bean
     public AppInstallAspect appInstallAspect() {
         return new AppInstallAspect();
+    }
+
+    @Bean
+    public PublicSessionLockAspect publicSessionLockAspect() {
+        return new PublicSessionLockAspect();
     }
 
     @Bean

--- a/src/main/java/org/commcare/formplayer/aspects/PublicSessionLockAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/PublicSessionLockAspect.java
@@ -1,0 +1,77 @@
+package org.commcare.formplayer.aspects;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.commcare.formplayer.beans.InstallRequestBean;
+import org.commcare.formplayer.beans.SessionNavigationBean;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.util.RequestUtils;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import lombok.extern.java.Log;
+
+/**
+ * Locks a public web apps session to the app and session endpoint that HQ bound its one-time link
+ * to. For a public session, the app id and endpoint id carried in the request are replaced with the
+ * HMAC-authenticated values from HQ's session_details response, so a recipient cannot navigate to
+ * any other app or form (both are otherwise client-supplied).
+ *
+ * Runs before {@link AppInstallAspect}, which keys the sandbox DB off the request's app id, so the
+ * storage factory, the MenuSession build, and endpoint navigation all see the authoritative app
+ * id.
+ */
+@Aspect
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Log
+public class PublicSessionLockAspect {
+
+    @Before(value = "@annotation(org.commcare.formplayer.annotations.AppInstall)")
+    public void lockToPublicApp(JoinPoint joinPoint) {
+        Optional<HqUserDetailsBean> userDetails = RequestUtils.getUserDetails();
+        if (userDetails.isEmpty() || !userDetails.get().isPublicSession()) {
+            return;
+        }
+        HqUserDetailsBean details = userDetails.get();
+        Object[] args = joinPoint.getArgs();
+        if (args.length == 0 || !(args[0] instanceof InstallRequestBean requestBean)) {
+            return;
+        }
+
+        // Fail closed: a public session must carry HQ's authoritative app id. A missing value means
+        // a misconfigured or out-of-date HQ; never fall back to the client-supplied app id.
+        if (!StringUtils.hasText(details.getPublicAppId())) {
+            throw new IllegalStateException(
+                    "Public web apps session is missing an authoritative app id from HQ");
+        }
+        if (!Objects.equals(requestBean.getAppId(), details.getPublicAppId())) {
+            log.warning("Public session request app id did not match the authoritative value; "
+                    + "using the authoritative app id");
+        }
+        requestBean.setAppId(details.getPublicAppId());
+
+        if (requestBean instanceof SessionNavigationBean navigationBean) {
+            if (!StringUtils.hasText(details.getPublicEndpointId())) {
+                throw new IllegalStateException(
+                        "Public web apps session is missing an authoritative endpoint id from HQ");
+            }
+            boolean clientDiffers = !Objects.equals(navigationBean.getEndpointId(),
+                    details.getPublicEndpointId())
+                    || (navigationBean.getEndpointArgs() != null
+                    && !navigationBean.getEndpointArgs().isEmpty());
+            if (clientDiffers) {
+                log.warning("Public session request endpoint/args did not match the authoritative "
+                        + "endpoint; using the authoritative endpoint with no args");
+            }
+            navigationBean.setEndpointId(details.getPublicEndpointId());
+            // Public sessions have an empty restore, so endpoint args (e.g. case ids) cannot
+            // resolve; the designated public endpoint must take no required arguments.
+            navigationBean.setEndpointArgs(null);
+        }
+    }
+}

--- a/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
@@ -5,9 +5,12 @@ import io.opentracing.util.GlobalTracer;
 import io.sentry.Sentry;
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.auth.HqAuth;
+import org.commcare.formplayer.auth.PublicFormSessionAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.beans.SessionRequestBean;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.objects.SerializableFormSession;
+import org.commcare.formplayer.util.RequestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.JoinPoint;
@@ -23,6 +26,7 @@ import org.commcare.formplayer.services.CategoryTimingHelper;
 import org.commcare.formplayer.services.RestoreFactory;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import datadog.trace.api.interceptor.MutableSpan;
 
@@ -115,7 +119,15 @@ public class UserRestoreAspect {
         restoreFactory.getSQLiteDB().closeConnection();
     }
 
-    private HqAuth getHqAuth(String sessionToken) {
+    // Package-private for testing.
+    HqAuth getHqAuth(String sessionToken) {
+        // A public web apps session has no Django sessionid; authenticate its outbound HQ calls
+        // with the public session key instead. Gate this on the HMAC-authenticated `public` field
+        // from HQ's session_details response, never on the client-supplied header.
+        Optional<HqUserDetailsBean> userDetails = RequestUtils.getUserDetails();
+        if (userDetails.isPresent() && userDetails.get().isPublicSession()) {
+            return new PublicFormSessionAuth(userDetails.get().getAuthToken());
+        }
         if (sessionToken != null) {
             return new DjangoAuth(sessionToken);
         }

--- a/src/main/java/org/commcare/formplayer/auth/CommCareSessionAuthFilter.java
+++ b/src/main/java/org/commcare/formplayer/auth/CommCareSessionAuthFilter.java
@@ -38,7 +38,7 @@ public class CommCareSessionAuthFilter extends AbstractPreAuthenticatedProcessin
             boolean hasCookie = Arrays.stream(request.getCookies()).anyMatch(
                     (cookie) -> Constants.POSTGRES_DJANGO_SESSION_ID.equals(cookie.getName())
             );
-            if (!hasCookie) {
+            if (!hasCookie && !isPublicSessionRequest(request)) {
                 return false;
             }
             Authentication currentUser = SecurityContextHolder.getContext().getAuthentication();
@@ -49,9 +49,30 @@ public class CommCareSessionAuthFilter extends AbstractPreAuthenticatedProcessin
 
     @Override
     protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+        if (isPublicSessionRequest(request)) {
+            return new PublicSessionCredential(
+                    getCookieValue(request, Constants.PUBLIC_FORM_SESSION_COOKIE_NAME));
+        }
+        return getCookieValue(request, Constants.POSTGRES_DJANGO_SESSION_ID);
+    }
+
+    /**
+     * A public web apps request is signaled by the {@code CommCare-Public-Session: true} header
+     * (a credential-routing hint, not a trust signal) paired with the
+     * {@code public_form_session_key} cookie carrying the session key.
+     */
+    private static boolean isPublicSessionRequest(HttpServletRequest request) {
+        if (!Constants.PUBLIC_FORM_SESSION_HEADER_VALUE.equals(
+                request.getHeader(Constants.PUBLIC_FORM_SESSION_HEADER))) {
+            return false;
+        }
+        return getCookieValue(request, Constants.PUBLIC_FORM_SESSION_COOKIE_NAME) != null;
+    }
+
+    private static String getCookieValue(HttpServletRequest request, String name) {
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
-                if (Constants.POSTGRES_DJANGO_SESSION_ID.equals(cookie.getName())) {
+                if (name.equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/org/commcare/formplayer/auth/PublicFormSessionAuth.java
+++ b/src/main/java/org/commcare/formplayer/auth/PublicFormSessionAuth.java
@@ -1,0 +1,37 @@
+package org.commcare.formplayer.auth;
+
+import org.commcare.formplayer.util.Constants;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.Assert;
+
+/**
+ * {@link HqAuth} for a public web apps session.
+ *
+ * Emits the credential pair HQ requires to recognize a public session on its receiver/restore
+ * endpoints: the {@code public_form_session_key} cookie carrying the session key together with the
+ * {@code CommCare-Public-Session: true} header.
+ */
+public class PublicFormSessionAuth implements HqAuth {
+
+    private final String sessionKey;
+
+    public PublicFormSessionAuth(String sessionKey) {
+        Assert.hasText(sessionKey, "A public form session key is required");
+        this.sessionKey = sessionKey;
+    }
+
+    @Override
+    public HttpHeaders getAuthHeaders() {
+        return new HttpHeaders() {
+            {
+                add("Cookie", Constants.PUBLIC_FORM_SESSION_COOKIE_NAME + "=" + sessionKey);
+                add(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE);
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "PublicFormSessionAuth";
+    }
+}

--- a/src/main/java/org/commcare/formplayer/auth/PublicSessionCredential.java
+++ b/src/main/java/org/commcare/formplayer/auth/PublicSessionCredential.java
@@ -1,0 +1,15 @@
+package org.commcare.formplayer.auth;
+
+import lombok.Value;
+
+/**
+ * Typed credential for a public web apps session (one-time link).
+ *
+ * Wraps the value of the {@code public_form_session_key} cookie so that the
+ * {@link org.commcare.formplayer.services.HqUserDetailsService} can distinguish a public session
+ * from a regular Django session.
+ */
+@Value
+public class PublicSessionCredential {
+    String sessionKey;
+}

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqPublicSessionKeyBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqPublicSessionKeyBean.java
@@ -1,0 +1,31 @@
+package org.commcare.formplayer.beans.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+
+/**
+ * HMAC-signed body sent to HQ's session_details endpoint for a public web apps session.
+ *
+ * Serializes to {@code {"publicSessionKey": ..., "domain": ...}}. HQ treats a request with a
+ * truthy {@code publicSessionKey} as a public session lookup, in contrast to
+ * {@link HqSessionKeyBean} which sends {@code sessionId}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HqPublicSessionKeyBean implements Serializable {
+    private String publicSessionKey;
+    private String domain;
+
+    public HqPublicSessionKeyBean(String domain, String publicSessionKey) {
+        this.domain = domain;
+        this.publicSessionKey = publicSessionKey;
+    }
+
+    public String getPublicSessionKey() {
+        return publicSessionKey;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
@@ -53,6 +53,12 @@ public class HqUserDetailsBean implements UserDetails {
     }
 
     public boolean isAuthorized(String domain, String username) {
+        if (publicSession) {
+            // Public web apps sessions authenticate via a single-use key that HQ has already
+            // validated and tied to exactly one domain. There is no real HQ account, so the
+            // per-session username is not a meaningful check.
+            return Arrays.asList(domains).contains(domain);
+        }
         return isSuperUser || Arrays.asList(domains).contains(domain) && this.username.equals(
                 username);
     }

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
@@ -35,6 +35,15 @@ public class HqUserDetailsBean implements UserDetails {
     @JsonProperty("public")
     private boolean publicSession;
 
+    // For a public web apps session, HQ returns the authoritative app and session endpoint the
+    // link is bound to. Formplayer uses these instead of the client-supplied values so a public
+    // session cannot navigate to any other app/form. Null for non-public sessions.
+    @JsonProperty("app_build_id")
+    private String publicAppId;
+
+    @JsonProperty("endpoint_id")
+    private String publicEndpointId;
+
     public HqUserDetailsBean() {
     }
 

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.beans.auth;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import org.springframework.security.core.GrantedAuthority;
@@ -28,6 +29,11 @@ public class HqUserDetailsBean implements UserDetails {
     private String domain;
     private String[] enabledToggles;
     private String[] enabledPreviews;
+
+    // HQ marks public web apps sessions with a JSON `public` field. `public` is a reserved word,
+    // so map it to this property. Primitive boolean so missing JSON defaults to false.
+    @JsonProperty("public")
+    private boolean publicSession;
 
     public HqUserDetailsBean() {
     }

--- a/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
+++ b/src/main/java/org/commcare/formplayer/configuration/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.authorization.AuthorityAuthorizationM
 
 import org.commcare.formplayer.auth.CommCareSessionAuthFilter;
 import org.commcare.formplayer.auth.HmacAuthFilter;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.services.FormSessionService;
 import org.commcare.formplayer.services.HqUserDetailsService;
 import org.commcare.formplayer.util.Constants;
@@ -18,6 +19,7 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,7 +32,9 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
 public class WebSecurityConfig {
@@ -63,8 +67,9 @@ public class WebSecurityConfig {
                 .requestMatchers(new AntPathRequestMatcher("/validate_form")).access(
                         getFormValidationAuthManager())
 
-                // full auth required for all other requests
-                .anyRequest().authenticated()
+                // full auth required for all other requests; a public web apps session is
+                // further restricted to its allowlisted routes (default-deny)
+                .anyRequest().access(getPublicSessionAuthManager())
         );
 
         // Configure the authentication manager with a provider that will use the
@@ -113,6 +118,35 @@ public class WebSecurityConfig {
             return hasAuthority(Constants.AUTHORITY_COMMCARE).check(authentication, request);
 
         };
+    }
+
+    /**
+     * @return AuthorizationManager enforcing the public web apps session route allowlist. A public
+     *         session may reach ONLY {@code get_endpoint}, {@code answer}, and {@code submit-all};
+     *         every other route is denied (default-deny.
+     */
+    private AuthorizationManager<RequestAuthorizationContext> getPublicSessionAuthManager() {
+        RequestMatcher allowedForPublicSession = new OrRequestMatcher(
+                new AntPathRequestMatcher("/" + Constants.URL_GET_ENDPOINT),
+                new AntPathRequestMatcher("/" + Constants.URL_ANSWER_QUESTION),
+                new AntPathRequestMatcher("/" + Constants.URL_SUBMIT_FORM));
+        AuthenticatedAuthorizationManager<RequestAuthorizationContext> isAuthed =
+                AuthenticatedAuthorizationManager.authenticated();
+        return (authentication, context) -> {
+            AuthorizationDecision authDecision = isAuthed.check(authentication, context);
+            if (authDecision != null && authDecision.isGranted()
+                    && isPublicSession(authentication.get())
+                    && !allowedForPublicSession.matches(context.getRequest())) {
+                return new AuthorizationDecision(false);
+            }
+            return authDecision;
+        };
+    }
+
+    private boolean isPublicSession(Authentication authentication) {
+        return authentication != null
+                && authentication.getPrincipal() instanceof HqUserDetailsBean bean
+                && bean.isPublicSession();
     }
 
     private HmacAuthFilter getHmacAuthFilter() {

--- a/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
+++ b/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
@@ -1,7 +1,9 @@
 package org.commcare.formplayer.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commcare.formplayer.auth.PublicSessionCredential;
 import org.commcare.formplayer.auth.UserDomainPreAuthPrincipal;
+import org.commcare.formplayer.beans.auth.HqPublicSessionKeyBean;
 import org.commcare.formplayer.beans.auth.HqSessionKeyBean;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
@@ -38,10 +40,23 @@ public class HqUserDetailsService implements AuthenticationUserDetailsService<Pr
     private WebClient webClient;
 
     public HqUserDetailsBean getUserDetails(String domain, String sessionKey) {
+        return requestUserDetails(domain, new HqSessionKeyBean(domain, sessionKey));
+    }
+
+    /**
+     * Look up user details for a public web apps session. Sends the session key as
+     * {@code publicSessionKey} rather than {@code sessionId} so HQ knows to resolves it against
+     * the public form session.
+     */
+    public HqUserDetailsBean getPublicUserDetails(String domain, String publicSessionKey) {
+        return requestUserDetails(domain, new HqPublicSessionKeyBean(domain, publicSessionKey));
+    }
+
+    private HqUserDetailsBean requestUserDetails(String domain, Object requestBody) {
         HttpHeaders headers = new HttpHeaders();
-        String data = null;
+        String data;
         try {
-            data = objectMapper.writeValueAsString(new HqSessionKeyBean(domain, sessionKey));
+            data = objectMapper.writeValueAsString(requestBody);
             headers.set("X-MAC-DIGEST", getHmac(data));
         } catch (Exception e) {
             throw new UserDetailsException(e);
@@ -73,9 +88,14 @@ public class HqUserDetailsService implements AuthenticationUserDetailsService<Pr
     @Override
     public UserDetails loadUserDetails(PreAuthenticatedAuthenticationToken token) throws UsernameNotFoundException {
         final UserDomainPreAuthPrincipal principal = (UserDomainPreAuthPrincipal) token.getPrincipal();
-        final String sessionId = (String) token.getCredentials();
+        final Object credentials = token.getCredentials();
         try {
-            HqUserDetailsBean userDetails = getUserDetails(principal.getDomain(), sessionId);
+            HqUserDetailsBean userDetails;
+            if (credentials instanceof PublicSessionCredential publicCredential) {
+                userDetails = getPublicUserDetails(principal.getDomain(), publicCredential.getSessionKey());
+            } else {
+                userDetails = getUserDetails(principal.getDomain(), (String) credentials);
+            }
             if (!userDetails.isAuthorized(principal.getDomain(), principal.getUsername())) {
                 throw new UsernameNotFoundException("Unable to authenticate user in requested domain");
             }

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -36,6 +36,7 @@ import org.commcare.formplayer.session.MenuSession;
 import org.commcare.formplayer.util.Constants;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.FormplayerHereFunctionHandler;
+import org.commcare.formplayer.util.RequestUtils;
 import org.commcare.formplayer.util.SimpleTimer;
 import org.commcare.formplayer.web.client.WebClient;
 import org.commcare.modern.session.SessionWrapper;
@@ -773,7 +774,10 @@ public class MenuSessionRunnerService {
         public BaseResponseBean advanceSessionWithEndpoint(MenuSession menuSession, String endpointId,
             @Nullable HashMap<String, String> endpointArgs)
             throws Exception {
-        if (!FeatureFlagChecker.isToggleEnabled(TOGGLE_SESSION_ENDPOINTS)) {
+        // A public web apps session is a deep-link into a form itself; we use the underlying
+        // functionality of SESSION_ENDPOINTS without its toggle.
+        if (!FeatureFlagChecker.isToggleEnabled(TOGGLE_SESSION_ENDPOINTS)
+                && !RequestUtils.isPublicSession()) {
             throw new RuntimeException("Linking into applications has been disabled for this project.");
         }
 

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -107,6 +107,13 @@ public class Constants {
     public static final String POSTGRES_DJANGO_SESSION_ID = "sessionid";
     public static final String COMMCARE_USER_SUFFIX = "commcarehq.org";
 
+    // Public web apps sessions (one-time links). Must match HQ's
+    // corehq/apps/app_manager/const.py PUBLIC_FORM_SESSION_* values.
+    public static final String PUBLIC_FORM_SESSION_COOKIE_NAME = "public_form_session_key";
+    public static final String PUBLIC_FORM_SESSION_HEADER = "CommCare-Public-Session";
+    // HQ compares the header against this exact value (case-sensitive).
+    public static final String PUBLIC_FORM_SESSION_HEADER_VALUE = "true";
+
     public static final int USER_LOCK_TIMEOUT = 21;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;

--- a/src/main/java/org/commcare/formplayer/util/RequestUtils.java
+++ b/src/main/java/org/commcare/formplayer/util/RequestUtils.java
@@ -109,6 +109,13 @@ public class RequestUtils {
     }
 
     /**
+     * @return True if the current request is authenticated as a public web apps session.
+     */
+    public static boolean isPublicSession() {
+        return getUserDetails().map(HqUserDetailsBean::isPublicSession).orElse(false);
+    }
+
+    /**
      * @return True if there is request in the context AND the request was authenticated with HMAC
      * auth
      */

--- a/src/test/java/org/commcare/formplayer/aspects/PublicSessionLockAspectTest.java
+++ b/src/test/java/org/commcare/formplayer/aspects/PublicSessionLockAspectTest.java
@@ -1,0 +1,106 @@
+package org.commcare.formplayer.aspects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.aspectj.lang.JoinPoint;
+import org.commcare.formplayer.beans.SessionNavigationBean;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.util.RequestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link PublicSessionLockAspect}: a public web apps session must navigate the
+ * HQ-authoritative app/endpoint, never the client-supplied values.
+ */
+public class PublicSessionLockAspectTest {
+
+    private final PublicSessionLockAspect aspect = new PublicSessionLockAspect();
+
+    private HqUserDetailsBean publicBean(String publicAppId, String publicEndpointId) {
+        HqUserDetailsBean bean = new HqUserDetailsBean("domain", new String[]{"domain"}, "user",
+                false, new String[]{}, new String[]{});
+        bean.setPublicSession(true);
+        bean.setPublicAppId(publicAppId);
+        bean.setPublicEndpointId(publicEndpointId);
+        return bean;
+    }
+
+    private SessionNavigationBean navBean(String appId, String endpointId, HashMap<String, String> args) {
+        SessionNavigationBean bean = new SessionNavigationBean();
+        bean.setAppId(appId);
+        bean.setEndpointId(endpointId);
+        bean.setEndpointArgs(args);
+        return bean;
+    }
+
+    private JoinPoint joinPointFor(Object bean) {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{bean, "token", null});
+        return joinPoint;
+    }
+
+    @Test
+    public void publicSession_overridesClientAppEndpointAndClearsArgs() {
+        HashMap<String, String> args = new HashMap<>();
+        args.put("case_id", "abc");
+        SessionNavigationBean bean = navBean("attacker-app", "attacker-endpoint", args);
+
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails)
+                    .thenReturn(Optional.of(publicBean("real-app", "real-endpoint")));
+            aspect.lockToPublicApp(joinPointFor(bean));
+        }
+
+        assertEquals("real-app", bean.getAppId());
+        assertEquals("real-endpoint", bean.getEndpointId());
+        assertNull(bean.getEndpointArgs());
+    }
+
+    @Test
+    public void nonPublicSession_leavesBeanUntouched() {
+        SessionNavigationBean bean = navBean("client-app", "client-endpoint", null);
+
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            // publicSession defaults to false
+            mocked.when(RequestUtils::getUserDetails)
+                    .thenReturn(Optional.of(new HqUserDetailsBean("domain", "user")));
+            aspect.lockToPublicApp(joinPointFor(bean));
+        }
+
+        assertEquals("client-app", bean.getAppId());
+        assertEquals("client-endpoint", bean.getEndpointId());
+    }
+
+    @Test
+    public void publicSession_missingAuthoritativeApp_failsClosed() {
+        SessionNavigationBean bean = navBean("client-app", "client-endpoint", null);
+        JoinPoint joinPoint = joinPointFor(bean);
+
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails)
+                    .thenReturn(Optional.of(publicBean(null, "real-endpoint")));
+            assertThrows(IllegalStateException.class, () -> aspect.lockToPublicApp(joinPoint));
+        }
+    }
+
+    @Test
+    public void publicSession_missingAuthoritativeEndpoint_failsClosed() {
+        SessionNavigationBean bean = navBean("client-app", "client-endpoint", null);
+        JoinPoint joinPoint = joinPointFor(bean);
+
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails)
+                    .thenReturn(Optional.of(publicBean("real-app", null)));
+            assertThrows(IllegalStateException.class, () -> aspect.lockToPublicApp(joinPoint));
+        }
+    }
+}

--- a/src/test/java/org/commcare/formplayer/aspects/UserRestoreAspectTest.java
+++ b/src/test/java/org/commcare/formplayer/aspects/UserRestoreAspectTest.java
@@ -1,0 +1,89 @@
+package org.commcare.formplayer.aspects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.commcare.formplayer.auth.DjangoAuth;
+import org.commcare.formplayer.auth.HqAuth;
+import org.commcare.formplayer.auth.PublicFormSessionAuth;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.util.RequestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link UserRestoreAspect#getHqAuth} credential selection, in particular the
+ * choice between a Django session and a public web apps session.
+ */
+public class UserRestoreAspectTest {
+
+    private final UserRestoreAspect aspect = new UserRestoreAspect();
+
+    private HqUserDetailsBean bean(boolean isPublicSession, String authToken) {
+        HqUserDetailsBean bean = new HqUserDetailsBean("domain", new String[]{"domain"}, "user",
+                false, new String[]{}, new String[]{});
+        bean.setPublicSession(isPublicSession);
+        bean.setAuthToken(authToken);
+        return bean;
+    }
+
+    @Test
+    public void publicSession_usesPublicFormSessionAuthWithTheSessionKey() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.of(bean(true, "pkey")));
+
+            HqAuth auth = aspect.getHqAuth(null);
+
+            assertTrue(auth instanceof PublicFormSessionAuth);
+            assertEquals("public_form_session_key=pkey", auth.getAuthHeaders().getFirst("Cookie"));
+        }
+    }
+
+    @Test
+    public void publicSession_winsEvenWhenASessionidCookieIsAlsoPresent() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.of(bean(true, "pkey")));
+
+            // Both signals present: the public credential must win, matching inbound selection.
+            HqAuth auth = aspect.getHqAuth("sessionid-value");
+
+            assertTrue(auth instanceof PublicFormSessionAuth);
+        }
+    }
+
+    @Test
+    public void regularSession_usesDjangoAuth() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.of(bean(false, null)));
+
+            HqAuth auth = aspect.getHqAuth("sessionid-value");
+
+            assertTrue(auth instanceof DjangoAuth);
+        }
+    }
+
+    @Test
+    public void noUserDetailsWithSessionToken_usesDjangoAuth() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.empty());
+
+            HqAuth auth = aspect.getHqAuth("sessionid-value");
+
+            assertTrue(auth instanceof DjangoAuth);
+        }
+    }
+
+    @Test
+    public void noUserDetailsNoSessionToken_returnsNull() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.empty());
+
+            // SMS requests have neither a public session nor a sessionid cookie.
+            assertNull(aspect.getHqAuth(null));
+        }
+    }
+}

--- a/src/test/java/org/commcare/formplayer/auth/PublicFormSessionAuthTest.java
+++ b/src/test/java/org/commcare/formplayer/auth/PublicFormSessionAuthTest.java
@@ -1,0 +1,35 @@
+package org.commcare.formplayer.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+public class PublicFormSessionAuthTest {
+
+    @Test
+    public void getAuthHeaders_emitsPublicCookieAndHeaderOnly() {
+        HttpHeaders headers = new PublicFormSessionAuth("session-key-123").getAuthHeaders();
+
+        assertEquals("public_form_session_key=session-key-123", headers.getFirst("Cookie"));
+        assertEquals("true", headers.getFirst("CommCare-Public-Session"));
+
+        // Exactly the two public headers — no Django sessionid/Authorization leaks out.
+        assertEquals(2, headers.size());
+        assertFalse(headers.containsKey("sessionid"));
+        assertFalse(headers.containsKey("Authorization"));
+    }
+
+    @Test
+    public void toString_doesNotLeakTheKey() {
+        assertFalse(new PublicFormSessionAuth("super-secret-key").toString().contains("super-secret-key"));
+    }
+
+    @Test
+    public void constructor_rejectsMissingKey() {
+        assertThrows(IllegalArgumentException.class, () -> new PublicFormSessionAuth(null));
+        assertThrows(IllegalArgumentException.class, () -> new PublicFormSessionAuth(""));
+    }
+}

--- a/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
+++ b/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.auth;
 
 import static org.commcare.formplayer.auth.AuthTestUtils.getMultipartRequestBuilder;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -138,6 +139,40 @@ public class SessionAuthTests {
         this.testEndpoint(builder, status().isOk());
     }
 
+    /**
+     * A public web apps session is confined to its allowlisted routes: any other route is denied
+     * with 403 at the security layer, before the controller runs. (clear_user_data is not on the
+     * allowlist.)
+     */
+    @Test
+    public void testPublicSession_DeniedOnNonAllowlistedRoute() throws Exception {
+        String sessionKey = "public-key-abc";
+        mockValidPublicSessionAuth(sessionKey);
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE)
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, sessionKey));
+        this.testEndpoint(builder, status().isForbidden());
+    }
+
+    /**
+     * A public web apps session is permitted on get_endpoint, answer, and submit-all. No controller
+     * for these is wired in this test, so an allowed request falls through (404) — the point is that
+     * the security layer does NOT deny it with 403.
+     */
+    @Test
+    public void testPublicSession_AllowedOnAllowlistedRoutes() throws Exception {
+        String sessionKey = "public-key-abc";
+        mockValidPublicSessionAuth(sessionKey);
+        for (String path : new String[]{
+                Constants.URL_GET_ENDPOINT, Constants.URL_ANSWER_QUESTION, Constants.URL_SUBMIT_FORM}) {
+            MockHttpServletRequestBuilder builder = getRequestBuilder(path, FULL_AUTH_BODY)
+                    .header(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE)
+                    .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, sessionKey));
+            this.testEndpoint(builder, result -> assertNotEquals(403, result.getResponse().getStatus(),
+                    "Allowlisted route '" + path + "' must not be forbidden for a public session"));
+        }
+    }
+
     @Test
     public void testMultipartEndpointWithFullAuth_WithAnyHmacAuth_Succeeds() throws Exception {
         String sessionId = "123";
@@ -156,11 +191,20 @@ public class SessionAuthTests {
         );
     }
 
+    // Returns a non-public bean on purpose: these tests isolate the auth filter's credential
+    // routing from the route allowlist (which only restricts sessions whose bean is public).
     private void mockValidPublicAuth(String sessionKey) {
         PublicTokenMatcher matcher = new PublicTokenMatcher(DOMAIN, USERNAME, sessionKey);
         when(userDetailsService.loadUserDetails(argThat(matcher))).thenReturn(
                 new HqUserDetailsBean(DOMAIN, USERNAME)
         );
+    }
+
+    private void mockValidPublicSessionAuth(String sessionKey) {
+        PublicTokenMatcher matcher = new PublicTokenMatcher(DOMAIN, USERNAME, sessionKey);
+        HqUserDetailsBean bean = new HqUserDetailsBean(DOMAIN, USERNAME);
+        bean.setPublicSession(true);
+        when(userDetailsService.loadUserDetails(argThat(matcher))).thenReturn(bean);
     }
 
     private void testEndpoint(MockHttpServletRequestBuilder requestBuilder,
@@ -177,7 +221,11 @@ public class SessionAuthTests {
      * Use the 'clear_user_data' endpoint for 'full auth' which required user details.
      */
     private MockHttpServletRequestBuilder getRequestBuilder(String body) {
-        return post(String.format("/%s", Constants.URL_CLEAR_USER_DATA))
+        return getRequestBuilder(Constants.URL_CLEAR_USER_DATA, body);
+    }
+
+    private MockHttpServletRequestBuilder getRequestBuilder(String path, String body) {
+        return post(String.format("/%s", path))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(body)
                 .with(SecurityMockMvcRequestPostProcessors.csrf());

--- a/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
+++ b/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
@@ -97,6 +97,47 @@ public class SessionAuthTests {
         this.testEndpoint(builder, status().isOk());
     }
 
+    /**
+     * A public web apps request (public header + public cookie, no session cookie) authenticates
+     * via a {@link PublicSessionCredential} carrying the public_form_session_key.
+     */
+    @Test
+    public void testEndpoint_WithPublicSession_Succeeds() throws Exception {
+        String sessionKey = "public-key-abc";
+        mockValidPublicAuth(sessionKey);
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE)
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, sessionKey));
+        this.testEndpoint(builder, status().isOk());
+    }
+
+    /**
+     * The public header is only honored when its value is exactly "true". A different value with no
+     * session cookie is not a recognized session and must not authenticate.
+     */
+    @Test
+    public void testEndpoint_PublicHeaderWrongValue_NoSessionCookie_Fails() throws Exception {
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, "false")
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, "public-key-abc"));
+        this.testEndpoint(builder, status().isForbidden());
+    }
+
+    /**
+     * When both signals are present, the explicit public header routes to the public credential
+     * rather than the Django session cookie.
+     */
+    @Test
+    public void testEndpoint_PublicHeaderAndSessionCookie_PrefersPublicCredential() throws Exception {
+        String sessionKey = "public-key-abc";
+        mockValidPublicAuth(sessionKey);
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE)
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, sessionKey))
+                .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "123"));
+        this.testEndpoint(builder, status().isOk());
+    }
+
     @Test
     public void testMultipartEndpointWithFullAuth_WithAnyHmacAuth_Succeeds() throws Exception {
         String sessionId = "123";
@@ -110,6 +151,13 @@ public class SessionAuthTests {
 
     private void mockValidAuth(String sessionId) {
         TokenMatcher matcher = new TokenMatcher(DOMAIN, USERNAME, sessionId);
+        when(userDetailsService.loadUserDetails(argThat(matcher))).thenReturn(
+                new HqUserDetailsBean(DOMAIN, USERNAME)
+        );
+    }
+
+    private void mockValidPublicAuth(String sessionKey) {
+        PublicTokenMatcher matcher = new PublicTokenMatcher(DOMAIN, USERNAME, sessionKey);
         when(userDetailsService.loadUserDetails(argThat(matcher))).thenReturn(
                 new HqUserDetailsBean(DOMAIN, USERNAME)
         );
@@ -154,6 +202,32 @@ public class SessionAuthTests {
             return principal.getDomain().equals(this.domain)
                     && principal.getUsername().equals(this.username)
                     && sessionId.equals(this.sessionId);
+        }
+    }
+
+    private class PublicTokenMatcher implements ArgumentMatcher<PreAuthenticatedAuthenticationToken> {
+        private String domain;
+        private String username;
+        private String sessionKey;
+
+        public PublicTokenMatcher(String domain, String username, String sessionKey) {
+            this.domain = domain;
+            this.username = username;
+            this.sessionKey = sessionKey;
+        }
+
+        @Override
+        public boolean matches(PreAuthenticatedAuthenticationToken token) {
+            if (token == null) {
+                return false;
+            }
+            final UserDomainPreAuthPrincipal principal =
+                    (UserDomainPreAuthPrincipal)token.getPrincipal();
+            final Object credentials = token.getCredentials();
+            return credentials instanceof PublicSessionCredential
+                    && ((PublicSessionCredential)credentials).getSessionKey().equals(this.sessionKey)
+                    && principal.getDomain().equals(this.domain)
+                    && principal.getUsername().equals(this.username);
         }
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
+++ b/src/test/java/org/commcare/formplayer/tests/BaseTestClass.java
@@ -122,6 +122,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -841,6 +842,14 @@ public class BaseTestClass {
             String endpointId,
             HashMap<String, String> endpointArgs,
             Class<T> clazz) throws Exception {
+        return sessionNavigateWithEndpoint(testName, endpointId, endpointArgs, true, clazz);
+    }
+
+    <T> T sessionNavigateWithEndpoint(String testName,
+            String endpointId,
+            HashMap<String, String> endpointArgs,
+            boolean withAuthCookie,
+            Class<T> clazz) throws Exception {
         SessionNavigationBean sessionNavigationBean = new SessionNavigationBean();
         sessionNavigationBean.setEndpointId(endpointId);
         if (endpointArgs != null) {
@@ -854,6 +863,7 @@ public class BaseTestClass {
                 RequestType.POST,
                 Constants.URL_GET_ENDPOINT,
                 sessionNavigationBean,
+                withAuthCookie,
                 clazz);
     }
 
@@ -947,6 +957,19 @@ public class BaseTestClass {
         );
     }
 
+    private <T> T generateMockQueryWithInstallReference(String installReference,
+            ControllerType controllerType,
+            RequestType requestType,
+            String urlPath,
+            Object bean,
+            boolean withAuthCookie,
+            Class<T> clazz) throws Exception {
+        return Installer.mockInstallReference(
+                () -> generateMockQuery(controllerType, requestType, urlPath, bean, null, withAuthCookie, clazz),
+                installReference
+        );
+    }
+
     private <T> T generateMockQuery(ControllerType controllerType,
             RequestType requestType,
             String urlPath,
@@ -960,6 +983,16 @@ public class BaseTestClass {
             String urlPath,
             Object bean,
             MockMultipartFile file,
+            Class<T> clazz) throws Exception {
+        return generateMockQuery(controllerType, requestType, urlPath, bean, file, true, clazz);
+    }
+
+    private <T> T generateMockQuery(ControllerType controllerType,
+            RequestType requestType,
+            String urlPath,
+            Object bean,
+            MockMultipartFile file,
+            boolean withAuthCookie,
             Class<T> clazz) throws Exception {
         MockMvc controller = null;
         ResultActions result = null;
@@ -1000,21 +1033,27 @@ public class BaseTestClass {
                 break;
         }
         switch (requestType) {
-            case POST:
-                result = controller.perform(
-                        post(urlPrepend(urlPath))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
-                                .content((String)bean));
+            case POST: {
+                MockHttpServletRequestBuilder builder = post(urlPrepend(urlPath))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content((String)bean);
+                if (withAuthCookie) {
+                    builder.cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"));
+                }
+                result = controller.perform(builder);
                 break;
+            }
 
-            case GET:
-                result = controller.perform(
-                        get(urlPrepend(urlPath))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"))
-                                .content((String)bean));
+            case GET: {
+                MockHttpServletRequestBuilder builder = get(urlPrepend(urlPath))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content((String)bean);
+                if (withAuthCookie) {
+                    builder.cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "derp"));
+                }
+                result = controller.perform(builder);
                 break;
+            }
         }
         restoreFactoryMock.getSQLiteDB().closeConnection();
         storageFactoryMock.getSQLiteDB().closeConnection();

--- a/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
@@ -140,6 +140,23 @@ public class EndpointLaunchTest extends BaseTestClass {
                         "f04bf0e8-2001-4885-a724-5497b34abe95"});
     }
 
+    /**
+     * A public web apps session carries the public_form_session_key cookie, not the Django
+     * sessionid. Exercises the get_endpoint deep-link with NO sessionid cookie: it must reach the
+     * handler and navigate.
+     */
+    @Test
+    @WithHqUser(enabledToggles = {TOGGLE_SESSION_ENDPOINTS})
+    public void testEndpointLaunchWithoutSessionCookie() throws Exception {
+        NewFormResponse formResponse = sessionNavigateWithEndpoint(APP_NAME,
+                "add_parent",
+                null,
+                false,
+                NewFormResponse.class);
+        assert formResponse.getTitle().contentEquals("Add Parent");
+        assertArrayEquals(formResponse.getSelections(), new String[]{"0", "0"});
+    }
+
     @Test
     @WithHqUser(enabledToggles = {TOGGLE_SESSION_ENDPOINTS})
     public void testEndpointsWithInlineCaseSearch() throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/EndpointLaunchTest.java
@@ -157,6 +157,23 @@ public class EndpointLaunchTest extends BaseTestClass {
         assertArrayEquals(formResponse.getSelections(), new String[]{"0", "0"});
     }
 
+    /**
+     * A public web apps session must be able to launch its endpoint even when the domain does not
+     * have the SESSION_ENDPOINTS toggle enabled. No sessionid cookie, matching a real public
+     * session. The toggle-off + non-public case still throws, per testToggleOff.
+     */
+    @Test
+    @WithHqUser(enabledToggles = {}, publicSession = true)
+    public void testEndpointLaunchForPublicSessionWithoutToggle() throws Exception {
+        NewFormResponse formResponse = sessionNavigateWithEndpoint(APP_NAME,
+                "add_parent",
+                null,
+                false,
+                NewFormResponse.class);
+        assert formResponse.getTitle().contentEquals("Add Parent");
+        assertArrayEquals(formResponse.getSelections(), new String[]{"0", "0"});
+    }
+
     @Test
     @WithHqUser(enabledToggles = {TOGGLE_SESSION_ENDPOINTS})
     public void testEndpointsWithInlineCaseSearch() throws Exception {

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -141,6 +141,7 @@ public class HqUserDetailsServiceTests {
 
         assertThat(details.getUsername()).isEqualTo("public@domain");
         assertThat(details.getDomains()).isEqualTo(new String[]{"domain"});
+        assertThat(details.isPublicSession()).isTrue();
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.commcare.formplayer.auth.PublicSessionCredential;
+import org.commcare.formplayer.auth.UserDomainPreAuthPrincipal;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
 import org.commcare.formplayer.repo.FormDefinitionRepo;
@@ -32,6 +34,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -113,5 +117,54 @@ public class HqUserDetailsServiceTests {
         assertThrows(SessionAuthUnavailableException.class, () -> {
             this.service.getUserDetails("domain", "invalid");
         });
+    }
+
+    @Test
+    public void whenCallingGetPublicUserDetails_thenClientSendsPublicSessionKey()
+            throws Exception {
+        String detailsString = "{" +
+                "\"domains\":[\"domain\"]," +
+                "\"djangoUserId\":null," +
+                "\"username\":\"public@domain\"," +
+                "\"authToken\":\"pub-key\"," +
+                "\"superUser\":false," +
+                "\"public\":true" +
+                "}";
+
+        this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
+                .andExpect(jsonPath("$.publicSessionKey").value("pub-key"))
+                .andExpect(jsonPath("$.sessionId").doesNotExist())
+                .andExpect(jsonPath("$.domain").value("domain"))
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+
+        HqUserDetailsBean details = this.service.getPublicUserDetails("domain", "pub-key");
+
+        assertThat(details.getUsername()).isEqualTo("public@domain");
+        assertThat(details.getDomains()).isEqualTo(new String[]{"domain"});
+    }
+
+    @Test
+    public void loadUserDetails_withPublicCredential_routesToPublicSessionKey()
+            throws Exception {
+        String detailsString = "{" +
+                "\"domains\":[\"domain\"]," +
+                "\"djangoUserId\":null," +
+                "\"username\":\"citrus\"," +
+                "\"authToken\":\"pub-key\"," +
+                "\"superUser\":false," +
+                "\"public\":true" +
+                "}";
+
+        this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
+                .andExpect(jsonPath("$.publicSessionKey").value("pub-key"))
+                .andExpect(jsonPath("$.sessionId").doesNotExist())
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+
+        UserDomainPreAuthPrincipal principal = new UserDomainPreAuthPrincipal("citrus", "domain");
+        PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, new PublicSessionCredential("pub-key"));
+
+        UserDetails details = this.service.loadUserDetails(token);
+        assertThat(details.getUsername()).isEqualTo("citrus");
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -74,7 +74,7 @@ public class HqUserDetailsTests {
         // authoritative app id and session endpoint the link is bound to.
         HqUserDetailsBean publicUser = mapper.readValue(
                 "{\"username\":\"pub\",\"public\":true,"
-                        + "\"commcare_app_id\":\"app-1\",\"endpoint_id\":\"ep-1\"}",
+                        + "\"app_build_id\":\"app-1\",\"endpoint_id\":\"ep-1\"}",
                 HqUserDetailsBean.class);
         Assertions.assertTrue(publicUser.isPublicSession());
         Assertions.assertEquals("app-1", publicUser.getPublicAppId());

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -70,19 +70,27 @@ public class HqUserDetailsTests {
     public void testPublicSessionDeserialization() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
-        // HQ sends the reserved word `public` for a public web apps session.
+        // HQ sends the reserved word `public` for a public web apps session, along with the
+        // authoritative app id and session endpoint the link is bound to.
         HqUserDetailsBean publicUser = mapper.readValue(
-                "{\"username\":\"pub\",\"public\":true}", HqUserDetailsBean.class);
+                "{\"username\":\"pub\",\"public\":true,"
+                        + "\"commcare_app_id\":\"app-1\",\"endpoint_id\":\"ep-1\"}",
+                HqUserDetailsBean.class);
         Assertions.assertTrue(publicUser.isPublicSession());
+        Assertions.assertEquals("app-1", publicUser.getPublicAppId());
+        Assertions.assertEquals("ep-1", publicUser.getPublicEndpointId());
 
         HqUserDetailsBean regularUser = mapper.readValue(
                 "{\"username\":\"reg\",\"public\":false}", HqUserDetailsBean.class);
         Assertions.assertFalse(regularUser.isPublicSession());
 
         // Absent `public` defaults to false (primitive boolean; the bean also ignores unknowns).
+        // The app/endpoint fields are reference types, so they default to null.
         HqUserDetailsBean noField = mapper.readValue(
                 "{\"username\":\"reg\"}", HqUserDetailsBean.class);
         Assertions.assertFalse(noField.isPublicSession());
+        Assertions.assertNull(noField.getPublicAppId());
+        Assertions.assertNull(noField.getPublicEndpointId());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.tests;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.utils.HqUserDetails;
@@ -35,6 +37,25 @@ public class HqUserDetailsTests {
         Assertions.assertTrue(user.isAuthorized("domain", "bilbo"));
         Assertions.assertFalse(user.isAuthorized("wrong-domain", "bilbo"));
         Assertions.assertFalse(user.isAuthorized("domain", "wrong-bilbo"));
+    }
+
+    @Test
+    public void testPublicSessionDeserialization() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // HQ sends the reserved word `public` for a public web apps session.
+        HqUserDetailsBean publicUser = mapper.readValue(
+                "{\"username\":\"pub\",\"public\":true}", HqUserDetailsBean.class);
+        Assertions.assertTrue(publicUser.isPublicSession());
+
+        HqUserDetailsBean regularUser = mapper.readValue(
+                "{\"username\":\"reg\",\"public\":false}", HqUserDetailsBean.class);
+        Assertions.assertFalse(regularUser.isPublicSession());
+
+        // Absent `public` defaults to false (primitive boolean; the bean also ignores unknowns).
+        HqUserDetailsBean noField = mapper.readValue(
+                "{\"username\":\"reg\"}", HqUserDetailsBean.class);
+        Assertions.assertFalse(noField.isPublicSession());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -40,6 +40,33 @@ public class HqUserDetailsTests {
     }
 
     @Test
+    public void testPublicSessionIsAuthorized() {
+        HqUserDetailsBean publicUser = new HqUserDetailsBean("domain",
+                new String[]{"domain"}, "public_abc123@domain.commcarehq.org",
+                false, new String[]{}, new String[]{});
+        publicUser.setPublicSession(true);
+
+        // Synthetic username is not checked for a public session...
+        Assertions.assertTrue(publicUser.isAuthorized("domain", "public_abc123@domain.commcarehq.org"));
+        Assertions.assertTrue(publicUser.isAuthorized("domain", "some-other-name"));
+
+        // ...but the requested domain must still be the session's domain.
+        Assertions.assertFalse(publicUser.isAuthorized("other-domain", "public_abc123@domain.commcarehq.org"));
+        Assertions.assertFalse(publicUser.isAuthorized("other-domain", "some-other-name"));
+    }
+
+    @Test
+    public void testNonPublicSessionStillEnforcesUsername() {
+        // Same shape as the public case but publicSession=false: the username check is enforced.
+        HqUserDetailsBean regularUser = new HqUserDetailsBean("domain",
+                new String[]{"domain"}, "real@domain.commcarehq.org",
+                false, new String[]{}, new String[]{});
+
+        Assertions.assertTrue(regularUser.isAuthorized("domain", "real@domain.commcarehq.org"));
+        Assertions.assertFalse(regularUser.isAuthorized("domain", "some-other-name"));
+    }
+
+    @Test
     public void testPublicSessionDeserialization() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -12,6 +12,7 @@ import static java.util.Collections.singletonList;
 
 import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.formplayer.auth.DjangoAuth;
+import org.commcare.formplayer.auth.PublicFormSessionAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.junit.RestoreFactoryAnswer;
@@ -263,6 +264,29 @@ public class RestoreFactoryTest extends BaseTestClass {
                 hasEntry("X-CommCareHQ-LastSyncToken", singletonList(syncToken)),
                 hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
         );
+    }
+
+    @Test
+    public void testGetRequestHeaders_PublicSession() {
+        String syncToken = "synctoken";
+        Mockito.doReturn(syncToken).when(restoreFactorySpy).getSyncToken();
+        // A public web apps session authenticates outbound calls with the public session key.
+        restoreFactorySpy.setHqAuth(new PublicFormSessionAuth("pkey"));
+
+        HttpHeaders headers = restoreFactorySpy.getRequestHeaders(null);
+
+        assertEquals(6, headers.size());
+        validateHeaders(headers, Arrays.asList(
+                hasEntry("Cookie", singletonList("public_form_session_key=pkey")),
+                hasEntry("CommCare-Public-Session", singletonList("true")),
+                hasEntry("X-OpenRosa-Version", singletonList("3.0")),
+                hasEntry("X-OpenRosa-DeviceId", singletonList("WebAppsLogin")),
+                hasEntry("X-CommCareHQ-LastSyncToken", singletonList(syncToken)),
+                hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
+        );
+        // The Django sessionid must never travel on a public session's outbound calls.
+        Assertions.assertFalse(headers.containsKey("sessionid"));
+        Assertions.assertFalse(headers.containsKey("Authorization"));
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/utils/HqUserDetails.java
+++ b/src/test/java/org/commcare/formplayer/utils/HqUserDetails.java
@@ -30,6 +30,7 @@ public class HqUserDetails {
     private boolean isSuperUser;
     private String[] enabledPreviews;
     private String[] enabledToggles;
+    private boolean publicSession;
 
     public HqUserDetails(WithHqUser withUser) {
         String username = StringUtils.hasLength(withUser.username()) ? withUser.username()
@@ -42,9 +43,13 @@ public class HqUserDetails {
         this.isSuperUser = withUser.isSuperUser();
         this.enabledPreviews = withUser.enabledPreviews();
         this.enabledToggles = withUser.enabledToggles();
+        this.publicSession = withUser.publicSession();
     }
 
     public HqUserDetailsBean toBean() {
-        return new HqUserDetailsBean(domain, domains, username, isSuperUser, enabledToggles, enabledPreviews);
+        HqUserDetailsBean bean = new HqUserDetailsBean(domain, domains, username, isSuperUser,
+                enabledToggles, enabledPreviews);
+        bean.setPublicSession(publicSession);
+        return bean;
     }
 }

--- a/src/test/java/org/commcare/formplayer/utils/WithHqUser.java
+++ b/src/test/java/org/commcare/formplayer/utils/WithHqUser.java
@@ -92,4 +92,9 @@ public @interface WithHqUser {
      * List of enabled toggles for the user. Defaults to a mock list of toggle_a and toggle_b
      */
     String[] enabledToggles() default {"toggle_a", "toggle_b"};
+
+    /**
+     * Whether this is a public web apps session (one-time link). Defaults to false.
+     */
+    boolean publicSession() default false;
 }


### PR DESCRIPTION
## Product Description

Adds formplayer support for public Web Apps sessions — a one-time link that lets a recipient with no HQ account open and submit a single, pre-designated Web Apps form. There is no effect on existing sessions, and this code is not reachable until the coordinated HQ change is deployed and begins issuing public sessions.

## Technical Summary
Encompasses several tickets:
[SAAS-19925](https://dimagi.atlassian.net/browse/SAAS-19925), [SAAS-19926](https://dimagi.atlassian.net/browse/SAAS-19926), [SAAS-19927](https://dimagi.atlassian.net/browse/SAAS-19927), [SAAS-19928](https://dimagi.atlassian.net/browse/SAAS-19928), [SAAS-19929](https://dimagi.atlassian.net/browse/SAAS-19929), [SAAS-19930](https://dimagi.atlassian.net/browse/SAAS-19930)

A public session authenticates with a `public_form_session_key` cookie and a `CommCare-Public-Session: true` header instead of the Django `sessionid`, and its `session_details` lookup is keyed by `publicSessionKey`. Every trust decision hangs off the HMAC-authenticated `public` field HQ returns — the client header is only a routing hint and is never trusted on its own.

- **Authorization** reuses the existing `HqUserDetails` path. A public session skips the per-user username check (there is no real account) but stays confined to the single domain HQ bound the link to, mirroring HQ's `PublicFormUser`.
- **Containment is HQ-authoritative and fail-closed.** Both the app build and the session endpoint are taken from the authenticated session details, not the request. The lock aspect overwrites any client-supplied `app_id`/`endpoint_id`/`endpointArgs` and rejects the request if HQ hasn't supplied them, so a valid key cannot be repointed at another form in the domain.
- **Route access is default-deny in the security layer**, not per-controller. A public session may only reach `get_endpoint`, `answer`, and `submit-all`; any other route — existing or added later — returns the standard 403 until explicitly allowlisted.
- **Endpoint navigation is decoupled from the `SESSION_ENDPOINTS` toggle for public sessions.** That toggle only exposes app-builder UI and won't necessarily be enabled for a domain using public webforms; a public session is itself a deep link, so it uses the endpoint machinery directly rather than forcing HQ to enable an unrelated flag.
- `app_build_id` is a pinned build doc id, not the canonical app id, so a link always runs the exact build it was published from.

### HQ dependency

The `session_details` endpoint already implements most of the changes necessary to support this work, but must be modified to include an `app_build_id` and `endpoint_id` when responding to a valid public session request. 

Code and this PR description were written by AI, reviewed and edited by human. Recommend reviewing by commit.

## Safety Assurance

### Safety story

Every new path is gated on the HMAC `public` flag and early-returns for normal sessions, so regular traffic is unaffected. Containment fails closed rather than falling back to client-supplied values. The feature is inert until HQ deploys its side and starts returning public session details, which bounds the blast radius to zero for current users. Verified with the full local test suite plus the targeted suites below.

### Automated test coverage

- Credential routing and domain-scoped authorization across public, regular, and superuser sessions.
- Outbound HQ calls carry the public credential.
- Route allowlist: 403 on non-allowlisted routes for public sessions; allowed routes reachable; regular sessions unaffected.
- App/endpoint lock: client-supplied values (including tampered ones) are overwritten with the authoritative values and args cleared; non-public beans left untouched; missing authoritative values fail closed.
- `get_endpoint` reachable without a `sessionid`, and endpoint launch for a public session with the toggle off.
- Deserialization of the new `session_details` fields.

### QA Plan

End-to-end once the HQ change is live: open a one-time link → land directly on the designated form → submit successfully; confirm the same link cannot be reused to reach any other form/app/domain, and that non-allowlisted endpoints are rejected.

### Special deploy instructions

- [x] This PR can be deployed after merge with no further considerations.

Because this code is unused until changes to allow creation of public webforms and public form sessions are implemented in HQ, this can be deployed at any time before that change, which is still estimated at several weeks out.

### Rollback instructions

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[SAAS-19925]: https://dimagi.atlassian.net/browse/SAAS-19925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19926]: https://dimagi.atlassian.net/browse/SAAS-19926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19927]: https://dimagi.atlassian.net/browse/SAAS-19927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19928]: https://dimagi.atlassian.net/browse/SAAS-19928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19929]: https://dimagi.atlassian.net/browse/SAAS-19929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19930]: https://dimagi.atlassian.net/browse/SAAS-19930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ