### PR TITLE
Use actual menu name to log to datadog

### DIFF
--- a/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
+++ b/src/main/java/org/commcare/formplayer/beans/menus/BaseResponseBean.java
@@ -20,6 +20,7 @@ import org.javarosa.core.services.locale.Localization;
 public class BaseResponseBean extends LocationRelevantResponseBean {
     protected NotificationMessage notification;
     protected String title;
+    protected String menuTitle;
     protected boolean clearSession;
     protected boolean shouldAutoSubmit;
     private String appId;
@@ -44,6 +45,7 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     protected void processTitle(SessionWrapper session) {
         setTitle(ScreenUtils.getBestTitle(session));
+        setMenuTitle(ScreenUtils.getMenuTitle(session));
     }
 
     public String getTitle() {
@@ -52,6 +54,14 @@ public class BaseResponseBean extends LocationRelevantResponseBean {
 
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    public String getMenuTitle() {
+        return menuTitle;
+    }
+
+    public void setMenuTitle(String menuTitle) {
+        this.menuTitle = menuTitle;
     }
 
     public String getSmartLinkRedirect() {

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -176,7 +176,7 @@ public class MenuSessionRunnerService {
                     (MenuScreen)nextScreen,
                     menuSession.getSessionWrapper()
             );
-            String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
+            String moduleName = menuSession.getSessionWrapper().getClosestMenuTitle();
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "menu");
             Sentry.setTag(Constants.MODULE_TAG, "menu");
@@ -194,14 +194,14 @@ public class MenuSessionRunnerService {
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_list");
             Sentry.setTag(Constants.MODULE_TAG, "case_list");
             // using getBestTitle to eliminate risk of showing private information
-            String caseListName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
+            String caseListName = menuSession.getSessionWrapper().getClosestMenuTitle();
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, caseListName);
             Sentry.setTag(Constants.MODULE_NAME_TAG, caseListName);
         } else if (nextScreen instanceof FormplayerQueryScreen) {
             String queryKey = ((FormplayerQueryScreen)nextScreen).getQueryKey();
             answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey);
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
-            String moduleName = ScreenUtils.getBestTitle(menuSession.getSessionWrapper());
+            String moduleName = menuSession.getSessionWrapper().getClosestMenuTitle();
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_search");
             Sentry.setTag(Constants.MODULE_TAG, "case_search");

--- a/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
+++ b/src/main/java/org/commcare/formplayer/services/MenuSessionRunnerService.java
@@ -33,10 +33,7 @@ import org.commcare.formplayer.screens.FormplayerQueryScreen;
 import org.commcare.formplayer.screens.FormplayerSyncScreen;
 import org.commcare.formplayer.session.FormSession;
 import org.commcare.formplayer.session.MenuSession;
-import org.commcare.formplayer.util.Constants;
-import org.commcare.formplayer.util.FormplayerDatadog;
-import org.commcare.formplayer.util.FormplayerHereFunctionHandler;
-import org.commcare.formplayer.util.SimpleTimer;
+import org.commcare.formplayer.util.*;
 import org.commcare.formplayer.web.client.WebClient;
 import org.commcare.modern.session.SessionWrapper;
 import org.commcare.modern.util.Pair;
@@ -176,7 +173,7 @@ public class MenuSessionRunnerService {
                     (MenuScreen)nextScreen,
                     menuSession.getSessionWrapper()
             );
-            String moduleName = menuSession.getSessionWrapper().getClosestMenuTitle();
+            String moduleName = ScreenUtils.getMenuTitle(menuSession.getSessionWrapper());
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "menu");
             Sentry.setTag(Constants.MODULE_TAG, "menu");
@@ -194,14 +191,14 @@ public class MenuSessionRunnerService {
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_list");
             Sentry.setTag(Constants.MODULE_TAG, "case_list");
             // using getBestTitle to eliminate risk of showing private information
-            String caseListName = menuSession.getSessionWrapper().getClosestMenuTitle();
+            String caseListName = ScreenUtils.getMenuTitle(menuSession.getSessionWrapper());
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, caseListName);
             Sentry.setTag(Constants.MODULE_NAME_TAG, caseListName);
         } else if (nextScreen instanceof FormplayerQueryScreen) {
             String queryKey = ((FormplayerQueryScreen)nextScreen).getQueryKey();
             answerQueryPrompts((FormplayerQueryScreen)nextScreen, queryData, queryKey);
             menuResponseBean = new QueryResponseBean((QueryScreen)nextScreen);
-            String moduleName = menuSession.getSessionWrapper().getClosestMenuTitle();
+            String moduleName = ScreenUtils.getMenuTitle(menuSession.getSessionWrapper());
             datadog.addRequestScopedTag(Constants.MODULE_NAME_TAG, moduleName);
             datadog.addRequestScopedTag(Constants.MODULE_TAG, "case_search");
             Sentry.setTag(Constants.MODULE_TAG, "case_search");


### PR DESCRIPTION
## Product Description

In addition to the menu name getBestTitle returns the command value for case search which is misleading for logging the moduleName (menu) to datadog and in some cases like BHA groups together modules that are distinct. Use the new getMenuTitle instead (added in https://github.com/dimagi/commcare-core/pull/1549). Also add the menuTitle to the navigate_menu response so it can be used for google analytics logging.

## Technical Summary

https://dimagi.atlassian.net/browse/USH-6605

## Safety Assurance

### Safety story

Tested locally.

### Automated test coverage
<!-- Identify the related test coverage and the conditions it will catch -->

### QA Plan
<!--
- Describe QA plan that (along with test coverage) proves that this PR is regression free.
- Link to QA Ticket
-->

### Special deploy instructions
<!--
If this PR does not require any special deploy considerations, check the box below.
Otherwise, replace it with:
- links to related items (cross-request PRs, etc).
- detailed instructions including deploy sequence and/or other constraints.

and verify that the **Rollback instructions** section below takes these
dependencies into consideration.
-->

- requires the commcare-core changes https://github.com/dimagi/commcare-core/pull/1549/changes

### Rollback instructions
<!--
If this PR follows standards of revertability, check the box below.
Otherwise replace it with detailed instructions or reasons a rollback is impossible.
-->

- [x] This PR can be reverted after deploy with no further considerations.

### Review

- [ ] The set of people pinged as reviewers is appropriate for the level of risk of the change.
