### PR TITLE
Public Webforms: Sandbox cleanup

### DIFF
--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -151,6 +151,13 @@ public class FormSubmissionHelper {
             return error.get();
         }
 
+        onSuccessfulSubmit(sessionID);
+
+        return context.getResponse();
+    }
+
+    // Package-private for testing.
+    void onSuccessfulSubmit(String sessionID) {
         // Only delete session immediately after successful submit
         formSessionService.deleteSessionById(sessionID);
 
@@ -158,8 +165,6 @@ public class FormSubmissionHelper {
         if (RequestUtils.isPublicSession()) {
             restoreFactory.markPublicSandboxForDeletion();
         }
-
-        return context.getResponse();
     }
 
     private FormSubmissionContext getFormProcessingContext(HttpServletRequest request, String sessionID, String domain,

--- a/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
+++ b/src/main/java/org/commcare/formplayer/application/FormSubmissionHelper.java
@@ -34,6 +34,7 @@ import org.commcare.formplayer.util.FormSubmissionContext;
 import org.commcare.formplayer.util.FormplayerDatadog;
 import org.commcare.formplayer.util.NotificationLogger;
 import org.commcare.formplayer.util.ProcessingStep;
+import org.commcare.formplayer.util.RequestUtils;
 import org.commcare.formplayer.util.serializer.SessionSerializer;
 import org.commcare.session.CommCareSession;
 import org.commcare.util.FileUtils;
@@ -152,6 +153,11 @@ public class FormSubmissionHelper {
 
         // Only delete session immediately after successful submit
         formSessionService.deleteSessionById(sessionID);
+
+        // A public session is one-time use, so discard its sandbox once the connection closes.
+        if (RequestUtils.isPublicSession()) {
+            restoreFactory.markPublicSandboxForDeletion();
+        }
 
         return context.getResponse();
     }

--- a/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
+++ b/src/main/java/org/commcare/formplayer/aspects/UserRestoreAspect.java
@@ -125,6 +125,13 @@ public class UserRestoreAspect {
     @After(value = "@annotation(org.commcare.formplayer.annotations.UserRestore)")
     public void closeRestoreFactory(JoinPoint joinPoint) throws Throwable {
         restoreFactory.getSQLiteDB().closeConnection();
+        if (restoreFactory.shouldDeletePublicSandboxOnClose()) {
+            try {
+                restoreFactory.getSQLiteDB().deleteDatabaseFolder();
+            } catch (Exception e) {
+                log.error("Failed to delete public web apps session sandbox", e);
+            }
+        }
     }
 
     // Package-private for testing.

--- a/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
+++ b/src/main/java/org/commcare/formplayer/services/RestoreFactory.java
@@ -102,6 +102,8 @@ public class RestoreFactory {
 
     private boolean permitAggressiveSyncs = true;
 
+    private boolean deletePublicSandboxOnClose = false;
+
     public static final String FREQ_DAILY = "freq-daily";
     public static final String FREQ_WEEKLY = "freq-weekly";
     public static final String FREQ_NEVER = "freq-never";
@@ -374,6 +376,17 @@ public class RestoreFactory {
 
     public SQLiteDB getSQLiteDB() {
         return sqLiteDB;
+    }
+
+    /**
+     * Marks this request's sandbox for deletion once the restore connection is closed.
+     */
+    public void markPublicSandboxForDeletion() {
+        this.deletePublicSandboxOnClose = true;
+    }
+
+    public boolean shouldDeletePublicSandboxOnClose() {
+        return deletePublicSandboxOnClose;
     }
 
     public boolean getHasLocationChanged() {

--- a/src/test/java/org/commcare/formplayer/application/FormSubmissionHelperTest.java
+++ b/src/test/java/org/commcare/formplayer/application/FormSubmissionHelperTest.java
@@ -1,0 +1,57 @@
+package org.commcare.formplayer.application;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.commcare.formplayer.services.FormSessionService;
+import org.commcare.formplayer.services.RestoreFactory;
+import org.commcare.formplayer.util.RequestUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Unit tests for {@link FormSubmissionHelper#onSuccessfulSubmit}: a public web apps session's
+ * sandbox is marked for deletion once its single form is submitted; a regular session is untouched.
+ */
+public class FormSubmissionHelperTest {
+
+    private FormSubmissionHelper helperWith(FormSessionService formSessionService,
+            RestoreFactory restoreFactory) {
+        FormSubmissionHelper helper = new FormSubmissionHelper();
+        helper.formSessionService = formSessionService;
+        helper.restoreFactory = restoreFactory;
+        return helper;
+    }
+
+    @Test
+    public void onSuccessfulSubmit_publicSession_marksSandboxForDeletion() {
+        FormSessionService formSessionService = mock(FormSessionService.class);
+        RestoreFactory restoreFactory = mock(RestoreFactory.class);
+        FormSubmissionHelper helper = helperWith(formSessionService, restoreFactory);
+
+        try (MockedStatic<RequestUtils> mocked = mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::isPublicSession).thenReturn(true);
+            helper.onSuccessfulSubmit("session-1");
+        }
+
+        verify(formSessionService).deleteSessionById("session-1");
+        verify(restoreFactory).markPublicSandboxForDeletion();
+    }
+
+    @Test
+    public void onSuccessfulSubmit_regularSession_leavesSandboxInPlace() {
+        FormSessionService formSessionService = mock(FormSessionService.class);
+        RestoreFactory restoreFactory = mock(RestoreFactory.class);
+        FormSubmissionHelper helper = helperWith(formSessionService, restoreFactory);
+
+        try (MockedStatic<RequestUtils> mocked = mockStatic(RequestUtils.class)) {
+            mocked.when(RequestUtils::isPublicSession).thenReturn(false);
+            helper.onSuccessfulSubmit("session-1");
+        }
+
+        verify(formSessionService).deleteSessionById("session-1");
+        verify(restoreFactory, never()).markPublicSandboxForDeletion();
+    }
+}

--- a/src/test/java/org/commcare/formplayer/aspects/UserRestoreAspectTest.java
+++ b/src/test/java/org/commcare/formplayer/aspects/UserRestoreAspectTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.commcare.formplayer.auth.DjangoAuth;
 import org.commcare.formplayer.auth.HqAuth;
@@ -16,6 +18,7 @@ import org.commcare.formplayer.beans.AuthenticatedRequestBean;
 import org.commcare.formplayer.beans.SessionNavigationBean;
 import org.commcare.formplayer.beans.auth.HqUserDetailsBean;
 import org.commcare.formplayer.services.RestoreFactory;
+import org.commcare.formplayer.sqlitedb.SQLiteDB;
 import org.commcare.formplayer.util.RequestUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -137,5 +140,50 @@ public class UserRestoreAspectTest {
 
         // Unchanged: a non-public session configures the restore from the request bean itself.
         verify(restoreFactory).configure(requestBean, auth);
+    }
+
+    @Test
+    public void closeRestoreFactory_publicSandboxMarked_deletesSandboxAfterClose() throws Throwable {
+        RestoreFactory restoreFactory = mock(RestoreFactory.class);
+        SQLiteDB sqLiteDB = mock(SQLiteDB.class);
+        when(restoreFactory.getSQLiteDB()).thenReturn(sqLiteDB);
+        when(restoreFactory.shouldDeletePublicSandboxOnClose()).thenReturn(true);
+        aspect.restoreFactory = restoreFactory;
+
+        aspect.closeRestoreFactory(null);
+
+        // The connection is always closed; a consumed public session's sandbox is then discarded.
+        verify(sqLiteDB).closeConnection();
+        verify(sqLiteDB).deleteDatabaseFolder();
+    }
+
+    @Test
+    public void closeRestoreFactory_notMarked_leavesSandboxInPlace() throws Throwable {
+        RestoreFactory restoreFactory = mock(RestoreFactory.class);
+        SQLiteDB sqLiteDB = mock(SQLiteDB.class);
+        when(restoreFactory.getSQLiteDB()).thenReturn(sqLiteDB);
+        when(restoreFactory.shouldDeletePublicSandboxOnClose()).thenReturn(false);
+        aspect.restoreFactory = restoreFactory;
+
+        aspect.closeRestoreFactory(null);
+
+        // Default path (regular session, or a public in-form action that is not a submit): never delete.
+        verify(sqLiteDB).closeConnection();
+        verify(sqLiteDB, never()).deleteDatabaseFolder();
+    }
+
+    @Test
+    public void closeRestoreFactory_deleteFailure_isSwallowed() throws Throwable {
+        RestoreFactory restoreFactory = mock(RestoreFactory.class);
+        SQLiteDB sqLiteDB = mock(SQLiteDB.class);
+        when(restoreFactory.getSQLiteDB()).thenReturn(sqLiteDB);
+        when(restoreFactory.shouldDeletePublicSandboxOnClose()).thenReturn(true);
+        doThrow(new RuntimeException("disk error")).when(sqLiteDB).deleteDatabaseFolder();
+        aspect.restoreFactory = restoreFactory;
+
+        // Cleanup is best-effort: a deletion failure must not propagate and fail the request.
+        aspect.closeRestoreFactory(null);
+
+        verify(sqLiteDB).deleteDatabaseFolder();
     }
 }

--- a/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
+++ b/src/test/java/org/commcare/formplayer/tests/RestoreFactoryTest.java
@@ -373,6 +373,16 @@ public class RestoreFactoryTest extends BaseTestClass {
         Assertions.assertEquals("testLocationId2 testLocationId1", UserUtils.getUserLocationsByDomain(domain, afterSandbox));
     }
 
+    @Test
+    public void markPublicSandboxForDeletion_flipsShouldDeleteFlag() {
+        RestoreFactory factory = new RestoreFactory();
+        Assertions.assertFalse(factory.shouldDeletePublicSandboxOnClose());
+
+        factory.markPublicSandboxForDeletion();
+
+        Assertions.assertTrue(factory.shouldDeletePublicSandboxOnClose());
+    }
+
     private void validateHeaders(HttpHeaders headers,
             List<Matcher<Map<? extends String, ? extends List<String>>>> matchers) {
         for (Matcher<Map<? extends String, ? extends List<String>>> matcher : matchers) {


### PR DESCRIPTION
## Technical Summary
- Last of three PRs in this repo for Public Webforms. A public session restores under a unique
  synthetic user, creating a persistent on-disk sandbox that is never reused once the one-time link
  is consumed. This PR deletes that sandbox on successful submit so they don't accumulate.
  - `FormSubmissionHelper`: on a confirmed submit (where the form session is deleted — the point HQ
    fires `consume_public_form_session`), a public session marks its request-scoped `RestoreFactory`
    for cleanup.
  - `UserRestoreAspect#closeRestoreFactory`: deletes the sandbox folder **after** the connection is
    closed, best-effort. Removing the one user folder reclaims both the user DB and the nested app DB.
- Runs only on a genuine submit (in-form actions leave an in-progress form intact) and also covers
  the auto-submit-on-`get_endpoint` path. Identity is the HQ-pinned restore user, never
  client-supplied — which is why this is server-side rather than exposing `clear_user_data`.

Code and this description written or co-written by AI and edited by human.

## Safety Assurance

### Safety story
Scope is tightly bounded: cleanup only fires for a public session, only on a successful submit, and
deletes only that session's own single-use sandbox (identity taken from the pinned `RestoreFactory`,
never the request body). Deletion happens after the connection closes and is wrapped best-effort, so
a cleanup failure logs and never fails the submit. No regular-user or shared data is touched.

### Automated test coverage
- `UserRestoreAspectTest` — marked → sandbox deleted after close; not marked → left intact; delete
  failure is swallowed. (Verified locally: passing.)

### QA Plan
This particular change will not get QA.

### Special deploy instructions
- [x] This PR can be deployed after merge with no further considerations.

### Rollback instructions
- [x] This PR can be reverted after deploy with no further considerations. (Reverting just stops the eager cleanup; abandoned/older sandboxes are already handled by the out-of-band old-user-DB purge.)

### Review
- [x] The set of people pinged as reviewers is appropriate for the level of risk of the change.
