### PR TITLE
Public Webforms: Authentication

### DIFF
--- a/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
@@ -5,9 +5,12 @@ import io.opentracing.util.GlobalTracer;
 import io.sentry.Sentry;
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.auth.HqAuth;
+import org.commcare.formplayer.auth.PublicFormSessionAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.beans.SessionRequestBean;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.objects.SerializableFormSession;
+import org.commcare.formplayer.util.RequestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.aspectj.lang.JoinPoint;
@@ -23,6 +26,7 @@ import org.commcare.formplayer.services.CategoryTimingHelper;
 import org.commcare.formplayer.services.RestoreFactory;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import datadog.trace.api.interceptor.MutableSpan;
 
@@ -115,7 +119,15 @@ public class UserRestoreAspect {
         restoreFactory.getSQLiteDB().closeConnection();
     }
 
-    private HqAuth getHqAuth(String sessionToken) {
+    // Package-private for testing.
+    HqAuth getHqAuth(String sessionToken) {
+        // A public web apps session has no Django sessionid; authenticate its outbound HQ calls
+        // with the public session key instead. Gate this on the HMAC-authenticated `public` field
+        // from HQ's session_details response, never on the client-supplied header.
+        Optional<HqUserDetailsBean> userDetails = RequestUtils.getUserDetails();
+        if (userDetails.isPresent() && userDetails.get().isPublicSession()) {
+            return new PublicFormSessionAuth(userDetails.get().getAuthToken());
+        }
         if (sessionToken != null) {
             return new DjangoAuth(sessionToken);
         }

--- a/src/main/java/org/commcare/formplayer/auth/CommCareSessionAuthFilter.java
+++ b/src/main/java/org/commcare/formplayer/auth/CommCareSessionAuthFilter.java
@@ -38,7 +38,7 @@ public class CommCareSessionAuthFilter extends AbstractPreAuthenticatedProcessin
             boolean hasCookie = Arrays.stream(request.getCookies()).anyMatch(
                     (cookie) -> Constants.POSTGRES_DJANGO_SESSION_ID.equals(cookie.getName())
             );
-            if (!hasCookie) {
+            if (!hasCookie && !isPublicSessionRequest(request)) {
                 return false;
             }
             Authentication currentUser = SecurityContextHolder.getContext().getAuthentication();
@@ -49,9 +49,30 @@ public class CommCareSessionAuthFilter extends AbstractPreAuthenticatedProcessin
 
     @Override
     protected Object getPreAuthenticatedCredentials(HttpServletRequest request) {
+        if (isPublicSessionRequest(request)) {
+            return new PublicSessionCredential(
+                    getCookieValue(request, Constants.PUBLIC_FORM_SESSION_COOKIE_NAME));
+        }
+        return getCookieValue(request, Constants.POSTGRES_DJANGO_SESSION_ID);
+    }
+
+    /**
+     * A public web apps request is signaled by the {@code CommCare-Public-Session: true} header
+     * (a credential-routing hint, not a trust signal) paired with the
+     * {@code public_form_session_key} cookie carrying the session key.
+     */
+    private static boolean isPublicSessionRequest(HttpServletRequest request) {
+        if (!Constants.PUBLIC_FORM_SESSION_HEADER_VALUE.equals(
+                request.getHeader(Constants.PUBLIC_FORM_SESSION_HEADER))) {
+            return false;
+        }
+        return getCookieValue(request, Constants.PUBLIC_FORM_SESSION_COOKIE_NAME) != null;
+    }
+
+    private static String getCookieValue(HttpServletRequest request, String name) {
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {
-                if (Constants.POSTGRES_DJANGO_SESSION_ID.equals(cookie.getName())) {
+                if (name.equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }

--- a/src/main/java/org/commcare/formplayer/auth/PublicFormSessionAuth.java
+++ b/src/main/java/org/commcare/formplayer/auth/PublicFormSessionAuth.java
@@ -2,7 +2,6 @@ package org.commcare.formplayer.auth;
 
 import org.commcare.formplayer.util.Constants;
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.Assert;
 
 /**
  * {@link HqAuth} for a public web apps session.
@@ -16,7 +15,6 @@ public class PublicFormSessionAuth implements HqAuth {
     private final String sessionKey;
 
     public PublicFormSessionAuth(String sessionKey) {
-        Assert.hasText(sessionKey, "A public form session key is required");
         this.sessionKey = sessionKey;
     }
 

--- a/src/main/java/org/commcare/formplayer/auth/PublicFormSessionAuth.java
+++ b/src/main/java/org/commcare/formplayer/auth/PublicFormSessionAuth.java
@@ -1,0 +1,37 @@
+package org.commcare.formplayer.auth;
+
+import org.commcare.formplayer.util.Constants;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.Assert;
+
+/**
+ * {@link HqAuth} for a public web apps session.
+ *
+ * Emits the credential pair HQ requires to recognize a public session on its receiver/restore
+ * endpoints: the {@code public_form_session_key} cookie carrying the session key together with the
+ * {@code CommCare-Public-Session: true} header.
+ */
+public class PublicFormSessionAuth implements HqAuth {
+
+    private final String sessionKey;
+
+    public PublicFormSessionAuth(String sessionKey) {
+        Assert.hasText(sessionKey, "A public form session key is required");
+        this.sessionKey = sessionKey;
+    }
+
+    @Override
+    public HttpHeaders getAuthHeaders() {
+        return new HttpHeaders() {
+            {
+                add("Cookie", Constants.PUBLIC_FORM_SESSION_COOKIE_NAME + "=" + sessionKey);
+                add(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE);
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "PublicFormSessionAuth";
+    }
+}

--- a/src/main/java/org/commcare/formplayer/auth/PublicSessionCredential.java
+++ b/src/main/java/org/commcare/formplayer/auth/PublicSessionCredential.java
@@ -1,0 +1,15 @@
+package org.commcare.formplayer.auth;
+
+import lombok.Value;
+
+/**
+ * Typed credential for a public web apps session (one-time link).
+ *
+ * Wraps the value of the {@code public_form_session_key} cookie so that the
+ * {@link org.commcare.formplayer.services.HqUserDetailsService} can distinguish a public session
+ * from a regular Django session.
+ */
+@Value
+public class PublicSessionCredential {
+    String sessionKey;
+}

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqPublicSessionKeyBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqPublicSessionKeyBean.java
@@ -1,0 +1,31 @@
+package org.commcare.formplayer.beans.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.io.Serializable;
+
+/**
+ * HMAC-signed body sent to HQ's session_details endpoint for a public web apps session.
+ *
+ * Serializes to {@code {"publicSessionKey": ..., "domain": ...}}. HQ treats a request with a
+ * truthy {@code publicSessionKey} as a public session lookup, in contrast to
+ * {@link HqSessionKeyBean} which sends {@code sessionId}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HqPublicSessionKeyBean implements Serializable {
+    private String publicSessionKey;
+    private String domain;
+
+    public HqPublicSessionKeyBean(String domain, String publicSessionKey) {
+        this.domain = domain;
+        this.publicSessionKey = publicSessionKey;
+    }
+
+    public String getPublicSessionKey() {
+        return publicSessionKey;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+}

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
@@ -53,6 +53,12 @@ public class HqUserDetailsBean implements UserDetails {
     }
 
     public boolean isAuthorized(String domain, String username) {
+        if (publicSession) {
+            // Public web apps sessions authenticate via a single-use key that HQ has already
+            // validated and tied to exactly one domain. There is no real HQ account, so the
+            // per-session username is not a meaningful check.
+            return Arrays.asList(domains).contains(domain);
+        }
         return isSuperUser || Arrays.asList(domains).contains(domain) && this.username.equals(
                 username);
     }

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
@@ -53,14 +53,12 @@ public class HqUserDetailsBean implements UserDetails {
     }
 
     public boolean isAuthorized(String domain, String username) {
-        if (publicSession) {
-            // Public web apps sessions authenticate via a single-use key that HQ has already
-            // validated and tied to exactly one domain. There is no real HQ account, so the
-            // per-session username is not a meaningful check.
-            return Arrays.asList(domains).contains(domain);
-        }
-        return isSuperUser || Arrays.asList(domains).contains(domain) && this.username.equals(
+        return isSuperUser || isAuthorizedForDomain(domain) && this.username.equals(
                 username);
+    }
+
+    public boolean isAuthorizedForDomain(String domain) {
+        return Arrays.asList(domains).contains(domain);
     }
 
     /////////////////////// UserDetails methods

--- a/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/auth/HqUserDetailsBean.java
@@ -1,6 +1,7 @@
 package org.commcare.formplayer.beans.auth;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
 import org.springframework.security.core.GrantedAuthority;
@@ -28,6 +29,11 @@ public class HqUserDetailsBean implements UserDetails {
     private String domain;
     private String[] enabledToggles;
     private String[] enabledPreviews;
+
+    // HQ marks public web apps sessions with a JSON `public` field. `public` is a reserved word,
+    // so map it to this property. Primitive boolean so missing JSON defaults to false.
+    @JsonProperty("public")
+    private boolean publicSession;
 
     public HqUserDetailsBean() {
     }

--- a/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
+++ b/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
@@ -1,7 +1,9 @@
 package org.commcare.formplayer.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commcare.formplayer.auth.PublicSessionCredential;
 import org.commcare.formplayer.auth.UserDomainPreAuthPrincipal;
+import org.commcare.formplayer.beans.auth.HqPublicSessionKeyBean;
 import org.commcare.formplayer.beans.auth.HqSessionKeyBean;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
@@ -38,10 +40,23 @@ public class HqUserDetailsService implements AuthenticationUserDetailsService<Pr
     private WebClient webClient;
 
     public HqUserDetailsBean getUserDetails(String domain, String sessionKey) {
+        return requestUserDetails(domain, new HqSessionKeyBean(domain, sessionKey));
+    }
+
+    /**
+     * Look up user details for a public web apps session. Sends the session key as
+     * {@code publicSessionKey} rather than {@code sessionId} so HQ knows to resolves it against
+     * the public form session.
+     */
+    public HqUserDetailsBean getPublicUserDetails(String domain, String publicSessionKey) {
+        return requestUserDetails(domain, new HqPublicSessionKeyBean(domain, publicSessionKey));
+    }
+
+    private HqUserDetailsBean requestUserDetails(String domain, Object requestBody) {
         HttpHeaders headers = new HttpHeaders();
-        String data = null;
+        String data;
         try {
-            data = objectMapper.writeValueAsString(new HqSessionKeyBean(domain, sessionKey));
+            data = objectMapper.writeValueAsString(requestBody);
             headers.set("X-MAC-DIGEST", getHmac(data));
         } catch (Exception e) {
             throw new UserDetailsException(e);
@@ -73,9 +88,14 @@ public class HqUserDetailsService implements AuthenticationUserDetailsService<Pr
     @Override
     public UserDetails loadUserDetails(PreAuthenticatedAuthenticationToken token) throws UsernameNotFoundException {
         final UserDomainPreAuthPrincipal principal = (UserDomainPreAuthPrincipal) token.getPrincipal();
-        final String sessionId = (String) token.getCredentials();
+        final Object credentials = token.getCredentials();
         try {
-            HqUserDetailsBean userDetails = getUserDetails(principal.getDomain(), sessionId);
+            HqUserDetailsBean userDetails;
+            if (credentials instanceof PublicSessionCredential publicCredential) {
+                userDetails = getPublicUserDetails(principal.getDomain(), publicCredential.getSessionKey());
+            } else {
+                userDetails = getUserDetails(principal.getDomain(), (String) credentials);
+            }
             if (!userDetails.isAuthorized(principal.getDomain(), principal.getUsername())) {
                 throw new UsernameNotFoundException("Unable to authenticate user in requested domain");
             }

--- a/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
+++ b/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
@@ -96,7 +96,11 @@ public class HqUserDetailsService implements AuthenticationUserDetailsService<Pr
             } else {
                 userDetails = getUserDetails(principal.getDomain(), (String) credentials);
             }
-            if (!userDetails.isAuthorized(principal.getDomain(), principal.getUsername())) {
+            // A public session has no real HQ account, so only its bound domain is meaningful.
+            boolean authorized = userDetails.isPublicSession()
+                    ? userDetails.isAuthorizedForDomain(principal.getDomain())
+                    : userDetails.isAuthorized(principal.getDomain(), principal.getUsername());
+            if (!authorized) {
                 throw new UsernameNotFoundException("Unable to authenticate user in requested domain");
             }
             return userDetails;

--- a/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
+++ b/src/main/java/org/commcare/formplayer/services/HqUserDetailsService.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.userdetails.AuthenticationUserDetailsService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.util.StringUtils;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -102,6 +103,9 @@ public class HqUserDetailsService implements AuthenticationUserDetailsService<Pr
                     : userDetails.isAuthorized(principal.getDomain(), principal.getUsername());
             if (!authorized) {
                 throw new UsernameNotFoundException("Unable to authenticate user in requested domain");
+            }
+            if (userDetails.isPublicSession() && !StringUtils.hasText(userDetails.getAuthToken())) {
+                throw new UsernameNotFoundException("Public web apps session is missing its session key");
             }
             return userDetails;
         } catch (SessionAuthUnavailableException e) {

--- a/src/main/java/org/commcare/formplayer/util/Constants.java
+++ b/src/main/java/org/commcare/formplayer/util/Constants.java
@@ -107,6 +107,13 @@ public class Constants {
     public static final String POSTGRES_DJANGO_SESSION_ID = "sessionid";
     public static final String COMMCARE_USER_SUFFIX = "commcarehq.org";
 
+    // Public web apps sessions (one-time links). Must match HQ's
+    // corehq/apps/app_manager/const.py PUBLIC_FORM_SESSION_* values.
+    public static final String PUBLIC_FORM_SESSION_COOKIE_NAME = "public_form_session_key";
+    public static final String PUBLIC_FORM_SESSION_HEADER = "CommCare-Public-Session";
+    // HQ compares the header against this exact value (case-sensitive).
+    public static final String PUBLIC_FORM_SESSION_HEADER_VALUE = "true";
+
     public static final int USER_LOCK_TIMEOUT = 21;
     // 15 minutes in milliseconds
     public static final int LOCK_DURATION = 60 * 15 * 1000;

--- a/src/test/java/org/commcare/formplayer/aspects/UserRestoreAspectTest.java
+++ b/src/test/java/org/commcare/formplayer/aspects/UserRestoreAspectTest.java
@@ -1,0 +1,89 @@
+package org.commcare.formplayer.aspects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.commcare.formplayer.auth.DjangoAuth;
+import org.commcare.formplayer.auth.HqAuth;
+import org.commcare.formplayer.auth.PublicFormSessionAuth;
+import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
+import org.commcare.formplayer.util.RequestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+/**
+ * Unit tests for {@link UserRestoreAspect#getHqAuth} credential selection, in particular the
+ * choice between a Django session and a public web apps session.
+ */
+public class UserRestoreAspectTest {
+
+    private final UserRestoreAspect aspect = new UserRestoreAspect();
+
+    private HqUserDetailsBean bean(boolean isPublicSession, String authToken) {
+        HqUserDetailsBean bean = new HqUserDetailsBean("domain", new String[]{"domain"}, "user",
+                false, new String[]{}, new String[]{});
+        bean.setPublicSession(isPublicSession);
+        bean.setAuthToken(authToken);
+        return bean;
+    }
+
+    @Test
+    public void publicSession_usesPublicFormSessionAuthWithTheSessionKey() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.of(bean(true, "pkey")));
+
+            HqAuth auth = aspect.getHqAuth(null);
+
+            assertTrue(auth instanceof PublicFormSessionAuth);
+            assertEquals("public_form_session_key=pkey", auth.getAuthHeaders().getFirst("Cookie"));
+        }
+    }
+
+    @Test
+    public void publicSession_winsEvenWhenASessionidCookieIsAlsoPresent() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.of(bean(true, "pkey")));
+
+            // Both signals present: the public credential must win, matching inbound selection.
+            HqAuth auth = aspect.getHqAuth("sessionid-value");
+
+            assertTrue(auth instanceof PublicFormSessionAuth);
+        }
+    }
+
+    @Test
+    public void regularSession_usesDjangoAuth() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.of(bean(false, null)));
+
+            HqAuth auth = aspect.getHqAuth("sessionid-value");
+
+            assertTrue(auth instanceof DjangoAuth);
+        }
+    }
+
+    @Test
+    public void noUserDetailsWithSessionToken_usesDjangoAuth() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.empty());
+
+            HqAuth auth = aspect.getHqAuth("sessionid-value");
+
+            assertTrue(auth instanceof DjangoAuth);
+        }
+    }
+
+    @Test
+    public void noUserDetailsNoSessionToken_returnsNull() {
+        try (MockedStatic<RequestUtils> mocked = Mockito.mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::getUserDetails).thenReturn(Optional.empty());
+
+            // SMS requests have neither a public session nor a sessionid cookie.
+            assertNull(aspect.getHqAuth(null));
+        }
+    }
+}

--- a/src/test/java/org/commcare/formplayer/auth/PublicFormSessionAuthTest.java
+++ b/src/test/java/org/commcare/formplayer/auth/PublicFormSessionAuthTest.java
@@ -1,0 +1,35 @@
+package org.commcare.formplayer.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+public class PublicFormSessionAuthTest {
+
+    @Test
+    public void getAuthHeaders_emitsPublicCookieAndHeaderOnly() {
+        HttpHeaders headers = new PublicFormSessionAuth("session-key-123").getAuthHeaders();
+
+        assertEquals("public_form_session_key=session-key-123", headers.getFirst("Cookie"));
+        assertEquals("true", headers.getFirst("CommCare-Public-Session"));
+
+        // Exactly the two public headers — no Django sessionid/Authorization leaks out.
+        assertEquals(2, headers.size());
+        assertFalse(headers.containsKey("sessionid"));
+        assertFalse(headers.containsKey("Authorization"));
+    }
+
+    @Test
+    public void toString_doesNotLeakTheKey() {
+        assertFalse(new PublicFormSessionAuth("super-secret-key").toString().contains("super-secret-key"));
+    }
+
+    @Test
+    public void constructor_rejectsMissingKey() {
+        assertThrows(IllegalArgumentException.class, () -> new PublicFormSessionAuth(null));
+        assertThrows(IllegalArgumentException.class, () -> new PublicFormSessionAuth(""));
+    }
+}

--- a/src/test/java/org/commcare/formplayer/auth/PublicFormSessionAuthTest.java
+++ b/src/test/java/org/commcare/formplayer/auth/PublicFormSessionAuthTest.java
@@ -2,7 +2,6 @@ package org.commcare.formplayer.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -25,11 +24,5 @@ public class PublicFormSessionAuthTest {
     @Test
     public void toString_doesNotLeakTheKey() {
         assertFalse(new PublicFormSessionAuth("super-secret-key").toString().contains("super-secret-key"));
-    }
-
-    @Test
-    public void constructor_rejectsMissingKey() {
-        assertThrows(IllegalArgumentException.class, () -> new PublicFormSessionAuth(null));
-        assertThrows(IllegalArgumentException.class, () -> new PublicFormSessionAuth(""));
     }
 }

--- a/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
+++ b/src/test/java/org/commcare/formplayer/auth/SessionAuthTests.java
@@ -97,6 +97,47 @@ public class SessionAuthTests {
         this.testEndpoint(builder, status().isOk());
     }
 
+    /**
+     * A public web apps request (public header + public cookie, no session cookie) authenticates
+     * via a {@link PublicSessionCredential} carrying the public_form_session_key.
+     */
+    @Test
+    public void testEndpoint_WithPublicSession_Succeeds() throws Exception {
+        String sessionKey = "public-key-abc";
+        mockValidPublicAuth(sessionKey);
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE)
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, sessionKey));
+        this.testEndpoint(builder, status().isOk());
+    }
+
+    /**
+     * The public header is only honored when its value is exactly "true". A different value with no
+     * session cookie is not a recognized session and must not authenticate.
+     */
+    @Test
+    public void testEndpoint_PublicHeaderWrongValue_NoSessionCookie_Fails() throws Exception {
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, "false")
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, "public-key-abc"));
+        this.testEndpoint(builder, status().isForbidden());
+    }
+
+    /**
+     * When both signals are present, the explicit public header routes to the public credential
+     * rather than the Django session cookie.
+     */
+    @Test
+    public void testEndpoint_PublicHeaderAndSessionCookie_PrefersPublicCredential() throws Exception {
+        String sessionKey = "public-key-abc";
+        mockValidPublicAuth(sessionKey);
+        MockHttpServletRequestBuilder builder = getRequestBuilder(FULL_AUTH_BODY)
+                .header(Constants.PUBLIC_FORM_SESSION_HEADER, Constants.PUBLIC_FORM_SESSION_HEADER_VALUE)
+                .cookie(new Cookie(Constants.PUBLIC_FORM_SESSION_COOKIE_NAME, sessionKey))
+                .cookie(new Cookie(Constants.POSTGRES_DJANGO_SESSION_ID, "123"));
+        this.testEndpoint(builder, status().isOk());
+    }
+
     @Test
     public void testMultipartEndpointWithFullAuth_WithAnyHmacAuth_Succeeds() throws Exception {
         String sessionId = "123";
@@ -110,6 +151,13 @@ public class SessionAuthTests {
 
     private void mockValidAuth(String sessionId) {
         TokenMatcher matcher = new TokenMatcher(DOMAIN, USERNAME, sessionId);
+        when(userDetailsService.loadUserDetails(argThat(matcher))).thenReturn(
+                new HqUserDetailsBean(DOMAIN, USERNAME)
+        );
+    }
+
+    private void mockValidPublicAuth(String sessionKey) {
+        PublicTokenMatcher matcher = new PublicTokenMatcher(DOMAIN, USERNAME, sessionKey);
         when(userDetailsService.loadUserDetails(argThat(matcher))).thenReturn(
                 new HqUserDetailsBean(DOMAIN, USERNAME)
         );
@@ -154,6 +202,32 @@ public class SessionAuthTests {
             return principal.getDomain().equals(this.domain)
                     && principal.getUsername().equals(this.username)
                     && sessionId.equals(this.sessionId);
+        }
+    }
+
+    private class PublicTokenMatcher implements ArgumentMatcher<PreAuthenticatedAuthenticationToken> {
+        private String domain;
+        private String username;
+        private String sessionKey;
+
+        public PublicTokenMatcher(String domain, String username, String sessionKey) {
+            this.domain = domain;
+            this.username = username;
+            this.sessionKey = sessionKey;
+        }
+
+        @Override
+        public boolean matches(PreAuthenticatedAuthenticationToken token) {
+            if (token == null) {
+                return false;
+            }
+            final UserDomainPreAuthPrincipal principal =
+                    (UserDomainPreAuthPrincipal)token.getPrincipal();
+            final Object credentials = token.getCredentials();
+            return credentials instanceof PublicSessionCredential
+                    && ((PublicSessionCredential)credentials).getSessionKey().equals(this.sessionKey)
+                    && principal.getDomain().equals(this.domain)
+                    && principal.getUsername().equals(this.username);
         }
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -35,6 +35,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -189,5 +190,25 @@ public class HqUserDetailsServiceTests {
 
         UserDetails details = this.service.loadUserDetails(token);
         assertThat(details.getUsername()).isEqualTo("public_abc123@domain");
+    }
+
+    @Test
+    public void loadUserDetails_publicSessionWithoutSessionKey_failsAuthentication()
+            throws Exception {
+        String detailsString = "{" +
+                "\"domains\":[\"domain\"]," +
+                "\"username\":\"public_abc123@domain\"," +
+                "\"superUser\":false," +
+                "\"public\":true" +
+                "}";
+
+        this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+
+        UserDomainPreAuthPrincipal principal = new UserDomainPreAuthPrincipal("someone", "domain");
+        PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, new PublicSessionCredential("pub-key"));
+
+        assertThrows(UsernameNotFoundException.class, () -> this.service.loadUserDetails(token));
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -141,6 +141,7 @@ public class HqUserDetailsServiceTests {
 
         assertThat(details.getUsername()).isEqualTo("public@domain");
         assertThat(details.getDomains()).isEqualTo(new String[]{"domain"});
+        assertThat(details.isPublicSession()).isTrue();
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -168,4 +168,26 @@ public class HqUserDetailsServiceTests {
         UserDetails details = this.service.loadUserDetails(token);
         assertThat(details.getUsername()).isEqualTo("citrus");
     }
+
+    @Test
+    public void loadUserDetails_publicSession_authorizesOnDomainIgnoringClaimedUsername()
+            throws Exception {
+        String detailsString = "{" +
+                "\"domains\":[\"domain\"]," +
+                "\"username\":\"public_abc123@domain\"," +
+                "\"authToken\":\"pub-key\"," +
+                "\"superUser\":false," +
+                "\"public\":true" +
+                "}";
+
+        this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+
+        UserDomainPreAuthPrincipal principal = new UserDomainPreAuthPrincipal("someone-else", "domain");
+        PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, new PublicSessionCredential("pub-key"));
+
+        UserDetails details = this.service.loadUserDetails(token);
+        assertThat(details.getUsername()).isEqualTo("public_abc123@domain");
+    }
 }

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsServiceTests.java
@@ -10,6 +10,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.commcare.formplayer.auth.PublicSessionCredential;
+import org.commcare.formplayer.auth.UserDomainPreAuthPrincipal;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.exceptions.SessionAuthUnavailableException;
 import org.commcare.formplayer.repo.FormDefinitionRepo;
@@ -32,6 +34,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -113,5 +117,54 @@ public class HqUserDetailsServiceTests {
         assertThrows(SessionAuthUnavailableException.class, () -> {
             this.service.getUserDetails("domain", "invalid");
         });
+    }
+
+    @Test
+    public void whenCallingGetPublicUserDetails_thenClientSendsPublicSessionKey()
+            throws Exception {
+        String detailsString = "{" +
+                "\"domains\":[\"domain\"]," +
+                "\"djangoUserId\":null," +
+                "\"username\":\"public@domain\"," +
+                "\"authToken\":\"pub-key\"," +
+                "\"superUser\":false," +
+                "\"public\":true" +
+                "}";
+
+        this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
+                .andExpect(jsonPath("$.publicSessionKey").value("pub-key"))
+                .andExpect(jsonPath("$.sessionId").doesNotExist())
+                .andExpect(jsonPath("$.domain").value("domain"))
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+
+        HqUserDetailsBean details = this.service.getPublicUserDetails("domain", "pub-key");
+
+        assertThat(details.getUsername()).isEqualTo("public@domain");
+        assertThat(details.getDomains()).isEqualTo(new String[]{"domain"});
+    }
+
+    @Test
+    public void loadUserDetails_withPublicCredential_routesToPublicSessionKey()
+            throws Exception {
+        String detailsString = "{" +
+                "\"domains\":[\"domain\"]," +
+                "\"djangoUserId\":null," +
+                "\"username\":\"citrus\"," +
+                "\"authToken\":\"pub-key\"," +
+                "\"superUser\":false," +
+                "\"public\":true" +
+                "}";
+
+        this.server.expect(requestTo(Constants.SESSION_DETAILS_VIEW))
+                .andExpect(jsonPath("$.publicSessionKey").value("pub-key"))
+                .andExpect(jsonPath("$.sessionId").doesNotExist())
+                .andRespond(withSuccess(detailsString, MediaType.APPLICATION_JSON));
+
+        UserDomainPreAuthPrincipal principal = new UserDomainPreAuthPrincipal("citrus", "domain");
+        PreAuthenticatedAuthenticationToken token = new PreAuthenticatedAuthenticationToken(
+                principal, new PublicSessionCredential("pub-key"));
+
+        UserDetails details = this.service.loadUserDetails(token);
+        assertThat(details.getUsername()).isEqualTo("citrus");
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -1,5 +1,7 @@
 package org.commcare.formplayer.tests;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.commcare.formplayer.beans.auth.FeatureFlagChecker;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.utils.HqUserDetails;
@@ -35,6 +37,25 @@ public class HqUserDetailsTests {
         Assertions.assertTrue(user.isAuthorized("domain", "bilbo"));
         Assertions.assertFalse(user.isAuthorized("wrong-domain", "bilbo"));
         Assertions.assertFalse(user.isAuthorized("domain", "wrong-bilbo"));
+    }
+
+    @Test
+    public void testPublicSessionDeserialization() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // HQ sends the reserved word `public` for a public web apps session.
+        HqUserDetailsBean publicUser = mapper.readValue(
+                "{\"username\":\"pub\",\"public\":true}", HqUserDetailsBean.class);
+        Assertions.assertTrue(publicUser.isPublicSession());
+
+        HqUserDetailsBean regularUser = mapper.readValue(
+                "{\"username\":\"reg\",\"public\":false}", HqUserDetailsBean.class);
+        Assertions.assertFalse(regularUser.isPublicSession());
+
+        // Absent `public` defaults to false (primitive boolean; the bean also ignores unknowns).
+        HqUserDetailsBean noField = mapper.readValue(
+                "{\"username\":\"reg\"}", HqUserDetailsBean.class);
+        Assertions.assertFalse(noField.isPublicSession());
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -40,30 +40,26 @@ public class HqUserDetailsTests {
     }
 
     @Test
-    public void testPublicSessionIsAuthorized() {
+    public void testIsAuthorizedForDomain() {
+        HqUserDetailsBean user = new HqUserDetailsBean("domain",
+                new String[]{"domain", "other-domain"}, "aragorn",
+                false, new String[]{}, new String[]{});
+
+        Assertions.assertTrue(user.isAuthorizedForDomain("domain"));
+        Assertions.assertTrue(user.isAuthorizedForDomain("other-domain"));
+        Assertions.assertFalse(user.isAuthorizedForDomain("wrong-domain"));
+    }
+
+    @Test
+    public void testIsAuthorizedIgnoresPublicSessionFlag() {
         HqUserDetailsBean publicUser = new HqUserDetailsBean("domain",
                 new String[]{"domain"}, "public_abc123@domain.commcarehq.org",
                 false, new String[]{}, new String[]{});
         publicUser.setPublicSession(true);
 
-        // Synthetic username is not checked for a public session...
         Assertions.assertTrue(publicUser.isAuthorized("domain", "public_abc123@domain.commcarehq.org"));
-        Assertions.assertTrue(publicUser.isAuthorized("domain", "some-other-name"));
-
-        // ...but the requested domain must still be the session's domain.
+        Assertions.assertFalse(publicUser.isAuthorized("domain", "some-other-name"));
         Assertions.assertFalse(publicUser.isAuthorized("other-domain", "public_abc123@domain.commcarehq.org"));
-        Assertions.assertFalse(publicUser.isAuthorized("other-domain", "some-other-name"));
-    }
-
-    @Test
-    public void testNonPublicSessionStillEnforcesUsername() {
-        // Same shape as the public case but publicSession=false: the username check is enforced.
-        HqUserDetailsBean regularUser = new HqUserDetailsBean("domain",
-                new String[]{"domain"}, "real@domain.commcarehq.org",
-                false, new String[]{}, new String[]{});
-
-        Assertions.assertTrue(regularUser.isAuthorized("domain", "real@domain.commcarehq.org"));
-        Assertions.assertFalse(regularUser.isAuthorized("domain", "some-other-name"));
     }
 
     @Test

--- a/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
+++ b/src/test/java/org/commcare/formplayer/tests/HqUserDetailsTests.java
@@ -40,6 +40,33 @@ public class HqUserDetailsTests {
     }
 
     @Test
+    public void testPublicSessionIsAuthorized() {
+        HqUserDetailsBean publicUser = new HqUserDetailsBean("domain",
+                new String[]{"domain"}, "public_abc123@domain.commcarehq.org",
+                false, new String[]{}, new String[]{});
+        publicUser.setPublicSession(true);
+
+        // Synthetic username is not checked for a public session...
+        Assertions.assertTrue(publicUser.isAuthorized("domain", "public_abc123@domain.commcarehq.org"));
+        Assertions.assertTrue(publicUser.isAuthorized("domain", "some-other-name"));
+
+        // ...but the requested domain must still be the session's domain.
+        Assertions.assertFalse(publicUser.isAuthorized("other-domain", "public_abc123@domain.commcarehq.org"));
+        Assertions.assertFalse(publicUser.isAuthorized("other-domain", "some-other-name"));
+    }
+
+    @Test
+    public void testNonPublicSessionStillEnforcesUsername() {
+        // Same shape as the public case but publicSession=false: the username check is enforced.
+        HqUserDetailsBean regularUser = new HqUserDetailsBean("domain",
+                new String[]{"domain"}, "real@domain.commcarehq.org",
+                false, new String[]{}, new String[]{});
+
+        Assertions.assertTrue(regularUser.isAuthorized("domain", "real@domain.commcarehq.org"));
+        Assertions.assertFalse(regularUser.isAuthorized("domain", "some-other-name"));
+    }
+
+    @Test
     public void testPublicSessionDeserialization() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -12,6 +12,7 @@ import static java.util.Collections.singletonList;
 
 import org.commcare.cases.util.CaseDBUtils;
 import org.commcare.formplayer.auth.DjangoAuth;
+import org.commcare.formplayer.auth.PublicFormSessionAuth;
 import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.configuration.CacheConfiguration;
 import org.commcare.formplayer.junit.RestoreFactoryAnswer;
@@ -263,6 +264,29 @@ public class RestoreFactoryTest extends BaseTestClass {
                 hasEntry("X-CommCareHQ-LastSyncToken", singletonList(syncToken)),
                 hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
         );
+    }
+
+    @Test
+    public void testGetRequestHeaders_PublicSession() {
+        String syncToken = "synctoken";
+        Mockito.doReturn(syncToken).when(restoreFactorySpy).getSyncToken();
+        // A public web apps session authenticates outbound calls with the public session key.
+        restoreFactorySpy.setHqAuth(new PublicFormSessionAuth("pkey"));
+
+        HttpHeaders headers = restoreFactorySpy.getRequestHeaders(null);
+
+        assertEquals(6, headers.size());
+        validateHeaders(headers, Arrays.asList(
+                hasEntry("Cookie", singletonList("public_form_session_key=pkey")),
+                hasEntry("CommCare-Public-Session", singletonList("true")),
+                hasEntry("X-OpenRosa-Version", singletonList("3.0")),
+                hasEntry("X-OpenRosa-DeviceId", singletonList("WebAppsLogin")),
+                hasEntry("X-CommCareHQ-LastSyncToken", singletonList(syncToken)),
+                hasEntry(equalTo("X-CommCareHQ-Origin-Token"), new ValueIsUUID()))
+        );
+        // The Django sessionid must never travel on a public session's outbound calls.
+        Assertions.assertFalse(headers.containsKey("sessionid"));
+        Assertions.assertFalse(headers.containsKey("Authorization"));
     }
 
     @Test


### PR DESCRIPTION
## Technical Summary
[SAAS-19925](https://dimagi.atlassian.net/browse/SAAS-19925), [SAAS-19926](https://dimagi.atlassian.net/browse/SAAS-19926), [SAAS-19927](https://dimagi.atlassian.net/browse/SAAS-19927)

- First of three PRs adding Public Web Apps Sessions (one-time links that let an
  unauthenticated recipient fill a single pre-designated form). This PR is the authentication layer
  only — recognizing and authenticating a public session, inbound and outbound.
  - `CommCareSessionAuthFilter`: a request with the `CommCare-Public-Session: true` header **and** a
    `public_form_session_key` cookie is wrapped as a `PublicSessionCredential`.
  - `HqUserDetailsService`: public sessions send the key as `publicSessionKey` (not `sessionId`) to
    `session_details`.
  - `HqUserDetailsBean`: new HMAC-authoritative `public` field; `isAuthorized` drops the
    synthetic-username check for public sessions but still requires the request domain to match.
  - `PublicFormSessionAuth`: authenticates formplayer's outbound HQ calls with the session key,
    selected in `UserRestoreAspect#getHqAuth`.
- Design decision: the `CommCare-Public-Session` header is only a **credential-routing hint** —
  trust comes solely from HQ's `public` field, returned over the HMAC-authenticated `session_details`
  call.

Code and PR description written or co-written by AI and edited by human. Review by commit.

## Safety Assurance

### Safety story
Purely additive and gated behind a new session type. The existing Django-cookie and HMAC auth paths
are untouched; the new branches only fire when the public header + cookie are present **and** HQ
confirms `public`. No public session can authenticate until HQ issues one-time links. No
existing data is read or written differently for non-public requests.

### Automated test coverage
- `SessionAuthTests` — credential routing, header-vs-cookie precedence, failure when the key is absent.
- `HqUserDetailsServiceTests` — `publicSessionKey` wire format vs `sessionId`.
- `HqUserDetailsTests` — domain-only `isAuthorized` for public sessions, `public` deserialization.
- `PublicFormSessionAuthTest`, `UserRestoreAspectTest` — outbound-auth selection.

### QA Plan
Public Webforms will get end-to-end QA before its release.

### Special deploy instructions
Though public form sessions are not yet being created in HQ, this PR should not be deployed without changes from #1792, which add required security checks to public form sessions.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations.

### Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.


[SAAS-19925]: https://dimagi.atlassian.net/browse/SAAS-19925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19926]: https://dimagi.atlassian.net/browse/SAAS-19926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAAS-19927]: https://dimagi.atlassian.net/browse/SAAS-19927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ